### PR TITLE
[FEATURE] Clerk 토큰 기반 보호 API 요청 구조 공통화

### DIFF
--- a/api/api-client.ts
+++ b/api/api-client.ts
@@ -1,0 +1,162 @@
+import { Platform } from 'react-native';
+
+const DEFAULT_API_BASE_URL =
+  Platform.select({
+    android: 'http://10.0.2.2:8080',
+    default: 'http://localhost:8080',
+  }) ?? 'http://localhost:8080';
+
+export const API_BASE_URL = (
+  process.env.EXPO_PUBLIC_API_BASE_URL ?? DEFAULT_API_BASE_URL
+).replace(/\/$/, '');
+
+export interface ApiResponse<T> {
+  data: T;
+}
+
+interface ApiErrorResponse {
+  code?: string;
+  message?: string;
+  timestamp?: string;
+  errors?: unknown;
+}
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export type ClerkTokenGetter = () => Promise<string | null>;
+
+export interface ApiRequestOptions extends Omit<RequestInit, 'body' | 'headers'> {
+  body?: unknown;
+  headers?: Record<string, string>;
+  token?: string;
+}
+
+export async function getClerkSessionToken(getToken: ClerkTokenGetter): Promise<string> {
+  const token = await getToken();
+
+  if (!token) {
+    throw new Error('Missing Clerk session token');
+  }
+
+  return token;
+}
+
+export async function publicApiRequest<T>(
+  path: string,
+  options: Omit<ApiRequestOptions, 'token'> = {},
+): Promise<T> {
+  return apiRequest<T>(path, options);
+}
+
+export async function authenticatedApiRequest<T>(
+  getToken: ClerkTokenGetter,
+  path: string,
+  options: Omit<ApiRequestOptions, 'token'> = {},
+): Promise<T> {
+  const token = await getClerkSessionToken(getToken);
+
+  return apiRequest<T>(path, { ...options, token });
+}
+
+export async function apiRequest<T>(
+  path: string,
+  { body, headers, token, method = body === undefined ? 'GET' : 'POST', ...init }: ApiRequestOptions = {},
+): Promise<T> {
+  const requestHeaders: Record<string, string> = {
+    Accept: 'application/json',
+    ...headers,
+  };
+
+  const requestInit: RequestInit = {
+    ...init,
+    method,
+    headers: requestHeaders,
+  };
+
+  if (token) {
+    requestHeaders.Authorization = `Bearer ${token}`;
+  }
+
+  if (body !== undefined) {
+    requestHeaders['Content-Type'] = requestHeaders['Content-Type'] ?? 'application/json';
+    requestInit.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(buildApiUrl(path), requestInit);
+  const responseBody = await parseResponseBody(response);
+
+  if (!response.ok) {
+    throw buildApiError(response, responseBody);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return unwrapApiResponse<T>(responseBody);
+}
+
+function buildApiUrl(path: string) {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  return `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  const responseText = await response.text();
+
+  if (!responseText) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(responseText);
+  } catch {
+    return responseText;
+  }
+}
+
+function unwrapApiResponse<T>(body: unknown): T {
+  if (isApiResponse<T>(body)) {
+    return body.data;
+  }
+
+  return body as T;
+}
+
+function isApiResponse<T>(body: unknown): body is ApiResponse<T> {
+  return typeof body === 'object' && body !== null && 'data' in body;
+}
+
+function buildApiError(response: Response, body: unknown) {
+  if (isApiErrorResponse(body)) {
+    return new ApiError(
+      body.message ?? `API request failed with status ${response.status}`,
+      response.status,
+      body.code,
+      body.errors,
+    );
+  }
+
+  if (typeof body === 'string' && body.length > 0) {
+    return new ApiError(body, response.status);
+  }
+
+  return new ApiError(`API request failed with status ${response.status}`, response.status);
+}
+
+function isApiErrorResponse(body: unknown): body is ApiErrorResponse {
+  return typeof body === 'object' && body !== null;
+}

--- a/api/terms.ts
+++ b/api/terms.ts
@@ -1,13 +1,4 @@
-import { Platform } from 'react-native';
-
-const DEFAULT_API_BASE_URL =
-  Platform.select({
-    android: 'http://10.0.2.2:8080',
-    default: 'http://localhost:8080',
-  }) ?? 'http://localhost:8080';
-
-const apiBaseUrl =
-  process.env.EXPO_PUBLIC_API_BASE_URL?.replace(/\/$/, '') ?? DEFAULT_API_BASE_URL;
+import { publicApiRequest } from '@/api/api-client';
 
 export type TermsType = 'terms_of_service' | 'privacy_policy' | 'service_guide';
 export type ContentFormat = 'markdown' | 'html' | 'plain_text';
@@ -23,39 +14,11 @@ export interface TermsResponse {
   updatedAt: string;
 }
 
-interface ApiResponse<T> {
-  data: T;
-}
-
-interface ApiErrorResponse {
-  code?: string;
-  message?: string;
-}
-
 export async function fetchTerms(type: TermsType, signal?: AbortSignal): Promise<TermsResponse> {
-  const response = await fetch(`${apiBaseUrl}/api/v1/terms/${type}`, {
+  const terms = await publicApiRequest<TermsResponse>(`/api/v1/terms/${type}`, {
     method: 'GET',
-    headers: {
-      Accept: 'application/json',
-    },
     signal,
   });
-
-  if (!response.ok) {
-    let errorMessage = '약관 정보를 불러오지 못했습니다.';
-
-    try {
-      const error = (await response.json()) as ApiErrorResponse;
-      errorMessage = error.message ?? errorMessage;
-    } catch {
-      // JSON 응답이 아닌 경우 기본 안내 문구를 사용합니다.
-    }
-
-    throw new Error(errorMessage);
-  }
-
-  const body = (await response.json()) as ApiResponse<TermsResponse> | TermsResponse;
-  const terms = 'data' in body ? body.data : body;
 
   if (!terms?.title || !terms.content) {
     throw new Error('약관 정보를 불러오지 못했습니다.');

--- a/services/auth-api.ts
+++ b/services/auth-api.ts
@@ -1,10 +1,6 @@
-import { Platform } from 'react-native';
+import { API_BASE_URL, apiRequest, getClerkSessionToken, type ClerkTokenGetter } from '@/api/api-client';
 
-type ApiResponse<T> = {
-  data: T;
-};
-
-type MeResponse = {
+export type MeResponse = {
   publicId: string;
 };
 
@@ -15,13 +11,6 @@ type JwtClaims = {
   iss?: string;
   sub?: string;
 };
-
-const defaultApiBaseUrl = Platform.select({
-  android: 'http://10.0.2.2:8080',
-  default: 'http://localhost:8080',
-});
-
-export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? defaultApiBaseUrl;
 
 function decodeJwtClaims(token: string): JwtClaims | null {
   try {
@@ -40,28 +29,13 @@ function decodeJwtClaims(token: string): JwtClaims | null {
   }
 }
 
-export async function syncAuthenticatedMember(getToken: () => Promise<string | null>) {
-  const token = await getToken();
-
-  if (!token) {
-    throw new Error('Missing Clerk session token');
-  }
+export async function syncAuthenticatedMember(getToken: ClerkTokenGetter): Promise<MeResponse> {
+  const token = await getClerkSessionToken(getToken);
 
   if (__DEV__) {
     console.log('Clerk token claims', decodeJwtClaims(token));
     console.log('Syncing authenticated member with API', API_BASE_URL);
   }
 
-  const response = await fetch(`${API_BASE_URL}/api/v1/auth/me`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    const responseText = await response.text();
-    throw new Error(`Failed to sync authenticated member: ${response.status} ${responseText}`);
-  }
-
-  return response.json() as Promise<ApiResponse<MeResponse>>;
+  return apiRequest<MeResponse>('/api/v1/auth/me', { token });
 }


### PR DESCRIPTION
Closes #41

## 개요

Clerk 기반 Google 로그인 및 회원 동기화 흐름은 유지하면서, 이후 백엔드 보호 API를 호출할 때 재사용할 수 있는 공통 API 요청 구조를 정리했습니다.

기존 프론트엔드에는 로그인 성공 후 `/api/v1/auth/me`를 호출해 Clerk 사용자와 백엔드 `member`를 동기화하는 흐름이 이미 구현되어 있었습니다. 이번 작업에서는 `/auth/me`를 새 로그인 API처럼 새로 연동하지 않고, 기존 역할인 Clerk JWT 검증 및 member 확인/동기화 API로 유지했습니다.

대신 이후 `analyses`, `saved-links`, 북마크, 삭제 API처럼 인증이 필요한 API를 연동할 때 Clerk `getToken()`으로 받은 토큰을 `Authorization: Bearer {token}` 헤더에 일관되게 포함할 수 있도록 공통 API 클라이언트를 추가했습니다.

또한 백엔드 응답이 `{ data: ... }` 형태로 내려오는 구조를 공통으로 처리하고, API base URL 설정과 에러 응답 처리도 한곳에서 관리하도록 정리했습니다. 기존 약관 API처럼 인증이 필요 없는 요청은 비인증 요청 함수로 분리해 공통 구조와 충돌 없이 동작하도록 변경했습니다.

## 주요 구현 내용

- 공통 API 클라이언트 `api/api-client.ts` 추가
- Android 에뮬레이터 기본 API 주소를 `http://10.0.2.2:8080`으로 설정
- 웹/기본 환경 API 주소를 `http://localhost:8080`으로 설정
- `EXPO_PUBLIC_API_BASE_URL` 환경변수로 API base URL 재정의 가능하도록 처리
- API base URL의 trailing slash 정규화 처리
- 백엔드 `ApiResponse<T>` 응답의 `{ data: ... }` 래핑 구조 공통 해제
- 직접 payload가 내려오는 경우도 fallback으로 처리
- 공통 `ApiError` 타입 추가
- 백엔드 에러 응답의 `message`, `code`, `errors`를 공통 에러 객체로 변환
- JSON 응답이 아니거나 빈 응답인 경우도 공통 요청 함수에서 처리
- `204 No Content` 응답 처리 추가
- 인증이 필요 없는 API 요청을 위한 `publicApiRequest` 추가
- 인증이 필요한 API 요청을 위한 `authenticatedApiRequest` 추가
- Clerk `getToken()` 결과를 검증하고 세션 토큰을 가져오는 `getClerkSessionToken` 추가
- 보호 API 요청 시 `Authorization: Bearer {token}` 헤더 자동 주입
- 기존 `/api/v1/auth/me` 회원 동기화 흐름을 공통 API 클라이언트 기반으로 변경
- 기존 약관 API를 공통 비인증 API 요청 구조로 변경

## 파일별 역할

- `api/api-client.ts`: API base URL 설정, 공통 요청 함수, 인증/비인증 요청 분리, Clerk 토큰 주입, `{ data }` 응답 래핑 해제, 공통 에러 처리
- `services/auth-api.ts`: 기존 `/api/v1/auth/me` 회원 동기화 API 호출 유지, 공통 API 클라이언트 기반으로 요청 방식 변경
- `api/terms.ts`: 약관 API의 자체 base URL/응답 파싱/에러 처리 로직을 제거하고 `publicApiRequest` 기반으로 변경

## 해결한 이슈 목록

- [x] 현재 Clerk 기반 Google 로그인 및 세션 유지 흐름 확인
- [x] 기존 `/api/v1/auth/me` 호출 위치와 역할 확인
- [x] `/auth/me`를 새 로그인 API가 아닌 기존 member 확인/동기화 흐름으로 유지
- [x] `/auth/me` 사전 호출에만 의존하지 않고 보호 API 요청마다 Clerk 토큰을 포함할 수 있는 구조로 정리
- [x] 기존 `services/auth-api.ts`의 역할과 유지해야 할 동작 확인
- [x] 기존 `api/terms.ts`의 base URL, 응답 파싱, 에러 처리 방식 확인
- [x] API base URL 설정 공통화
- [x] Clerk `getToken()`으로 받은 토큰을 보호 API 요청 헤더에 재사용 가능하게 주입
- [x] 인증이 필요한 API와 인증이 필요 없는 API 호출 방식 분리
- [x] 백엔드 `{ data: ... }` 응답 래퍼를 공통으로 처리
- [x] 공통 API 요청에서 성공 응답과 에러 응답을 일관되게 처리
- [x] 약관 API처럼 인증이 필요 없는 API가 공통 구조와 충돌 없이 동작하도록 정리
- [x] 이후 분석 요청, polling, 저장 링크 API 연동에서 재사용 가능한 구조 마련

## 체크 사항

- [x] 앱 로그인 후 `/api/v1/auth/me` 200 응답 확인
- [x] 백엔드 로그에서 `ApiResponse[data=MeResponse[publicId=...]]` 응답 확인
- [x] Docker DB에서 `member` 동기화 확인
- [x] 비인증 약관 API `GET /api/v1/terms/terms_of_service` 200 응답 확인
- [x] 약관 API 응답이 `{ data: ... }` 구조로 내려오는 것 확인

## 참고

이번 작업은 보호 API 요청 구조를 공통화하는 기반 작업입니다.

분석 요청 `POST /api/v1/analyses`, 분석 polling, 저장 링크 `POST /api/v1/saved-links`, 북마크/삭제 API 실제 화면 연동은 후속 작업에서 진행합니다.