### PR TITLE
[FIX] URL 입력 검증 로직 개선

### DIFF
--- a/app/(tabs)/(home)/add-link.tsx
+++ b/app/(tabs)/(home)/add-link.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import {
-  ActivityIndicator,
   KeyboardAvoidingView,
-  Linking,
   Platform,
   StyleSheet,
   Text,
@@ -15,14 +13,35 @@ import { Stack, router } from 'expo-router';
 import { ScanButton } from '@/components/ui/scan-button';
 import { Colors, Typography } from '@/constants/theme';
 
+function getRawHostname(value: string): string | null {
+  const authority = value.match(/^https?:\/\/([^/?#]+)/i)?.[1];
+  if (!authority) return null;
+
+  return authority.split('@').pop()?.split(':')[0] ?? null;
+}
+
+function isValidHostname(hostname: string): boolean {
+  const labels = hostname.split('.');
+  if (labels.length < 2) return false;
+  if (labels.some((label) => !label)) return false;
+
+  const tld = labels[labels.length - 1];
+  if (!/^[a-z]{2,}$/i.test(tld)) return false;
+
+  return labels.every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(label));
+}
+
 function isValidUrlFormat(value: string): boolean {
   const trimmed = value.trim();
-  if (!/^https?:\/\//i.test(trimmed)) return false;
+  if (!trimmed || /\s/.test(trimmed)) return false;
+
+  const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  const rawHostname = getRawHostname(candidate);
+  if (!rawHostname || !isValidHostname(rawHostname)) return false;
+
   try {
-    const parsed = new URL(trimmed);
-    const parts = parsed.hostname.split('.');
-    const tld = parts[parts.length - 1];
-    return parts.length >= 2 && tld.length >= 2;
+    const parsed = new URL(candidate);
+    return isValidHostname(parsed.hostname);
   } catch {
     return false;
   }
@@ -31,9 +50,8 @@ function isValidUrlFormat(value: string): boolean {
 export default function AddLinkScreen() {
   const [url, setUrl] = useState('');
   const [error, setError] = useState('');
-  const [isChecking, setIsChecking] = useState(false);
 
-  const handleScan = async () => {
+  const handleScan = () => {
     const trimmed = url.trim();
 
     if (!trimmed) {
@@ -41,27 +59,13 @@ export default function AddLinkScreen() {
       return;
     }
 
-    // 1단계: new URL()로 형식 검증
     if (!isValidUrlFormat(trimmed)) {
       setError('올바르지 않은 URL 입력입니다.');
       return;
     }
 
-    // 2단계: Linking.canOpenURL()로 실제 열기 가능 여부 확인
-    setIsChecking(true);
-    try {
-      const canOpen = await Linking.canOpenURL(trimmed);
-      if (!canOpen) {
-        setError('올바르지 않은 URL 입력입니다.');
-        return;
-      }
-      setError('');
-      router.push({ pathname: '/(tabs)/(home)/scanning', params: { url: trimmed } });
-    } catch {
-      setError('URL 확인 중 오류가 발생했습니다.');
-    } finally {
-      setIsChecking(false);
-    }
+    setError('');
+    router.push({ pathname: '/(tabs)/(home)/scanning', params: { url: trimmed } });
   };
 
   const handleChangeUrl = (value: string) => {
@@ -70,7 +74,7 @@ export default function AddLinkScreen() {
   };
 
   const hasError = error.length > 0;
-  const scanDisabled = !url.trim() || isChecking;
+  const scanDisabled = !url.trim();
 
   return (
     <>
@@ -118,9 +122,8 @@ export default function AddLinkScreen() {
                   keyboardType="url"
                   returnKeyType="search"
                   onSubmitEditing={handleScan}
-                  editable={!isChecking}
                 />
-                {url.length > 0 && !isChecking && (
+                {url.length > 0 && (
                   <TouchableOpacity
                     onPress={() => { setUrl(''); setError(''); }}
                     hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
@@ -130,13 +133,7 @@ export default function AddLinkScreen() {
                   </TouchableOpacity>
                 )}
               </View>
-              {isChecking ? (
-                <View style={styles.loadingBox}>
-                  <ActivityIndicator size="small" color={Colors.brand.primary} />
-                </View>
-              ) : (
-                <ScanButton onPress={handleScan} disabled={scanDisabled} />
-              )}
+              <ScanButton onPress={handleScan} disabled={scanDisabled} />
             </View>
 
             {/* 에러 메시지 */}
@@ -232,17 +229,6 @@ const styles = StyleSheet.create({
     color: Colors.brand.primary,
     lineHeight: 16,
   },
-  loadingBox: {
-    width: 60,
-    height: 60,
-    borderRadius: 16,
-    borderWidth: 1.5,
-    borderColor: Colors.brand.line,
-    backgroundColor: Colors.brand.background,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-
   // 에러
   errorText: {
     ...Typography.body,

--- a/components/ui/card-link.tsx
+++ b/components/ui/card-link.tsx
@@ -30,13 +30,6 @@ const VERDICT_LABELS: Record<LinkVerdict, string> = {
 
 const VERDICT_COLORS: Record<LinkVerdict, { background: string; text: string }> = Colors.brand.verdict;
 
-function normalizeLinkUrl(value?: string | null) {
-  const trimmed = value?.trim();
-  if (!trimmed) return null;
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
-  return `https://${trimmed}`;
-}
-
 function getFirstText(...values: (string | null | undefined)[]) {
   return values.find((value) => value?.trim())?.trim();
 }
@@ -58,7 +51,7 @@ export function CardLink({
   const moreRef = useRef<View>(null);
   const displayUrl = getFirstText(finalUrl, originalUrl) ?? 'URL 정보 없음';
   const displayTitle = getFirstText(title, summary) ?? '제목 없음';
-  const openUrl = normalizeLinkUrl(getFirstText(finalUrl, originalUrl));
+  const openUrl = getFirstText(finalUrl, originalUrl);
   const normalizedVerdict = verdict && verdict in VERDICT_LABELS ? verdict : undefined;
   const statusLabel = normalizedVerdict ? VERDICT_LABELS[normalizedVerdict] : (getFirstText(label) ?? '결과 없음');
   const statusColors = normalizedVerdict ? VERDICT_COLORS[normalizedVerdict] : undefined;
@@ -88,12 +81,6 @@ export function CardLink({
     }
 
     try {
-      const canOpen = await Linking.canOpenURL(openUrl);
-      if (!canOpen) {
-        Alert.alert('URL을 열 수 없어요', '외부 브라우저에서 열 수 없는 주소입니다.');
-        return;
-      }
-
       await Linking.openURL(openUrl);
     } catch {
       Alert.alert('URL을 열 수 없어요', '잠시 후 다시 시도해주세요.');


### PR DESCRIPTION
Closes #36

## 개요

URL 입력 화면에서 `www.naver.com`, `naver.com`처럼 `http://`, `https://` 프로토콜이 없는 정상적인 도메인 주소도 올바른 URL 형식으로 판단되도록 검증 로직을 개선했습니다.

기존에는 입력값에 `http://` 또는 `https://`가 없으면 즉시 실패 처리하고, 이후 `Linking.canOpenURL()`로 실제 열기 가능 여부까지 확인하고 있었습니다. 이 방식은 스킴이 없는 정상 도메인을 잘못 거부하고, 프론트에서 URL을 열 수 있는지까지 판단하게 되어 원본 URL을 그대로 백엔드에 넘기기로 한 방향과 맞지 않았습니다.

이번 작업에서는 사용자가 입력한 주소를 원본으로 유지하고, `https://`를 붙인 값은 검증용 내부 후보로만 사용하도록 변경했습니다. 따라서 `naver.com` 입력 시 검증 단계에서는 `https://naver.com` 형태로 파싱 가능 여부를 확인하지만, 스캔 화면/백엔드 전달값과 실제 접속 기준 주소는 사용자가 입력한 `naver.com` 그대로 유지됩니다.

또한 `네이버.com`처럼 한글/비ASCII 문자가 포함된 도메인이 `new URL()`에서 punycode로 변환되어 통과하는 문제를 막기 위해 원본 hostname 기준의 ASCII 도메인 검증을 추가했습니다.

## 주요 구현 내용

- URL 입력 검증 시 `http://`, `https://`가 없는 도메인도 URL 후보로 판단
- `https://` 보정값은 검증 함수 내부에서만 사용
- 스캔 화면/백엔드로 전달하는 URL은 사용자가 입력한 원본 문자열 기준으로 유지
- 입력 단계에서 `Linking.canOpenURL()` 검증 제거
- 원본 hostname 기준 ASCII 도메인 검증 추가
- 한글/비ASCII 도메인 입력 차단
- 빈 라벨, 잘못된 하이픈 위치, 짧은 TLD 등 잘못된 도메인 형식 차단
- 저장 링크 카드에서 외부 브라우저 실행 시 `https://` 자동 보정 제거
- 실제 접속 시에도 저장된 원본 URL을 그대로 `Linking.openURL()`에 전달하도록 변경

## 동작 방식

예시 1:

```text
사용자 입력: naver.com
검증용 내부 값: https://naver.com
스캔 화면/백엔드 전달값: naver.com
실제 접속 기준 주소: naver.com
```

예시 2:

```text
사용자 입력: https://naver.com
검증용 내부 값: https://naver.com
스캔 화면/백엔드 전달값: https://naver.com
실제 접속 기준 주소: https://naver.com
```

즉, `https://`를 붙이는 처리는 URL 형식 검증을 위한 임시 처리이며, 백엔드에 넘기거나 실제 접속할 때 사용하는 값은 사용자가 입력한 주소를 기준으로 합니다.

## 파일별 역할

- `app/(tabs)/(home)/add-link.tsx`: URL 입력 형식 검증 로직 개선, `Linking.canOpenURL()` 기반 검증 제거, 원본 URL 전달 유지
- `components/ui/card-link.tsx`: 저장 링크 실행 시 URL 자동 보정 제거, 원본 URL 기반 외부 브라우저 실행 처리

## 해결한 이슈 목록

- [x] 현재 URL 체크 로직 위치와 동작 방식 확인
- [x] `www.naver.com`, `naver.com`처럼 스킴이 없는 정상 도메인을 URL 형식으로 인정
- [x] `http://`, `https://`가 이미 포함된 URL은 기존처럼 허용
- [x] `https://` 보정값은 검증 내부에서만 사용하도록 처리
- [x] 프론트에서 URL을 임의로 보정해 백엔드에 전달하지 않도록 처리
- [x] 입력 단계에서 `Linking.canOpenURL()` 의존 제거
- [x] `ㅎㅇ.com`, `한글.com` 등 비ASCII 도메인 차단
- [x] `a..com`, `-naver.com`, `naver-.com`, `naver.c` 등 잘못된 도메인 형식 차단
- [x] 저장 링크 접속 시에도 사용자가 저장한 원본 URL을 그대로 사용하도록 처리

## 체크 사항

- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] `npm run lint` 통과
- [x] 변경 파일 범위 확인
- [x] 작업 브랜치 push 완료
- [x] 기존 미추적 파일 `clerk-build.log`는 커밋에서 제외

## 참고

허용되는 입력:
- `www.naver.com`
- `naver.com`
- `https://www.naver.com`
- `http://www.naver.com`
- `sub.domain.co.kr`

거부되는 입력:
- `네이버.com`
- `한글.com`
- `naver`
- `naver.c`
- `a..com`
- `-naver.com`
- `naver-.com`
- `https://`