### PR TITLE
[FEATURE] 폴더 화면 구현

### DIFF
--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -1,0 +1,209 @@
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import { AddFolderButton } from '@/components/ui/add-folder-button';
+import { AppIcon } from '@/components/ui/app-icon';
+import { FolderContextMenu } from '@/components/ui/folder-context-menu';
+import { SwipeableCardLink } from '@/components/ui/swipeable-card-link';
+import { Toast } from '@/components/ui/toast';
+import { Colors, Typography } from '@/constants/theme';
+import { useSavedLinks } from '@/context/saved-links-context';
+import { useFolders } from '@/context/folders-context';
+import type { AnchorPosition } from '@/components/ui/folder-card';
+import { useEffect, useState } from 'react';
+
+type MoreMenuState = {
+  visible: boolean;
+  anchor?: AnchorPosition;
+  linkId?: number;
+};
+
+export default function FolderDetailScreen() {
+  const { id, urlAdded } = useLocalSearchParams<{ id: string; urlAdded?: string }>();
+  const router = useRouter();
+  const folderId = Number(id);
+
+  const { links, toggleBookmark, assignCategory } = useSavedLinks();
+  const { folders } = useFolders();
+  const folderLinks = links.filter((l) => l.categoryId === folderId);
+  const folderName = folders.find((f) => f.id === folderId)?.name ?? '폴더';
+
+  const [menuState, setMenuState] = useState<MoreMenuState>({ visible: false });
+  const [toastVisible, setToastVisible] = useState(false);
+  const [addToastVisible, setAddToastVisible] = useState(false);
+
+  useEffect(() => {
+    if (urlAdded === '1') setAddToastVisible(true);
+  }, [urlAdded]);
+
+  const handleMore = (linkId: number, anchor: AnchorPosition) => {
+    setMenuState({ visible: true, anchor, linkId });
+  };
+
+  const handleDelete = (linkId: number) => {
+    // API: PATCH /api/v1/saved-links/{id} { categoryId: null }
+    assignCategory([linkId], null);
+    setToastVisible(true);
+  };
+
+  const handleAddUrl = () => {
+    router.push({
+      pathname: '/(tabs)/(folder)/folder-add-url',
+      params: { folderId: String(folderId), folderName },
+    });
+  };
+
+  const currentLink = folderLinks.find((l) => l.id === menuState.linkId);
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      {/* 헤더 */}
+      <View style={styles.header}>
+        <AppIcon name="back" size={24} onPress={() => router.back()} />
+        <Text style={styles.headerTitle}>폴더 목록</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* 폴더명 + URL 추가 버튼 */}
+        <View style={styles.canvasHeaderWrapper}>
+          <View style={styles.canvasHeader}>
+            <Text style={styles.folderName}>{folderName}</Text>
+            <AddFolderButton label="URL 추가" onPress={handleAddUrl} />
+          </View>
+          <Toast
+            visible={toastVisible}
+            message="폴더에서 제외되었어요"
+            onHide={() => setToastVisible(false)}
+          />
+          <Toast
+            visible={addToastVisible}
+            message="URL이 추가되었어요"
+            onHide={() => setAddToastVisible(false)}
+          />
+        </View>
+
+        {/* 링크 목록 */}
+        {folderLinks.length > 0 ? (
+          <View style={styles.list}>
+            {folderLinks.map((link) => (
+              <SwipeableCardLink
+                key={link.id}
+                label={link.siteName}
+                title={link.title}
+                summary={link.description}
+                url={link.originalUrl}
+                bookmarked={link.isBookmarked}
+                onBookmark={() => toggleBookmark(link.id)}
+                onMore={(anchor: AnchorPosition) => handleMore(link.id, anchor)}
+                onPress={() => {
+                  // TODO: 링크 상세/분석 결과 화면 이동
+                }}
+                onDelete={() => handleDelete(link.id)}
+              />
+            ))}
+          </View>
+        ) : (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyText}>이 폴더에 링크가 없어요</Text>
+            <Text style={styles.emptySubtext}>URL 추가 버튼을 눌러 링크를 저장해보세요</Text>
+          </View>
+        )}
+      </ScrollView>
+
+      <FolderContextMenu
+        visible={menuState.visible}
+        anchor={menuState.anchor}
+        items={[
+          {
+            label: currentLink?.isBookmarked ? '북마크 해제' : '북마크 추가',
+            onPress: () => {
+              if (menuState.linkId == null) return;
+              // API: PATCH /saved-links/{id}/bookmark
+              toggleBookmark(menuState.linkId);
+            },
+          },
+          {
+            label: '폴더에서 삭제',
+            destructive: true,
+            onPress: () => {
+              if (menuState.linkId == null) return;
+              // API: PATCH /api/v1/saved-links/{id} { categoryId: null }
+              handleDelete(menuState.linkId);
+            },
+          },
+        ]}
+        onDismiss={() => setMenuState({ visible: false })}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+  },
+
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  headerTitle: {
+    ...Typography.title,
+    color: Colors.brand.text,
+    flex: 1,
+  },
+  headerSpacer: {
+    width: 24,
+  },
+
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingBottom: 32,
+    gap: 12,
+  },
+
+  canvasHeaderWrapper: {
+    position: 'relative',
+  },
+  canvasHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 4,
+  },
+  folderName: {
+    ...Typography.title,
+    color: Colors.brand.text,
+  },
+
+  list: {
+    gap: 10,
+  },
+
+  emptyState: {
+    paddingVertical: 60,
+    alignItems: 'center',
+    gap: 6,
+  },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.brand.textSecondary,
+  },
+  emptySubtext: {
+    ...Typography.caption,
+    color: Colors.brand.textHint,
+  },
+});

