### PR TITLE
[DESIGN] 홈 및 폴더 화면 UI 크기 정리

### DIFF
--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -75,7 +75,9 @@ export default function FolderDetailScreen() {
           <View style={styles.canvasHeader}>
             <View style={styles.folderTitleGroup}>
               <Text style={styles.folderTitleLabel}>현재 폴더</Text>
-              <Text style={styles.folderName}>{folderName}</Text>
+              <Text style={styles.folderName} numberOfLines={1} ellipsizeMode="tail">
+                {folderName}
+              </Text>
             </View>
             <AddFolderButton label="URL 추가" onPress={handleAddUrl} />
           </View>
@@ -181,9 +183,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    gap: 12,
     paddingVertical: 4,
   },
   folderTitleGroup: {
+    flex: 1,
+    minWidth: 0,
     gap: 4,
     marginLeft: 10,
   },

--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -73,7 +73,10 @@ export default function FolderDetailScreen() {
         {/* 폴더명 + URL 추가 버튼 */}
         <View style={styles.canvasHeaderWrapper}>
           <View style={styles.canvasHeader}>
-            <Text style={styles.folderName}>{folderName}</Text>
+            <View style={styles.folderTitleGroup}>
+              <Text style={styles.folderTitleLabel}>현재 폴더</Text>
+              <Text style={styles.folderName}>{folderName}</Text>
+            </View>
             <AddFolderButton label="URL 추가" onPress={handleAddUrl} />
           </View>
           <Toast
@@ -154,7 +157,7 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   headerTitle: {
-    ...Typography.title,
+    ...Typography.pageTitle,
     color: Colors.brand.text,
     flex: 1,
   },
@@ -179,6 +182,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingVertical: 4,
+  },
+  folderTitleGroup: {
+    gap: 4,
+    marginLeft: 10,
+  },
+  folderTitleLabel: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
   },
   folderName: {
     ...Typography.title,

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -211,7 +211,7 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   title: {
-    ...Typography.title,
+    ...Typography.pageTitle,
     color: Colors.brand.text,
   },
   subtitle: {

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'expo-router';
 import { AddFolderButton } from '@/components/ui/add-folder-button';
 import { FolderCard } from '@/components/ui/folder-card';
 import { FolderContextMenu } from '@/components/ui/folder-context-menu';
+import { SectionHeader } from '@/components/ui/section-header';
 import { Colors, Typography } from '@/constants/theme';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { useSavedLinks } from '@/context/saved-links-context';
@@ -97,10 +98,10 @@ export default function FolderScreen() {
 
         {/* 폴더 캔버스 */}
         <View style={styles.canvas}>
-          <View style={styles.canvasHeader}>
-            <Text style={styles.canvasTitle}>내 폴더</Text>
-            <AddFolderButton onPress={handleAddFolder} />
-          </View>
+          <SectionHeader
+            label="내 폴더"
+            rightSlot={<AddFolderButton onPress={handleAddFolder} />}
+          />
 
           {folders.length > 0 ? (
             <View style={styles.grid}>
@@ -226,16 +227,6 @@ const styles = StyleSheet.create({
     padding: 16,
     gap: 16,
   },
-  canvasHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  canvasTitle: {
-    ...Typography.title,
-    color: Colors.brand.text,
-  },
-
   grid: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -36,7 +36,7 @@ export default function HomeScreen() {
           <View style={styles.wordmark}>
             <IconSymbol
               name="checkmark.shield.fill"
-              size={28}
+              size={30}
               color={Colors.brand.primary}
             />
             <Text style={styles.brandText}>LinClean</Text>
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   brandText: {
-    ...Typography.title,
+    ...Typography.displayMedium,
     color: Colors.brand.primary,
   },
 

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
 
@@ -5,17 +6,18 @@ interface SectionHeaderProps {
   label: string;
   onViewAll?: () => void;
   viewAllLabel?: string;
+  rightSlot?: ReactNode;
 }
 
-export function SectionHeader({ label, onViewAll, viewAllLabel = '전체보기' }: SectionHeaderProps) {
+export function SectionHeader({ label, onViewAll, viewAllLabel = '전체보기', rightSlot }: SectionHeaderProps) {
   return (
     <View style={styles.container}>
       <Text style={styles.label}>{label}</Text>
-      {onViewAll && (
+      {rightSlot ?? (onViewAll && (
         <TouchableOpacity onPress={onViewAll} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
           <Text style={styles.viewAll}>{viewAllLabel}</Text>
         </TouchableOpacity>
-      )}
+      ))}
     </View>
   );
 }
@@ -27,7 +29,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   label: {
-    ...Typography.section,
+    ...Typography.sectionTitle,
     color: Colors.brand.text,
   },
   viewAll: {

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
   },
   message: {
     ...Typography.summary,
+    lineHeight: 20,
     fontWeight: '700',
     color: Colors.brand.onPrimary,
   },

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -134,6 +134,7 @@ export const Fonts = {
 // Font size tokens (from Figma Design System)
 const fontSizeDisplay = 32;
 const fontSizeDisplayMedium = 30;
+const fontSizePageTitle = 24;
 const fontSizeTitle = 22;
 const fontSizeSectionTitle = 20;
 const fontSizeSection = 18;
@@ -152,6 +153,7 @@ const fontWeightRegular = '400' as const;
 export const Typography = {
   display: { fontSize: fontSizeDisplay, fontWeight: fontWeightBold },
   displayMedium: { fontSize: fontSizeDisplayMedium, fontWeight: fontWeightBold },
+  pageTitle: { fontSize: fontSizePageTitle, fontWeight: fontWeightBold },
   title: { fontSize: fontSizeTitle, fontWeight: fontWeightBold },
   sectionTitle: { fontSize: fontSizeSectionTitle, fontWeight: fontWeightBold },
   section: { fontSize: fontSizeSection, fontWeight: fontWeightBold },

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -135,6 +135,7 @@ export const Fonts = {
 const fontSizeDisplay = 32;
 const fontSizeDisplayMedium = 30;
 const fontSizeTitle = 22;
+const fontSizeSectionTitle = 20;
 const fontSizeSection = 18;
 const fontSizeProfile = 17;
 const fontSizeBody = 16;
@@ -152,6 +153,7 @@ export const Typography = {
   display: { fontSize: fontSizeDisplay, fontWeight: fontWeightBold },
   displayMedium: { fontSize: fontSizeDisplayMedium, fontWeight: fontWeightBold },
   title: { fontSize: fontSizeTitle, fontWeight: fontWeightBold },
+  sectionTitle: { fontSize: fontSizeSectionTitle, fontWeight: fontWeightBold },
   section: { fontSize: fontSizeSection, fontWeight: fontWeightBold },
   profile: { fontSize: fontSizeProfile, fontWeight: fontWeightBold },
   body: { fontSize: fontSizeBody, fontWeight: fontWeightRegular },


### PR DESCRIPTION
Closes #34

## 개요

홈 화면과 폴더 화면의 디자인 변경을 하였습니다.

홈 화면의 `보안 등급별 링크 현황`, `최근 저장한 링크` 영역과 폴더 화면의 `내 폴더` 타이틀 크기를 같은 타이포그래피 토큰으로 통일하여 화면 간 시각적 일관성을 개선했습니다.

또한 홈 상단의 LinClean 브랜드 영역 크기를 조정하고, 폴더 상세 화면의 폴더 제목 위치와 제목 위계를 정리했습니다. 폴더 상세에서는 현재 보고 있는 폴더명이 제목임을 더 명확히 알 수 있도록 보조 라벨을 추가했습니다.

폴더 상세 화면의 toast 메시지 문구가 일부 기기에서 살짝 잘려 보이는 문제도 함께 보정했습니다.
노출 위치는 기존과 동일하게 유지하고, 텍스트 줄 높이만 조정해 표시 안정성을 개선했습니다.

변경 전 화면은, issue에 스크린샷 올려놨습니다!

## 주요 구현 내용

- 홈/폴더 섹션 타이틀 크기를 `Typography.sectionTitle` 20px로 통일
- `SectionHeader`에 오른쪽 액션 슬롯을 추가해 폴더 화면에서도 공통 섹션 헤더 사용
- 폴더 화면의 `내 폴더` 타이틀을 홈 섹션 타이틀과 동일한 컴포넌트/토큰으로 렌더링
- 홈 상단 LinClean 아이콘과 브랜드 텍스트 크기를 30px 기준으로 조정
- 폴더 상세 화면의 폴더명 위치를 링크 카드 기준선에 더 가깝게 조정
- 폴더 상세 화면에 `현재 폴더` 보조 라벨 추가
- 페이지 최상단 제목인 `폴더`, `폴더 목록`에 `Typography.pageTitle` 24px 토큰 적용
- 기존 하드코딩 대신 디자인 시스템의 타이포그래피/컬러 토큰을 활용
- 폴더 상세 화면 toast 메시지에 명시적인 `lineHeight`를 적용해 Android에서 한글 문구가 살짝 잘려 보이는 문제 보정

## 파일별 역할

- `constants/theme.ts`: `Typography.sectionTitle`, `Typography.pageTitle` 타이포그래피 토큰 추가
- `components/ui/section-header.tsx`: 공통 섹션 헤더에 `rightSlot` 추가 및 섹션 타이틀 토큰 적용
- `app/(tabs)/(home)/index.tsx`: 홈 브랜드 아이콘 및 LinClean 텍스트 크기 조정
- `app/(tabs)/(folder)/index.tsx`: `내 폴더` 타이틀을 공통 `SectionHeader`로 변경, 페이지 제목 크기 조정
- `app/(tabs)/(folder)/[id].tsx`: 폴더 상세 제목 위치 조정, 보조 라벨 추가, 상단 제목 크기 조정
- `components/ui/toast.tsx`: toast 메시지 텍스트의 `lineHeight`를 지정해 문구 표시 안정성 개선

## 해결한 이슈 목록

- [x] `보안 등급별 링크 현황` 영역의 제목/크기 확인 및 조정
- [x] `최근 저장한 링크` 영역의 제목/크기 확인 및 조정
- [x] 폴더 화면의 `내 폴더` 글씨 크기를 홈 화면 섹션 타이틀과 통일
- [x] 홈 화면의 LinClean 아이콘 및 브랜드 텍스트 크기 조정
- [x] 아이콘 크기 변경 후 홈 화면 레이아웃 유지
- [x] 폴더 상세 화면의 폴더 제목 위치 조정
- [x] 폴더 제목이 제목처럼 보이도록 보조 라벨과 타이포그래피 위계 적용
- [x] 페이지 상단 제목과 섹션 제목의 크기 위계 정리
- [x] 모바일 화면에서 홈/폴더 화면 UI가 자연스럽게 표시되는지 확인
- [x] 폴더 상세 화면 toast 문구가 잘리지 않고 자연스럽게 표시되도록 보정

## 체크 사항

- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 작업 브랜치 push 완료
- [x] `npm run lint` 통과
- [x] 디자인 토큰을 활용해 하드코딩 최소화
- [x] Expo dev-client에서 에뮬레이터 재실행 후 화면 표시 확인

## Screenshots or Video
- 변경 후 toast
<img width="232" height="69" alt="image" src="https://github.com/user-attachments/assets/d368012d-eedb-4790-878c-f3877f4aecdd" />

- 변경 후 홈화면
<img width="499" height="1022" alt="image" src="https://github.com/user-attachments/assets/bdeb7df2-a25e-4c9d-947a-8b2f60257f2b" />

- 변경 후 폴더 목록 화면
<img width="505" height="1018" alt="image" src="https://github.com/user-attachments/assets/a8aeeec7-37ad-486a-977f-a9d26dec9e7d" />

- 변경 후 폴더 상세 화면
<img width="503" height="1023" alt="image" src="https://github.com/user-attachments/assets/19401dbf-eb6d-427b-a254-e880a89ceea2" />


