### PR TITLE
[FEATURE] 링크 액션 모달 추가

### DIFF
--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -142,7 +142,7 @@ export default function FolderScreen() {
       >
         <KeyboardAvoidingView
           style={renameStyles.overlay}
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
           <Pressable style={renameStyles.backdrop} onPress={handleRenameCancel} />
           <View style={renameStyles.sheet}>

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -1,30 +1,36 @@
+import { useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { useSavedLinks } from '@/context/saved-links-context';
+import { LinkSaveModal } from '@/components/ui/link-save-modal';
 
 export default function ScanResultCautionScreen() {
   const { url } = useLocalSearchParams<{ url: string }>();
   const { addLink } = useSavedLinks();
+  const [saveModalVisible, setSaveModalVisible] = useState(false);
 
-  const handleSave = () => {
+  const handleSave = (title: string) => {
+    const resolvedUrl = url ?? '';
+
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
     addLink({
       id: Date.now(),
       analysisId: `mock-${Date.now()}`,
       categoryId: null,
-      originalUrl: url ?? '',
-      finalUrl: url ?? null,
-      title: url ?? '제목 없음',
+      originalUrl: resolvedUrl,
+      finalUrl: resolvedUrl || null,
+      title,
       description: '저장된 링크입니다.',
       siteName: (() => {
-        try { return new URL(url ?? '').hostname; } catch { return '알 수 없음'; }
+        try { return new URL(resolvedUrl).hostname; } catch { return '알 수 없음'; }
       })(),
       verdict: 'caution',
       isBookmarked: false,
       createdAt: new Date().toISOString(),
     });
+    setSaveModalVisible(false);
     router.dismissAll();
   };
 
@@ -77,7 +83,7 @@ export default function ScanResultCautionScreen() {
 
         {/* 버튼 영역 */}
         <View style={styles.buttonArea}>
-          <TouchableOpacity style={styles.cautionButton} onPress={handleSave} activeOpacity={0.8}>
+          <TouchableOpacity style={styles.cautionButton} onPress={() => setSaveModalVisible(true)} activeOpacity={0.8}>
             <Text style={styles.cautionButtonText}>주의 후 저장</Text>
           </TouchableOpacity>
 
@@ -86,6 +92,13 @@ export default function ScanResultCautionScreen() {
           </TouchableOpacity>
         </View>
       </ScrollView>
+
+      <LinkSaveModal
+        visible={saveModalVisible}
+        url={url ?? ''}
+        onCancel={() => setSaveModalVisible(false)}
+        onSave={handleSave}
+      />
     </>
   );
 }

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
 import { useSavedLinks } from '@/context/saved-links-context';
+import { LinkSaveModal } from '@/components/ui/link-save-modal';
 
 // TODO: 백엔드 연동 시 아래 흐름으로 교체
 // 1. scanning.tsx에서 POST /api/v1/analyses → analysisId 수신 후 params로 전달
@@ -14,25 +16,29 @@ import { useSavedLinks } from '@/context/saved-links-context';
 export default function ScanResultScreen() {
   const { url } = useLocalSearchParams<{ url: string }>();
   const { addLink } = useSavedLinks();
+  const [saveModalVisible, setSaveModalVisible] = useState(false);
 
-  const handleSave = () => {
+  const handleSave = (title: string) => {
+    const resolvedUrl = url ?? '';
+
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
     // 현재는 URL 기반 mock 데이터로 즉시 추가
     addLink({
       id: Date.now(),
       analysisId: `mock-${Date.now()}`,
       categoryId: null,
-      originalUrl: url ?? '',
-      finalUrl: url ?? null,
-      title: url ?? '제목 없음',
+      originalUrl: resolvedUrl,
+      finalUrl: resolvedUrl || null,
+      title,
       description: '저장된 링크입니다.',
       siteName: (() => {
-        try { return new URL(url ?? '').hostname; } catch { return '알 수 없음'; }
+        try { return new URL(resolvedUrl).hostname; } catch { return '알 수 없음'; }
       })(),
       verdict: 'safe',
       isBookmarked: false,
       createdAt: new Date().toISOString(),
     });
+    setSaveModalVisible(false);
     router.dismissAll();
   };
 
@@ -92,7 +98,7 @@ export default function ScanResultScreen() {
 
         {/* 버튼 영역 */}
         <View style={styles.buttonArea}>
-          <TouchableOpacity style={styles.primaryButton} onPress={handleSave} activeOpacity={0.8}>
+          <TouchableOpacity style={styles.primaryButton} onPress={() => setSaveModalVisible(true)} activeOpacity={0.8}>
             <Text style={styles.primaryButtonText}>저장</Text>
           </TouchableOpacity>
 
@@ -101,6 +107,13 @@ export default function ScanResultScreen() {
           </TouchableOpacity>
         </View>
       </ScrollView>
+
+      <LinkSaveModal
+        visible={saveModalVisible}
+        url={url ?? ''}
+        onCancel={() => setSaveModalVisible(false)}
+        onSave={handleSave}
+      />
     </>
   );
 }

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -16,6 +16,7 @@ import { Colors, Typography } from '@/constants/theme';
 interface LinkSaveModalProps {
   visible: boolean;
   url: string;
+  // 향후 링크카드 more 버튼의 URL 제목 수정 기능에서 기존 제목을 초기값으로 사용합니다.
   initialTitle?: string;
   onCancel: () => void;
   onSave: (title: string) => void;

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -172,7 +172,7 @@ const styles = StyleSheet.create({
   },
   urlBox: {
     height: 56,
-    borderRadius: 18,
+    borderRadius: 20,
     backgroundColor: Colors.brand.background,
     justifyContent: 'center',
     paddingHorizontal: 18,

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -75,6 +75,7 @@ export function LinkSaveModal({
               returnKeyType="done"
               onSubmitEditing={handleSave}
               maxLength={50}
+              autoFocus
             />
           </View>
 

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { Colors, Typography } from '@/constants/theme';
+
+interface LinkSaveModalProps {
+  visible: boolean;
+  url: string;
+  initialTitle?: string;
+  onCancel: () => void;
+  onSave: (title: string) => void;
+}
+
+export function LinkSaveModal({
+  visible,
+  url,
+  initialTitle = '',
+  onCancel,
+  onSave,
+}: LinkSaveModalProps) {
+  const [title, setTitle] = useState(initialTitle);
+
+  const trimmedTitle = title.trim();
+  const saveDisabled = trimmedTitle.length === 0;
+
+  useEffect(() => {
+    setTitle(initialTitle);
+  }, [initialTitle, visible]);
+
+  const handleSave = () => {
+    if (saveDisabled) return;
+    onSave(trimmedTitle);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onCancel}
+    >
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <Pressable style={styles.backdrop} onPress={onCancel} />
+
+        <View style={styles.sheet}>
+          <View style={styles.handle} />
+
+          <View style={styles.header}>
+            <Text style={styles.title}>링크 저장</Text>
+            <Text style={styles.description}>저장할 URL 제목을 입력해 주세요.</Text>
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>URL 제목</Text>
+            <TextInput
+              style={styles.input}
+              value={title}
+              onChangeText={setTitle}
+              placeholder="예: 네이버 블로그"
+              placeholderTextColor={Colors.brand.textHint}
+              returnKeyType="done"
+              onSubmitEditing={handleSave}
+              maxLength={50}
+            />
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>검사 대상 URL</Text>
+            <View style={styles.urlBox}>
+              <Text style={styles.urlText} numberOfLines={1} ellipsizeMode="tail">
+                {url}
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.actions}>
+            <TouchableOpacity
+              style={styles.cancelButton}
+              onPress={onCancel}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.cancelButtonText}>취소</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.saveButton, saveDisabled && styles.saveButtonDisabled]}
+              onPress={handleSave}
+              activeOpacity={0.8}
+              disabled={saveDisabled}
+            >
+              <Text style={[styles.saveButtonText, saveDisabled && styles.saveButtonTextDisabled]}>
+                저장
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(29, 38, 35, 0.42)',
+  },
+  sheet: {
+    width: '100%',
+    backgroundColor: Colors.light.background,
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
+    paddingTop: 14,
+    paddingHorizontal: 24,
+    paddingBottom: 32,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 51,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: Colors.brand.line,
+    marginBottom: 30,
+  },
+  header: {
+    gap: 14,
+    marginBottom: 34,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.brand.text,
+  },
+  description: {
+    ...Typography.summary,
+    color: Colors.brand.textSecondary,
+  },
+  fieldGroup: {
+    gap: 12,
+    marginBottom: 28,
+  },
+  label: {
+    ...Typography.caption,
+    color: Colors.brand.text,
+  },
+  input: {
+    height: 56,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: Colors.brand.line,
+    paddingHorizontal: 18,
+    ...Typography.body,
+    color: Colors.brand.text,
+    backgroundColor: Colors.light.background,
+  },
+  urlBox: {
+    height: 56,
+    borderRadius: 18,
+    backgroundColor: Colors.brand.background,
+    justifyContent: 'center',
+    paddingHorizontal: 18,
+  },
+  urlText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.text,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 14,
+    marginTop: 4,
+  },
+  cancelButton: {
+    flex: 1,
+    height: 56,
+    borderRadius: 28,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.light.background,
+  },
+  cancelButtonText: {
+    ...Typography.section,
+    color: Colors.brand.primary,
+  },
+  saveButton: {
+    flex: 1,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.brand.primary,
+  },
+  saveButtonDisabled: {
+    backgroundColor: Colors.brand.softMint,
+  },
+  saveButtonText: {
+    ...Typography.section,
+    color: Colors.light.background,
+  },
+  saveButtonTextDisabled: {
+    color: Colors.brand.textHint,
+  },
+});


### PR DESCRIPTION
Closes #21

## 개요
검사 결과 화면에서 안전 또는 주의 판정을 받은 URL을 저장할 때, 사용자가 URL 제목을 입력할 수 있는 링크 저장 모달을 추가했습니다.

기존에는 저장 버튼을 누르면 URL이 즉시 저장되고, 저장 제목이 URL 값으로 들어가는 흐름이었습니다. 이번 작업에서는 저장 전에 하단 모달을 띄워 사용자가 직접 URL 제목을 입력하도록 변경했으며, 입력한 제목 값을 기존 저장 로직에 전달하도록 연결했습니다.

모달 UI는 Figma의 링크 저장 모달 디자인을 기준으로 구현했고, 색상과 타이포그래피는 기존 디자인 시스템 토큰을 활용했습니다.

## 주요 구현 내용
- 링크 저장 모달 컴포넌트 추가
- 안전 검사 결과 화면의 저장 버튼과 모달 연결
- 주의 검사 결과 화면의 저장 버튼과 모달 연결
- URL 제목 입력값을 기존 `addLink` 저장 로직에 전달
- 검사 대상 URL을 모달 내부에 읽기 전용 정보로 표시
- 제목 미입력 시 저장 버튼 비활성화 처리
- 취소 버튼 및 배경 터치 시 모달 닫기 처리
- Android 키보드 표시 시 모달이 흔들리지 않도록 키보드 회피 동작 조정

## 파일별 역할
- `components/ui/link-save-modal.tsx`: 링크 저장 하단 모달 컴포넌트
- `app/(tabs)/(home)/scan-result.tsx`: 안전 결과 화면에서 저장 모달을 열고 입력한 제목으로 링크 저장
- `app/(tabs)/(home)/scan-result-caution.tsx`: 주의 결과 화면에서 저장 모달을 열고 입력한 제목으로 링크 저장

## 해결한 이슈 목록
- [x] 새로운 기능 추가: URL 제목 입력용 링크 저장 모달 추가
- [x] CSS 등 사용자 UI 디자인 변경: Figma 기반 하단 모달 UI 구현
- [x] 기존 저장 기능 수정: 저장 버튼 클릭 시 즉시 저장 대신 모달을 통한 저장 흐름으로 변경
- [x] 기존 기능 유지: 안전/주의 결과에서만 저장 가능하도록 기존 화면 흐름 유지

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] `npx tsc --noEmit` 통과
- [x] 에뮬레이터에서 모달 UI 및 저장 흐름 확인

## Screenshots or Video

<img width="485" height="1023" alt="image" src="https://github.com/user-attachments/assets/c6ff81f9-a5e9-4a05-b4a1-64e02e3d6873" />