--- a/app/(tabs)/(folder)/_layout.tsx
+++ b/app/(tabs)/(folder)/_layout.tsx
@@ -1,5 +1,14 @@
 import { Stack } from 'expo-router';
 
+import { FoldersProvider } from '@/context/folders-context';
+import { SavedLinksProvider } from '@/context/saved-links-context';
+
 export default function FolderLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <SavedLinksProvider>
+      <FoldersProvider>
+        <Stack screenOptions={{ headerShown: false }} />
+      </FoldersProvider>
+    </SavedLinksProvider>
+  );
 }

--- a/app/(tabs)/(folder)/_layout.tsx
+++ b/app/(tabs)/(folder)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function FolderLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/(tabs)/(folder)/folder-add-url.tsx
+++ b/app/(tabs)/(folder)/folder-add-url.tsx
@@ -1,0 +1,313 @@
+import { useCallback, useState } from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { router, Stack, useLocalSearchParams } from 'expo-router';
+
+import { Button } from '@/components/ui/button';
+import { CardLink } from '@/components/ui/card-link';
+import { Colors, Typography } from '@/constants/theme';
+import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
+
+// ─── Selection circle ─────────────────────────────────────────────────────────
+
+function SelectionCircle({ selected }: { selected: boolean }) {
+  return (
+    <View
+      style={[
+        circleStyles.circle,
+        selected ? circleStyles.selected : circleStyles.unselected,
+      ]}
+    >
+      {selected && <View style={circleStyles.checkmark} />}
+    </View>
+  );
+}
+
+const CIRCLE_SIZE = 24;
+
+const circleStyles = StyleSheet.create({
+  circle: {
+    width: CIRCLE_SIZE,
+    height: CIRCLE_SIZE,
+    borderRadius: CIRCLE_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  unselected: {
+    backgroundColor: Colors.light.background,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+  },
+  selected: {
+    backgroundColor: Colors.brand.primary,
+    borderWidth: 0,
+  },
+  checkmark: {
+    width: 5,
+    height: 9,
+    borderBottomWidth: 2,
+    borderRightWidth: 2,
+    borderColor: Colors.light.background,
+    transform: [{ rotate: '45deg' }, { translateY: -2 }],
+  },
+});
+
+// ─── Selectable card row ──────────────────────────────────────────────────────
+
+interface SelectableCardProps {
+  link: SavedLink;
+  selected: boolean;
+  onToggle: (id: number) => void;
+}
+
+function SelectableCard({ link, selected, onToggle }: SelectableCardProps) {
+  return (
+    <View style={styles.cardRow}>
+      <CardLink
+        label={link.siteName}
+        title={link.title}
+        summary={link.description}
+        url={link.originalUrl}
+        bookmarked={link.isBookmarked}
+        icon={false}
+        onPress={() => onToggle(link.id)}
+      />
+      {selected && (
+        <View style={styles.selectedOverlay} pointerEvents="none" />
+      )}
+      <View style={styles.checkOverlay} pointerEvents="none">
+        <SelectionCircle selected={selected} />
+      </View>
+    </View>
+  );
+}
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+export default function FolderAddUrlScreen() {
+  const { folderId, folderName } = useLocalSearchParams<{
+    folderId: string;
+    folderName: string;
+  }>();
+  const { links, assignCategory } = useSavedLinks();
+
+  // 미분류 URL만 표시 (categoryId === null)
+  const uncategorizedLinks = links.filter((l) => l.categoryId === null);
+
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [isAdding, setIsAdding] = useState(false);
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleAdd = async () => {
+    if (isAdding || selectedIds.size === 0) return;
+    setIsAdding(true);
+    try {
+      // PATCH /api/v1/saved-links/{id} { categoryId } — 선택한 링크들을 폴더에 추가
+      assignCategory([...selectedIds], Number(folderId));
+      router.replace({
+        pathname: '/(tabs)/(folder)/[id]',
+        params: { id: folderId, urlAdded: '1' },
+      });
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const selectedCount = selectedIds.size;
+  const name = folderName ?? '폴더';
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: 'URL 추가',
+          headerBackTitle: '',
+          headerTransparent: false,
+          headerStyle: { backgroundColor: Colors.brand.background },
+          headerTitleStyle: {
+            ...Typography.title,
+            color: Colors.brand.text,
+          },
+          headerTintColor: Colors.brand.text,
+          headerShadowVisible: false,
+        }}
+      />
+
+      <View style={styles.container}>
+        {/* ── 폴더명 표시 ── */}
+        <View style={styles.folderNameRow}>
+          <Text style={styles.folderNameLabel}>추가할 폴더</Text>
+          <View style={styles.chip}>
+            <Text style={styles.chipText}>{name}</Text>
+          </View>
+        </View>
+
+        {/* ── 섹션 타이틀 ── */}
+        <Text style={styles.sectionTitle}>폴더에 담기지 않은 URL</Text>
+
+        {/* ── URL 리스트 ── */}
+        {uncategorizedLinks.length > 0 ? (
+          <FlatList
+            data={uncategorizedLinks}
+            keyExtractor={(item) => String(item.id)}
+            renderItem={({ item }) => (
+              <SelectableCard
+                link={item}
+                selected={selectedIds.has(item.id)}
+                onToggle={toggleSelect}
+              />
+            )}
+            contentContainerStyle={styles.listContent}
+            showsVerticalScrollIndicator={false}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+          />
+        ) : (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyText}>담기지 않은 URL이 없어요</Text>
+            <Text style={styles.emptySubtext}>모든 URL이 이미 폴더에 분류되어 있어요</Text>
+          </View>
+        )}
+
+        {/* ── 하단 액션 바 ── */}
+        <View style={styles.bottomBar}>
+          <View style={styles.countBlock}>
+            <Text style={styles.countLabel}>선택한 URL</Text>
+            <Text style={styles.countNumber}>{selectedCount}개</Text>
+          </View>
+          <View style={styles.addButtonWrap}>
+            <Button
+              label="추가하기"
+              variant="primary"
+              size="large"
+              onPress={handleAdd}
+              loading={isAdding}
+              disabled={isAdding || selectedCount === 0}
+            />
+          </View>
+        </View>
+      </View>
+    </>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+  },
+
+  folderNameRow: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 16,
+    gap: 8,
+  },
+  folderNameLabel: {
+    ...Typography.caption,
+    color: Colors.brand.text,
+  },
+  chip: {
+    alignSelf: 'flex-start',
+    backgroundColor: Colors.brand.softMint,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  chipText: {
+    ...Typography.title,
+    color: Colors.brand.primaryDeep,
+  },
+
+  sectionTitle: {
+    ...Typography.section,
+    color: Colors.brand.text,
+    paddingHorizontal: 20,
+    marginBottom: 12,
+  },
+
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  separator: {
+    height: 8,
+  },
+
+  cardRow: {
+    position: 'relative',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  selectedOverlay: {
+    position: 'absolute',
+    inset: 0,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0,0,0,0.08)',
+  },
+  checkOverlay: {
+    position: 'absolute',
+    right: 16,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+  },
+
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingBottom: 60,
+  },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.brand.textSecondary,
+  },
+  emptySubtext: {
+    ...Typography.caption,
+    color: Colors.brand.textHint,
+  },
+
+  bottomBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderTopWidth: 1,
+    borderTopColor: Colors.brand.line,
+    backgroundColor: Colors.light.background,
+    gap: 16,
+  },
+  countBlock: {
+    gap: 2,
+  },
+  countLabel: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
+  },
+  countNumber: {
+    ...Typography.title,
+    color: Colors.brand.text,
+  },
+  addButtonWrap: {
+    flex: 1,
+  },
+});

--- a/app/(tabs)/(folder)/folder-name.tsx
+++ b/app/(tabs)/(folder)/folder-name.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { router, Stack } from 'expo-router';
+
+import { Button } from '@/components/ui/button';
+import { Colors, Typography } from '@/constants/theme';
+
+export default function FolderNameScreen() {
+  const [folderName, setFolderName] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
+
+  const canProceed = folderName.trim().length > 0;
+
+  const handleNext = () => {
+    router.push({
+      pathname: '/(tabs)/(folder)/folder-url-select',
+      params: { folderName: folderName.trim() },
+    });
+  };
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: '새 폴더 만들기',
+          headerBackTitle: '',
+          headerTransparent: false,
+          headerStyle: { backgroundColor: Colors.brand.background },
+          headerTitleStyle: {
+            ...Typography.title,
+            color: Colors.brand.text,
+          },
+          headerTintColor: Colors.brand.text,
+          headerShadowVisible: false,
+        }}
+      />
+      <View style={styles.safeArea}>
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
+          <View style={styles.container}>
+            <Text style={styles.subtitle}>먼저 폴더 이름을 정해주세요</Text>
+
+            <View style={styles.card}>
+              <Text style={styles.fieldLabel}>폴더 이름</Text>
+              <View style={[styles.inputRow, isFocused && styles.inputRowFocused]}>
+                <TextInput
+                  style={styles.input}
+                  value={folderName}
+                  onChangeText={setFolderName}
+                  onFocus={() => setIsFocused(true)}
+                  onBlur={() => setIsFocused(false)}
+                  placeholder="폴더 이름 입력"
+                  placeholderTextColor={Colors.brand.textHint}
+                  returnKeyType="done"
+                  maxLength={50}
+                  autoFocus
+                />
+                {folderName.length > 0 && (
+                  <TouchableOpacity
+                    onPress={() => setFolderName('')}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    style={styles.clearButton}
+                  >
+                    <Text style={styles.clearButtonText}>−</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+              <Text style={styles.helperText}>
+                {'이 이름으로 폴더가 생성되고,\n다음 단계에서 URL을 고를 수 있어요.'}
+              </Text>
+            </View>
+
+            <View style={styles.buttonArea}>
+              <Button
+                label="다음"
+                variant="primary"
+                size="large"
+                disabled={!canProceed}
+                onPress={handleNext}
+              />
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+  },
+  flex: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 16,
+  },
+  subtitle: {
+    ...Typography.summary,
+    color: Colors.brand.textSecondary,
+    marginBottom: 24,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    gap: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  fieldLabel: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  inputRowFocused: {
+    borderColor: Colors.brand.primary,
+  },
+  input: {
+    flex: 1,
+    ...Typography.section,
+    color: Colors.brand.text,
+    padding: 0,
+  },
+  clearButton: {
+    marginLeft: 8,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.softMint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clearButtonText: {
+    ...Typography.caption,
+    color: Colors.brand.primary,
+    lineHeight: 16,
+  },
+  helperText: {
+    ...Typography.caption,
+    fontWeight: '400',
+    color: Colors.brand.textSecondary,
+    lineHeight: 20,
+  },
+  buttonArea: {
+    marginTop: 32,
+  },
+});

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -1,0 +1,317 @@
+import { useCallback, useState } from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { router, Stack, useLocalSearchParams } from 'expo-router';
+
+import { Button } from '@/components/ui/button';
+import { CardLink } from '@/components/ui/card-link';
+import { Colors, Typography } from '@/constants/theme';
+import { useFolders } from '@/context/folders-context';
+import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
+
+
+// ─── Selection circle ─────────────────────────────────────────────────────────
+// CheckIcon의 미선택 상태(dark filled)와 달리, 미선택 = 흰 빈 원으로 표시
+
+function SelectionCircle({ selected }: { selected: boolean }) {
+  return (
+    <View
+      style={[
+        circleStyles.circle,
+        selected ? circleStyles.selected : circleStyles.unselected,
+      ]}
+    >
+      {selected && <View style={circleStyles.checkmark} />}
+    </View>
+  );
+}
+
+const CIRCLE_SIZE = 24;
+
+const circleStyles = StyleSheet.create({
+  circle: {
+    width: CIRCLE_SIZE,
+    height: CIRCLE_SIZE,
+    borderRadius: CIRCLE_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  unselected: {
+    backgroundColor: Colors.light.background,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+  },
+  selected: {
+    backgroundColor: Colors.brand.primary,
+    borderWidth: 0,
+  },
+  checkmark: {
+    width: 5,
+    height: 9,
+    borderBottomWidth: 2,
+    borderRightWidth: 2,
+    borderColor: Colors.light.background,
+    transform: [{ rotate: '45deg' }, { translateY: -2 }],
+  },
+});
+
+// ─── Selectable card row ──────────────────────────────────────────────────────
+
+interface SelectableCardProps {
+  link: SavedLink;
+  selected: boolean;
+  onToggle: (id: number) => void;
+}
+
+function SelectableCard({ link, selected, onToggle }: SelectableCardProps) {
+  return (
+    <View style={styles.cardRow}>
+      <CardLink
+        label={link.siteName}
+        title={link.title}
+        summary={link.description}
+        url={link.originalUrl}
+        bookmarked={link.isBookmarked}
+        icon={false}
+        onPress={() => onToggle(link.id)}
+      />
+      {/* 선택 시 카드 위에 어두운 오버레이 */}
+      {selected && (
+        <View style={styles.selectedOverlay} pointerEvents="none" />
+      )}
+      <View style={styles.checkOverlay} pointerEvents="none">
+        <SelectionCircle selected={selected} />
+      </View>
+    </View>
+  );
+}
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+export default function FolderUrlSelectScreen() {
+  const { folderName } = useLocalSearchParams<{ folderName: string }>();
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [isCreating, setIsCreating] = useState(false);
+  const { addFolder } = useFolders();
+  const { links: allLinks, assignCategory } = useSavedLinks();
+  const links = allLinks.filter((l) => l.categoryId === null);
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleCreate = async () => {
+    if (isCreating) return;
+    setIsCreating(true);
+    try {
+      // TODO: POST /api/v1/categories { name: folderName } 로 교체
+      const newId = addFolder(folderName ?? '새 폴더');
+      if (selectedIds.size > 0) {
+        assignCategory([...selectedIds], newId);
+      }
+      router.dismissAll();
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const selectedCount = selectedIds.size;
+  const name = folderName ?? '새 폴더';
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: '새 폴더 만들기',
+          headerBackTitle: '',
+          headerTransparent: false,
+          headerStyle: { backgroundColor: Colors.brand.background },
+          headerTitleStyle: {
+            ...Typography.title,
+            color: Colors.brand.text,
+          },
+          headerTintColor: Colors.brand.text,
+          headerShadowVisible: false,
+        }}
+      />
+
+      <View style={styles.container}>
+        {/* ── 폴더명 표시 ── */}
+        <View style={styles.folderNameRow}>
+          <Text style={styles.folderNameLabel}>현재 폴더명</Text>
+          <View style={styles.chip}>
+            <Text style={styles.chipText}>{name}</Text>
+          </View>
+        </View>
+
+        {/* ── 섹션 타이틀 ── */}
+        <Text style={styles.sectionTitle}>폴더에 담기지 않은 URL</Text>
+
+        {/* ── URL 리스트 ── */}
+        {links.length > 0 ? (
+          <FlatList
+            data={links}
+            keyExtractor={(item) => String(item.id)}
+            renderItem={({ item }) => (
+              <SelectableCard
+                link={item}
+                selected={selectedIds.has(item.id)}
+                onToggle={toggleSelect}
+              />
+            )}
+            contentContainerStyle={styles.listContent}
+            showsVerticalScrollIndicator={false}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+          />
+        ) : (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyText}>담기지 않은 URL이 없어요</Text>
+            <Text style={styles.emptySubtext}>모든 URL이 이미 폴더에 분류되어 있어요</Text>
+          </View>
+        )}
+
+        {/* ── 하단 액션 바 ── */}
+        <View style={styles.bottomBar}>
+          <View style={styles.countBlock}>
+            <Text style={styles.countLabel}>선택한 URL</Text>
+            <Text style={styles.countNumber}>{selectedCount}개</Text>
+          </View>
+          <View style={styles.createButtonWrap}>
+            <Button
+              label="생성하기"
+              variant="primary"
+              size="large"
+              onPress={handleCreate}
+              loading={isCreating}
+              disabled={isCreating}
+            />
+          </View>
+        </View>
+      </View>
+    </>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+  },
+
+  // Folder name display
+  folderNameRow: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 16,
+    gap: 8,
+  },
+  folderNameLabel: {
+    ...Typography.caption,
+    color: Colors.brand.text,
+  },
+  chip: {
+    alignSelf: 'flex-start',
+    backgroundColor: Colors.brand.softMint,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  chipText: {
+    ...Typography.title,
+    color: Colors.brand.primaryDeep,
+  },
+
+  // Section title
+  sectionTitle: {
+    ...Typography.section,
+    color: Colors.brand.text,
+    paddingHorizontal: 20,
+    marginBottom: 12,
+  },
+
+  // List
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  separator: {
+    height: 8,
+  },
+
+  // Selectable card
+  cardRow: {
+    position: 'relative',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  selectedOverlay: {
+    position: 'absolute',
+    inset: 0,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0,0,0,0.08)',
+  },
+  checkOverlay: {
+    position: 'absolute',
+    right: 16,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+  },
+
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingBottom: 60,
+  },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.brand.textSecondary,
+  },
+  emptySubtext: {
+    ...Typography.caption,
+    color: Colors.brand.textHint,
+  },
+
+  // Bottom action bar
+  bottomBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderTopWidth: 1,
+    borderTopColor: Colors.brand.line,
+    backgroundColor: Colors.light.background,
+    gap: 16,
+  },
+  countBlock: {
+    gap: 2,
+  },
+  countLabel: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
+  },
+  countNumber: {
+    ...Typography.title,
+    color: Colors.brand.text,
+  },
+  createButtonWrap: {
+    flex: 1,
+  },
+});

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -1,0 +1,341 @@
+import { useMemo, useRef, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { AddFolderButton } from '@/components/ui/add-folder-button';
+import { FolderCard } from '@/components/ui/folder-card';
+import { FolderContextMenu } from '@/components/ui/folder-context-menu';
+import { Colors, Typography } from '@/constants/theme';
+import type { AnchorPosition } from '@/components/ui/folder-card';
+import { useSavedLinks } from '@/context/saved-links-context';
+import { useFolders } from '@/context/folders-context';
+
+type MenuState = {
+  visible: boolean;
+  anchor?: AnchorPosition;
+  folderId?: number;
+};
+
+export default function FolderScreen() {
+  const router = useRouter();
+  const { links } = useSavedLinks();
+  const { folders: rawFolders, renameFolder, deleteFolder } = useFolders();
+  const [menuState, setMenuState] = useState<MenuState>({ visible: false });
+  const [renameState, setRenameState] = useState<{ visible: boolean; folderId?: number; value: string }>({
+    visible: false,
+    value: '',
+  });
+  const renameInputRef = useRef<TextInput>(null);
+
+  const folders = useMemo(
+    () => rawFolders.map((f) => ({
+      ...f,
+      linkCount: links.filter((l) => l.categoryId === f.id).length,
+    })),
+    [links, rawFolders]
+  );
+
+  const handleMorePress = (folderId: number, anchor: AnchorPosition) => {
+    setMenuState({ visible: true, anchor, folderId });
+  };
+
+  const handleEditName = () => {
+    if (menuState.folderId == null) return;
+    const current = folders.find((f) => f.id === menuState.folderId)?.name ?? '';
+    setRenameState({ visible: true, folderId: menuState.folderId, value: current });
+    setTimeout(() => renameInputRef.current?.focus(), 100);
+  };
+
+  const handleRenameConfirm = () => {
+    const trimmed = renameState.value.trim();
+    if (renameState.folderId == null || !trimmed) return;
+    renameFolder(renameState.folderId, trimmed);
+    setRenameState({ visible: false, value: '' });
+  };
+
+  const handleRenameCancel = () => {
+    setRenameState({ visible: false, value: '' });
+  };
+
+  const handleDelete = () => {
+    if (menuState.folderId == null) return;
+    deleteFolder(menuState.folderId);
+  };
+
+  const handleAddFolder = () => {
+    router.push('/folder-name');
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* 상단 헤더 */}
+        <View style={styles.header}>
+          <Text style={styles.title}>폴더</Text>
+          <Text style={styles.subtitle}>저장한 링크를 폴더별로 정리해요</Text>
+        </View>
+
+        {/* 폴더 캔버스 */}
+        <View style={styles.canvas}>
+          <View style={styles.canvasHeader}>
+            <Text style={styles.canvasTitle}>내 폴더</Text>
+            <AddFolderButton onPress={handleAddFolder} />
+          </View>
+
+          {folders.length > 0 ? (
+            <View style={styles.grid}>
+              {folders.map((folder) => (
+                <FolderCard
+                  key={folder.id}
+                  folderName={folder.name}
+                  urlCount={folder.linkCount}
+                  onPress={() => router.push({ pathname: '/(tabs)/(folder)/[id]' as any, params: { id: folder.id } })}
+                  onMorePress={(anchor) => handleMorePress(folder.id, anchor)}
+                />
+              ))}
+            </View>
+          ) : (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyText}>아직 폴더가 없어요</Text>
+              <Text style={styles.emptySubtext}>
+                폴더 추가 버튼을 눌러 정리를 시작해보세요
+              </Text>
+            </View>
+          )}
+        </View>
+      </ScrollView>
+
+      <FolderContextMenu
+        visible={menuState.visible}
+        anchor={menuState.anchor}
+        onEditName={handleEditName}
+        onDelete={handleDelete}
+        onDismiss={() => setMenuState({ visible: false })}
+      />
+
+      {/* 폴더명 수정 모달 */}
+      <Modal
+        visible={renameState.visible}
+        transparent
+        animationType="fade"
+        onRequestClose={handleRenameCancel}
+      >
+        <KeyboardAvoidingView
+          style={renameStyles.overlay}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
+          <Pressable style={renameStyles.backdrop} onPress={handleRenameCancel} />
+          <View style={renameStyles.sheet}>
+            <Text style={renameStyles.sheetTitle}>폴더명 수정</Text>
+            <View style={renameStyles.inputRow}>
+              <TextInput
+                ref={renameInputRef}
+                style={renameStyles.input}
+                value={renameState.value}
+                onChangeText={(v) => setRenameState((s) => ({ ...s, value: v }))}
+                placeholder="폴더 이름 입력"
+                placeholderTextColor={Colors.brand.textHint}
+                returnKeyType="done"
+                onSubmitEditing={handleRenameConfirm}
+                maxLength={50}
+                autoFocus
+              />
+              {renameState.value.length > 0 && (
+                <TouchableOpacity
+                  onPress={() => setRenameState((s) => ({ ...s, value: '' }))}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  style={renameStyles.clearButton}
+                >
+                  <Text style={renameStyles.clearButtonText}>−</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+            <View style={renameStyles.actions}>
+              <TouchableOpacity style={renameStyles.cancelBtn} onPress={handleRenameCancel}>
+                <Text style={renameStyles.cancelText}>취소</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[renameStyles.confirmBtn, !renameState.value.trim() && renameStyles.confirmBtnDisabled]}
+                onPress={handleRenameConfirm}
+                disabled={!renameState.value.trim()}
+              >
+                <Text style={[renameStyles.confirmText, !renameState.value.trim() && renameStyles.confirmTextDisabled]}>
+                  저장
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: 24,
+    paddingBottom: 32,
+    gap: 20,
+  },
+
+  header: {
+    paddingTop: 16,
+    gap: 4,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.brand.text,
+  },
+  subtitle: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
+  },
+
+  canvas: {
+    backgroundColor: '#fff',
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: Colors.brand.line,
+    padding: 16,
+    gap: 16,
+  },
+  canvasHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  canvasTitle: {
+    ...Typography.title,
+    color: Colors.brand.text,
+  },
+
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+
+  emptyState: {
+    paddingVertical: 40,
+    alignItems: 'center',
+    gap: 6,
+  },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.brand.textSecondary,
+  },
+  emptySubtext: {
+    ...Typography.caption,
+    color: Colors.brand.textHint,
+  },
+});
+
+const renameStyles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  sheet: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 24,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  sheetTitle: {
+    ...Typography.section,
+    color: Colors.brand.text,
+    textAlign: 'center',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  input: {
+    flex: 1,
+    ...Typography.body,
+    color: Colors.brand.text,
+    padding: 0,
+  },
+  clearButton: {
+    marginLeft: 8,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.softMint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clearButtonText: {
+    ...Typography.caption,
+    color: Colors.brand.primary,
+    lineHeight: 16,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cancelBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    alignItems: 'center',
+  },
+  cancelText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.textSecondary,
+  },
+  confirmBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.primary,
+    alignItems: 'center',
+  },
+  confirmBtnDisabled: {
+    backgroundColor: Colors.brand.softMint,
+  },
+  confirmText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  confirmTextDisabled: {
+    color: Colors.brand.textHint,
+  },
+});

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -29,7 +29,7 @@ type MenuState = {
 
 export default function FolderScreen() {
   const router = useRouter();
-  const { links } = useSavedLinks();
+  const { links, assignCategory } = useSavedLinks();
   const { folders: rawFolders, renameFolder, deleteFolder } = useFolders();
   const [menuState, setMenuState] = useState<MenuState>({ visible: false });
   const [renameState, setRenameState] = useState<{ visible: boolean; folderId?: number; value: string }>({
@@ -70,7 +70,12 @@ export default function FolderScreen() {
 
   const handleDelete = () => {
     if (menuState.folderId == null) return;
-    deleteFolder(menuState.folderId);
+    const folderId = menuState.folderId;
+    const linkIds = links.filter((link) => link.categoryId === folderId).map((link) => link.id);
+    if (linkIds.length > 0) {
+      assignCategory(linkIds, null);
+    }
+    deleteFolder(folderId);
   };
 
   const handleAddFolder = () => {

--- a/context/folders-context.tsx
+++ b/context/folders-context.tsx
@@ -1,0 +1,56 @@
+import { createContext, useCallback, useContext, useState } from 'react';
+
+export interface Folder {
+  id: number;
+  name: string;
+}
+
+interface FoldersContextValue {
+  folders: Folder[];
+  addFolder: (name: string) => number;
+  renameFolder: (id: number, name: string) => void;
+  deleteFolder: (id: number) => void;
+}
+
+const MOCK_FOLDERS: Folder[] = [
+  { id: 1, name: '맛집 정보' },
+  { id: 2, name: '취업' },
+  { id: 3, name: '취미' },
+];
+
+let nextId = MOCK_FOLDERS.length + 1;
+
+const FoldersContext = createContext<FoldersContextValue | null>(null);
+
+export function FoldersProvider({ children }: { children: React.ReactNode }) {
+  const [folders, setFolders] = useState<Folder[]>(MOCK_FOLDERS);
+
+  const addFolder = useCallback((name: string): number => {
+    // TODO: 백엔드 연동 시 POST /api/v1/categories { name } 호출 후 응답 id로 교체
+    const id = nextId++;
+    setFolders((prev) => [...prev, { id, name }]);
+    return id;
+  }, []);
+
+  const renameFolder = useCallback((id: number, name: string) => {
+    // TODO: PATCH /api/v1/categories/{id}
+    setFolders((prev) => prev.map((f) => (f.id === id ? { ...f, name } : f)));
+  }, []);
+
+  const deleteFolder = useCallback((id: number) => {
+    // TODO: DELETE /api/v1/categories/{id}
+    setFolders((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  return (
+    <FoldersContext.Provider value={{ folders, addFolder, renameFolder, deleteFolder }}>
+      {children}
+    </FoldersContext.Provider>
+  );
+}
+
+export function useFolders(): FoldersContextValue {
+  const ctx = useContext(FoldersContext);
+  if (!ctx) throw new Error('useFolders must be used within FoldersProvider');
+  return ctx;
+}


### PR DESCRIPTION
Closes #7

## 개요
저장된 링크를 폴더 단위로 관리할 수 있는 폴더 탭 화면을 구현합니다. 폴더 목록, 폴더 상세, 폴더 생성, 폴더에 URL 추가, 저장 링크 선택 화면을 추가하여 사용자가 링크를 목적별로 분류할 수 있는 흐름을 제공합니다.

폴더 데이터는 백엔드 연동 전까지 `FoldersContext` 기반 mock 상태로 관리합니다. 독립 브랜치 merge 충돌을 줄이기 위해 홈/저장 링크 파일은 이 PR에서 다시 추가하지 않고, 폴더 전용 라우트와 폴더 context 중심으로 구성했습니다.

## 주요 구현 내용
- 폴더 탭 Stack 레이아웃 추가
- 폴더 목록 및 폴더별 링크 개수 표시
- 폴더 상세 화면과 링크 관리 기능 구현
- 폴더명 입력, URL 선택, 폴더에 URL 추가 화면 구현
- 폴더 생성/수정/삭제 mock context 추가
- 링크의 폴더 지정 및 폴더 제외 처리 구현
- 폴더 상세에서 링크를 완전히 삭제하지 않고, 해당 폴더에서만 제외하도록 동작 수정
- 저장 링크의 `categoryId`를 `null`로 변경할 수 있도록 context 타입 확장
- 폴더 상세의 삭제 문구를 실제 동작에 맞춰 “폴더에서 삭제/제외”로 변경
- 저장 링크 화면의 폴더 필터를 하드코딩 목록이 아닌 `folders-context` 기반으로 생성하도록 개선

## 파일별 역할
- `app/(tabs)/(folder)/_layout.tsx`: 폴더 탭 내부 Stack 레이아웃
- `app/(tabs)/(folder)/index.tsx`: 폴더 목록 화면
- `app/(tabs)/(folder)/[id].tsx`: 폴더 상세 및 폴더 내 링크 관리 화면, 링크의 폴더 제외 처리
- `app/(tabs)/(folder)/folder-name.tsx`: 새 폴더 이름 입력 화면
- `app/(tabs)/(folder)/folder-url-select.tsx`: 폴더에 담을 저장 링크 선택 화면
- `app/(tabs)/(folder)/folder-add-url.tsx`: 폴더 생성 후 URL 추가 흐름 화면
- `context/folders-context.tsx`: 폴더 mock 데이터 및 CRUD 상태 관리
- `context/saved-links-context.tsx`: 링크의 `categoryId` 지정/해제 처리
- `app/(tabs)/(home)/saved-links.tsx`: 폴더 context 기반 필터 목록 반영
- `components/ui/swipeable-card-link.tsx`: 스와이프 액션 문구를 “폴더에서 삭제”로 변경


## 해결한 이슈 목록
- [x] 새로운 기능 추가: 폴더 목록, 폴더 상세, 폴더 생성 화면 구현
- [x] 새로운 기능 추가: 폴더에 저장 링크를 선택해 추가하는 화면 구현
- [x] 새로운 기능 추가: 폴더명 수정, 폴더 삭제 mock 동작 구현
- [x] CSS 등 사용자 UI 디자인 변경: 폴더 카드, 폴더 상세, URL 선택 화면 UI 적용
- [x] 버그 수정: 폴더 전용 layout에서 `FoldersProvider`와 `SavedLinksProvider`를 연결해 폴더 화면의 context 사용 오류 방지
- [x] 코드 리팩토링: 폴더 PR이 #6 홈 스캔 PR의 파일을 중복 추가하지 않도록 파일 책임 범위 분리

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 변경 사항에 대한 테스트

## Screenshots or Video

### 폴더 메인화면
<img width="476" height="1020" alt="폴더 화면 캡쳐" src="https://github.com/user-attachments/assets/f4803fb8-673d-41b1-982b-03fefd5d781d" />

### 폴더 속 저장된 URL 화면
<img width="496" height="1017" alt="폴더 속 저장된 url 화면" src="https://github.com/user-attachments/assets/eee35f45-5f42-4115-9f9d-fe3421b852d7" />

### 폴더속 URL 추가 버튼 눌렀을 시 나오는 화면
<img width="498" height="1018" alt="폴더 속 url 추가 버튼 눌렀을 시 나오는 화면" src="https://github.com/user-attachments/assets/8698eee3-aef0-4f12-a5aa-0a133da36fd0" />

### 새폴더 단계 1
<img width="492" height="1022" alt="폴더 추가 화면" src="https://github.com/user-attachments/assets/e79b1d45-1d98-4b45-9e23-f57bde55561c" />

### 새폴더 단계 2
<img width="497" height="1026" alt="폴더 추가화면 2" src="https://github.com/user-attachments/assets/ddb571da-1b6d-4305-80a9-2fe1f0ed19e3" />

### 폴더 추가된 뒤 화면
<img width="490" height="1025" alt="폴더 추가된 뒤 화면" src="https://github.com/user-attachments/assets/e38739db-b1fa-46e9-a25c-dc59a026641f" />

### 폴더에서 URL 삭제 버튼 1
<img width="495" height="1027" alt="폴더에서 url 삭제 버튼" src="https://github.com/user-attachments/assets/8296e0ee-26ea-4b85-a9e3-a699c90ed233" />

### 폴더에서 URL 삭제 버튼 2
<img width="488" height="1025" alt="폴더에서 url 삭제버튼 2" src="https://github.com/user-attachments/assets/6918a49d-3a22-4cb5-9f1e-96ba16863aec" />