### PR TITLE
[FEATURE] 링크 검사 분석 요청 및 polling 연동

### DIFF
--- a/api/analyses.ts
+++ b/api/analyses.ts
@@ -1,0 +1,57 @@
+import {
+  authenticatedApiRequest,
+  type ApiRequestOptions,
+  type ClerkTokenGetter,
+} from '@/api/api-client';
+
+export type AnalysisStatus = 'queued' | 'succeeded' | 'failed';
+export type AnalysisVerdict = 'safe' | 'caution' | 'danger';
+
+export type AnalysisReason = {
+  code: string;
+  stage: number;
+  weight: number;
+  message: string;
+};
+
+export type AnalysisResponse = {
+  analysisId: string;
+  status: AnalysisStatus;
+  originalUrl?: string;
+  finalUrl?: string;
+  verdict?: AnalysisVerdict;
+  score?: number;
+  summary?: string;
+  reasons?: AnalysisReason[];
+  analyzedAt?: string;
+  elapsedMs?: number;
+  errorCode?: string;
+  errorStage?: number;
+  errorMessage?: string;
+};
+
+type AnalysisRequestOptions = Pick<ApiRequestOptions, 'signal'>;
+
+export function requestAnalysis(
+  getToken: ClerkTokenGetter,
+  url: string,
+  options: AnalysisRequestOptions = {},
+) {
+  return authenticatedApiRequest<AnalysisResponse>(getToken, '/api/v1/analyses', {
+    ...options,
+    method: 'POST',
+    body: { url },
+  });
+}
+
+export function fetchAnalysis(
+  getToken: ClerkTokenGetter,
+  analysisId: string,
+  options: AnalysisRequestOptions = {},
+) {
+  return authenticatedApiRequest<AnalysisResponse>(
+    getToken,
+    `/api/v1/analyses/${encodeURIComponent(analysisId)}`,
+    options,
+  );
+}

--- a/app/(tabs)/(home)/scan-result-block.tsx
+++ b/app/(tabs)/(home)/scan-result-block.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
@@ -8,6 +9,7 @@ import { useAnalysisResult } from '@/hooks/use-analysis-result';
 import {
   getAnalysisDisplayUrl,
   getAnalysisReasonText,
+  getAnalysisResultPath,
   getRouteParam,
 } from '@/utils/analysis-result-display';
 
@@ -21,6 +23,44 @@ export default function ScanResultBlockScreen() {
   const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
   const displayUrl = getAnalysisDisplayUrl(analysis, url);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('danger'));
+  const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'danger');
+  const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
+
+  useEffect(() => {
+    if (!analysis?.verdict || analysis.verdict === 'danger') {
+      return;
+    }
+
+    router.replace({
+      pathname: getAnalysisResultPath(analysis.verdict),
+      params: {
+        url: analysis.originalUrl ?? url ?? '',
+        analysisId: analysis.analysisId,
+        verdict: analysis.verdict,
+      },
+    });
+  }, [analysis, url]);
+
+  if (isVerifyingAnalysis || shouldRedirectToVerdict) {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            headerShown: true,
+            title: '寃??寃곌낵',
+            headerBackTitle: '',
+            headerStyle: { backgroundColor: Colors.brand.background },
+            headerTitleStyle: { ...Typography.title, color: Colors.brand.text },
+            headerTintColor: Colors.brand.text,
+            headerShadowVisible: false,
+          }}
+        />
+        <View style={styles.loadingContainer}>
+          <Text style={styles.statusText}>遺꾩꽍 寃곌낵瑜?遺덈윭?ㅻ뒗 以묒엯?덈떎.</Text>
+        </View>
+      </>
+    );
+  }
 
   return (
     <>
@@ -114,6 +154,13 @@ const styles = StyleSheet.create({
     color: Colors.brand.textWarning,
     textAlign: 'center',
     marginBottom: 10,
+  },
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
   },
   card: {
     width: '100%',

--- a/app/(tabs)/(home)/scan-result-block.tsx
+++ b/app/(tabs)/(home)/scan-result-block.tsx
@@ -4,11 +4,23 @@ import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
 import { Colors, Typography } from '@/constants/theme';
+import { useAnalysisResult } from '@/hooks/use-analysis-result';
+import {
+  getAnalysisDisplayUrl,
+  getAnalysisReasonText,
+  getRouteParam,
+} from '@/utils/analysis-result-display';
 
 export default function ScanResultBlockScreen() {
-  const { url } = useLocalSearchParams<{ url: string }>();
-  // TODO: 테스트용 mock 판정 이유입니다. 백엔드 reason 응답 연동 시 제거합니다.
-  const reason = getMockScanResultReason('danger');
+  const {
+    analysisId: analysisIdParam,
+    url: urlParam,
+  } = useLocalSearchParams<{ analysisId?: string | string[]; url?: string | string[] }>();
+  const analysisId = getRouteParam(analysisIdParam);
+  const url = getRouteParam(urlParam);
+  const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
+  const displayUrl = getAnalysisDisplayUrl(analysis, url);
+  const reason = getAnalysisReasonText(analysis, getMockScanResultReason('danger'));
 
   return (
     <>
@@ -36,13 +48,16 @@ export default function ScanResultBlockScreen() {
         {/* 결과 텍스트 */}
         <Text style={styles.resultTitle}>차단된 위험 링크입니다.</Text>
 
+        {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
+        {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+
         <ScanResultReason reason={reason} style={styles.reasonCard} />
 
         {/* 검사 대상 카드 */}
         <View style={styles.card}>
           <Text style={styles.cardLabel}>검사 대상</Text>
           <Text style={styles.cardUrl} numberOfLines={1} ellipsizeMode="tail">
-            {url}
+            {displayUrl}
           </Text>
         </View>
 
@@ -87,6 +102,18 @@ const styles = StyleSheet.create({
   },
   reasonCard: {
     marginBottom: 24,
+  },
+  statusText: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+  errorText: {
+    ...Typography.caption,
+    color: Colors.brand.textWarning,
+    textAlign: 'center',
+    marginBottom: 10,
   },
   card: {
     width: '100%',

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
@@ -12,6 +12,7 @@ import {
   getAnalysisDisplayUrl,
   getAnalysisFinalUrl,
   getAnalysisReasonText,
+  getAnalysisResultPath,
   getRouteParam,
   getSiteName,
 } from '@/utils/analysis-result-display';
@@ -29,6 +30,23 @@ export default function ScanResultCautionScreen() {
   const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('caution'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
+  const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'caution');
+  const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
+
+  useEffect(() => {
+    if (!analysis?.verdict || analysis.verdict === 'caution') {
+      return;
+    }
+
+    router.replace({
+      pathname: getAnalysisResultPath(analysis.verdict),
+      params: {
+        url: analysis.originalUrl ?? url ?? '',
+        analysisId: analysis.analysisId,
+        verdict: analysis.verdict,
+      },
+    });
+  }, [analysis, url]);
 
   const handleSave = (title: string) => {
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
@@ -58,6 +76,27 @@ export default function ScanResultCautionScreen() {
       }
     }
   };
+
+  if (isVerifyingAnalysis || shouldRedirectToVerdict) {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            headerShown: true,
+            title: '寃??寃곌낵',
+            headerBackTitle: '',
+            headerStyle: { backgroundColor: Colors.brand.background },
+            headerTitleStyle: { ...Typography.title, color: Colors.brand.text },
+            headerTintColor: Colors.brand.text,
+            headerShadowVisible: false,
+          }}
+        />
+        <View style={styles.loadingContainer}>
+          <Text style={styles.statusText}>遺꾩꽍 寃곌낵瑜?遺덈윭?ㅻ뒗 以묒엯?덈떎.</Text>
+        </View>
+      </>
+    );
+  }
 
   return (
     <>
@@ -158,6 +197,13 @@ const styles = StyleSheet.create({
     color: Colors.brand.textWarning,
     textAlign: 'center',
     marginBottom: 10,
+  },
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
   },
   card: {
     width: '100%',

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -7,29 +7,41 @@ import { getMockScanResultReason } from '@/constants/scan-result-reasons';
 import { Colors, Typography } from '@/constants/theme';
 import { useSavedLinks } from '@/context/saved-links-context';
 import { LinkSaveModal } from '@/components/ui/link-save-modal';
+import { useAnalysisResult } from '@/hooks/use-analysis-result';
+import {
+  getAnalysisDisplayUrl,
+  getAnalysisFinalUrl,
+  getAnalysisReasonText,
+  getRouteParam,
+  getSiteName,
+} from '@/utils/analysis-result-display';
 
 export default function ScanResultCautionScreen() {
-  const { url } = useLocalSearchParams<{ url: string }>();
+  const {
+    analysisId: analysisIdParam,
+    url: urlParam,
+  } = useLocalSearchParams<{ analysisId?: string | string[]; url?: string | string[] }>();
   const { addLink } = useSavedLinks();
-  // TODO: 테스트용 mock 판정 이유입니다. 백엔드 reason 응답 연동 시 제거합니다.
-  const reason = getMockScanResultReason('caution');
+  const analysisId = getRouteParam(analysisIdParam);
+  const url = getRouteParam(urlParam);
+  const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
+  const displayUrl = getAnalysisDisplayUrl(analysis, url);
+  const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
+  const reason = getAnalysisReasonText(analysis, getMockScanResultReason('caution'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
 
   const handleSave = (title: string) => {
-    const resolvedUrl = url ?? '';
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
     addLink({
       id: Date.now(),
-      analysisId: `mock-${Date.now()}`,
+      analysisId: analysis?.analysisId ?? analysisId ?? `mock-${Date.now()}`,
       categoryId: null,
-      originalUrl: resolvedUrl,
-      finalUrl: resolvedUrl || null,
+      originalUrl: displayUrl,
+      finalUrl: finalUrl || null,
       title,
-      description: '저장된 링크입니다.',
-      siteName: (() => {
-        try { return new URL(resolvedUrl).hostname; } catch { return '알 수 없음'; }
-      })(),
-      verdict: 'caution',
+      description: analysis?.summary ?? '저장된 링크입니다.',
+      siteName: getSiteName(finalUrl || displayUrl),
+      verdict: analysis?.verdict ?? 'caution',
       isBookmarked: false,
       createdAt: new Date().toISOString(),
     });
@@ -38,9 +50,9 @@ export default function ScanResultCautionScreen() {
   };
 
   const handleOpenUrl = async () => {
-    if (url) {
+    if (finalUrl) {
       try {
-        await Linking.openURL(url);
+        await Linking.openURL(finalUrl);
       } catch {
         // URL을 열 수 없는 경우 무시
       }
@@ -73,13 +85,16 @@ export default function ScanResultCautionScreen() {
         {/* 결과 텍스트 */}
         <Text style={styles.resultTitle}>주의가 필요한 링크입니다.</Text>
 
+        {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
+        {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+
         <ScanResultReason reason={reason} style={styles.reasonCard} />
 
         {/* 검사 대상 카드 */}
         <View style={styles.card}>
           <Text style={styles.cardLabel}>검사 대상</Text>
           <Text style={styles.cardUrl} numberOfLines={1} ellipsizeMode="tail">
-            {url}
+            {displayUrl}
           </Text>
         </View>
 
@@ -97,7 +112,7 @@ export default function ScanResultCautionScreen() {
 
       <LinkSaveModal
         visible={saveModalVisible}
-        url={url ?? ''}
+        url={displayUrl}
         onCancel={() => setSaveModalVisible(false)}
         onSave={handleSave}
       />
@@ -131,6 +146,18 @@ const styles = StyleSheet.create({
   },
   reasonCard: {
     marginBottom: 24,
+  },
+  statusText: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+  errorText: {
+    ...Typography.caption,
+    color: Colors.brand.textWarning,
+    textAlign: 'center',
+    marginBottom: 10,
   },
   card: {
     width: '100%',

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -32,6 +32,7 @@ export default function ScanResultCautionScreen() {
   const [saveModalVisible, setSaveModalVisible] = useState(false);
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'caution');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
+  const canSave = displayUrl.trim().length > 0 && !isLoading && !shouldRedirectToVerdict;
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'caution') {
@@ -49,6 +50,10 @@ export default function ScanResultCautionScreen() {
   }, [analysis, url]);
 
   const handleSave = (title: string) => {
+    if (!canSave) {
+      return;
+    }
+
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
     addLink({
       id: Date.now(),
@@ -139,7 +144,12 @@ export default function ScanResultCautionScreen() {
 
         {/* 버튼 영역 */}
         <View style={styles.buttonArea}>
-          <TouchableOpacity style={styles.cautionButton} onPress={() => setSaveModalVisible(true)} activeOpacity={0.8}>
+          <TouchableOpacity
+            style={[styles.cautionButton, !canSave && styles.disabledButton]}
+            onPress={() => setSaveModalVisible(true)}
+            activeOpacity={0.8}
+            disabled={!canSave}
+          >
             <Text style={styles.cautionButtonText}>주의 후 저장</Text>
           </TouchableOpacity>
 
@@ -237,6 +247,9 @@ const styles = StyleSheet.create({
   cautionButtonText: {
     ...Typography.section,
     color: Colors.brand.text,
+  },
+  disabledButton: {
+    opacity: 0.45,
   },
   secondaryButton: {
     width: '100%',

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -7,6 +7,14 @@ import { getMockScanResultReason } from '@/constants/scan-result-reasons';
 import { Colors, Typography } from '@/constants/theme';
 import { useSavedLinks } from '@/context/saved-links-context';
 import { LinkSaveModal } from '@/components/ui/link-save-modal';
+import { useAnalysisResult } from '@/hooks/use-analysis-result';
+import {
+  getAnalysisDisplayUrl,
+  getAnalysisFinalUrl,
+  getAnalysisReasonText,
+  getRouteParam,
+  getSiteName,
+} from '@/utils/analysis-result-display';
 
 // TODO: 백엔드 연동 시 아래 흐름으로 교체
 // 1. scanning.tsx에서 POST /api/v1/analyses → analysisId 수신 후 params로 전달
@@ -16,28 +24,32 @@ import { LinkSaveModal } from '@/components/ui/link-save-modal';
 // API 명세: Draft of the specification.md > 4.1 링크 저장 참고
 
 export default function ScanResultScreen() {
-  const { url } = useLocalSearchParams<{ url: string }>();
+  const {
+    analysisId: analysisIdParam,
+    url: urlParam,
+  } = useLocalSearchParams<{ analysisId?: string | string[]; url?: string | string[] }>();
   const { addLink } = useSavedLinks();
-  // TODO: 테스트용 mock 판정 이유입니다. 백엔드 reason 응답 연동 시 제거합니다.
-  const reason = getMockScanResultReason('safe');
+  const analysisId = getRouteParam(analysisIdParam);
+  const url = getRouteParam(urlParam);
+  const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
+  const displayUrl = getAnalysisDisplayUrl(analysis, url);
+  const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
+  const reason = getAnalysisReasonText(analysis, getMockScanResultReason('safe'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
 
   const handleSave = (title: string) => {
-    const resolvedUrl = url ?? '';
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
     // 현재는 URL 기반 mock 데이터로 즉시 추가
     addLink({
       id: Date.now(),
-      analysisId: `mock-${Date.now()}`,
+      analysisId: analysis?.analysisId ?? analysisId ?? `mock-${Date.now()}`,
       categoryId: null,
-      originalUrl: resolvedUrl,
-      finalUrl: resolvedUrl || null,
+      originalUrl: displayUrl,
+      finalUrl: finalUrl || null,
       title,
-      description: '저장된 링크입니다.',
-      siteName: (() => {
-        try { return new URL(resolvedUrl).hostname; } catch { return '알 수 없음'; }
-      })(),
-      verdict: 'safe',
+      description: analysis?.summary ?? '저장된 링크입니다.',
+      siteName: getSiteName(finalUrl || displayUrl),
+      verdict: analysis?.verdict ?? 'safe',
       isBookmarked: false,
       createdAt: new Date().toISOString(),
     });
@@ -46,9 +58,9 @@ export default function ScanResultScreen() {
   };
 
   const handleOpenUrl = async () => {
-    if (url) {
+    if (finalUrl) {
       try {
-        await Linking.openURL(url);
+        await Linking.openURL(finalUrl);
       } catch {
         // URL을 열 수 없는 경우 무시
       }
@@ -81,13 +93,16 @@ export default function ScanResultScreen() {
         {/* 결과 텍스트 */}
         <Text style={styles.resultTitle}>안전한 웹사이트입니다.</Text>
 
+        {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
+        {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+
         <ScanResultReason reason={reason} style={styles.reasonCard} />
 
         {/* 검사 대상 카드 */}
         <View style={styles.card}>
           <Text style={styles.cardLabel}>검사 대상</Text>
           <Text style={styles.cardUrl} numberOfLines={1} ellipsizeMode="tail">
-            {url}
+            {displayUrl}
           </Text>
         </View>
 
@@ -105,7 +120,7 @@ export default function ScanResultScreen() {
 
       <LinkSaveModal
         visible={saveModalVisible}
-        url={url ?? ''}
+        url={displayUrl}
         onCancel={() => setSaveModalVisible(false)}
         onSave={handleSave}
       />
@@ -141,6 +156,18 @@ const styles = StyleSheet.create({
   },
   reasonCard: {
     marginBottom: 24,
+  },
+  statusText: {
+    ...Typography.caption,
+    color: Colors.brand.textSecondary,
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+  errorText: {
+    ...Typography.caption,
+    color: Colors.brand.textWarning,
+    textAlign: 'center',
+    marginBottom: 10,
   },
   // 검사 대상 카드
   card: {

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
@@ -12,6 +12,7 @@ import {
   getAnalysisDisplayUrl,
   getAnalysisFinalUrl,
   getAnalysisReasonText,
+  getAnalysisResultPath,
   getRouteParam,
   getSiteName,
 } from '@/utils/analysis-result-display';
@@ -36,6 +37,23 @@ export default function ScanResultScreen() {
   const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('safe'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
+  const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'safe');
+  const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
+
+  useEffect(() => {
+    if (!analysis?.verdict || analysis.verdict === 'safe') {
+      return;
+    }
+
+    router.replace({
+      pathname: getAnalysisResultPath(analysis.verdict),
+      params: {
+        url: analysis.originalUrl ?? url ?? '',
+        analysisId: analysis.analysisId,
+        verdict: analysis.verdict,
+      },
+    });
+  }, [analysis, url]);
 
   const handleSave = (title: string) => {
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
@@ -66,6 +84,27 @@ export default function ScanResultScreen() {
       }
     }
   };
+
+  if (isVerifyingAnalysis || shouldRedirectToVerdict) {
+    return (
+      <>
+        <Stack.Screen
+          options={{
+            headerShown: true,
+            title: '寃??寃곌낵',
+            headerBackTitle: '',
+            headerStyle: { backgroundColor: Colors.brand.background },
+            headerTitleStyle: { ...Typography.title, color: Colors.brand.text },
+            headerTintColor: Colors.brand.text,
+            headerShadowVisible: false,
+          }}
+        />
+        <View style={styles.loadingContainer}>
+          <Text style={styles.statusText}>遺꾩꽍 寃곌낵瑜?遺덈윭?ㅻ뒗 以묒엯?덈떎.</Text>
+        </View>
+      </>
+    );
+  }
 
   return (
     <>
@@ -170,6 +209,13 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   // 검사 대상 카드
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: Colors.brand.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
   card: {
     width: '100%',
     backgroundColor: Colors.brand.surface,

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -39,6 +39,7 @@ export default function ScanResultScreen() {
   const [saveModalVisible, setSaveModalVisible] = useState(false);
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'safe');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
+  const canSave = displayUrl.trim().length > 0 && !isLoading && !shouldRedirectToVerdict;
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'safe') {
@@ -56,6 +57,10 @@ export default function ScanResultScreen() {
   }, [analysis, url]);
 
   const handleSave = (title: string) => {
+    if (!canSave) {
+      return;
+    }
+
     // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
     // 현재는 URL 기반 mock 데이터로 즉시 추가
     addLink({
@@ -147,7 +152,12 @@ export default function ScanResultScreen() {
 
         {/* 버튼 영역 */}
         <View style={styles.buttonArea}>
-          <TouchableOpacity style={styles.primaryButton} onPress={() => setSaveModalVisible(true)} activeOpacity={0.8}>
+          <TouchableOpacity
+            style={[styles.primaryButton, !canSave && styles.disabledButton]}
+            onPress={() => setSaveModalVisible(true)}
+            activeOpacity={0.8}
+            disabled={!canSave}
+          >
             <Text style={styles.primaryButtonText}>저장</Text>
           </TouchableOpacity>
 
@@ -249,6 +259,9 @@ const styles = StyleSheet.create({
   primaryButtonText: {
     ...Typography.section,
     color: Colors.brand.onPrimary,
+  },
+  disabledButton: {
+    opacity: 0.45,
   },
   secondaryButton: {
     width: '100%',

--- a/app/(tabs)/(home)/scanning.tsx
+++ b/app/(tabs)/(home)/scanning.tsx
@@ -1,29 +1,93 @@
+import { useAuth } from '@clerk/expo';
 import LottieView from 'lottie-react-native';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { useEffect } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { fetchAnalysis, requestAnalysis, type AnalysisResponse, type AnalysisVerdict } from '@/api/analyses';
+import { ApiError } from '@/api/api-client';
 import { Colors, Typography } from '@/constants/theme';
 
-// TODO: 백엔드 연동 시 POST /api/v1/analyses 호출 후 폴링으로 결과 확인
-// Request: { original_url }
-// Response: { analysis_id, status, verdict, score, summary }
-// verdict: 'safe' → scan-result(allowed), 'caution'/'danger' → 별도 결과 화면
-// API 명세: Draft of the specification.md > POST /analyses, GET /analyses/{analysisId} 참고
+const POLLING_INTERVAL_MS = 2_000;
+const MAX_POLLING_MS = 30_000;
 
 export default function ScanningScreen() {
-  const { url } = useLocalSearchParams<{ url: string }>();
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+  const { url: urlParam } = useLocalSearchParams<{ url?: string | string[] }>();
+  const url = getUrlParam(urlParam);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [retryKey, setRetryKey] = useState(0);
+  const getTokenRef = useRef(getToken);
 
   useEffect(() => {
-    // TODO: 실제 백엔드 분석 요청으로 교체
-    // verdict에 따라 화면 분기:
-    //   safe    → '/(tabs)/(home)/scan-result'
-    //   caution → '/(tabs)/(home)/scan-result-caution'
-    //   block   → '/(tabs)/(home)/scan-result-block'
-    const timer = setTimeout(() => {
-      router.replace({ pathname: '/(tabs)/(home)/scan-result-block', params: { url } });
-    }, 3000);
-    return () => clearTimeout(timer);
-  }, [url]);
+    getTokenRef.current = getToken;
+  }, [getToken]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let timedOut = false;
+
+    if (!isLoaded) {
+      return () => abortController.abort();
+    }
+
+    if (!isSignedIn) {
+      setErrorMessage('로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.');
+      return () => abortController.abort();
+    }
+
+    if (!url) {
+      setErrorMessage('검사할 URL을 찾을 수 없습니다. 링크를 다시 입력해주세요.');
+      return () => abortController.abort();
+    }
+
+    setErrorMessage('');
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        timedOut = true;
+        abortController.abort();
+        reject(new Error('TIMEOUT'));
+      }, MAX_POLLING_MS);
+    });
+
+    Promise.race([
+      runAnalysisPolling({
+        getToken: () => getTokenRef.current(),
+        url,
+        signal: abortController.signal,
+      }),
+      timeoutPromise,
+    ])
+      .catch((error) => {
+        if (timedOut) {
+          setErrorMessage(getAnalysisErrorMessage(new Error('TIMEOUT')));
+          return;
+        }
+
+        if (isAbortError(error)) {
+          return;
+        }
+
+        setErrorMessage(getAnalysisErrorMessage(error));
+      })
+      .finally(() => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      });
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      abortController.abort();
+    };
+  }, [isLoaded, isSignedIn, retryKey, url]);
+
+  const hasError = errorMessage.length > 0;
 
   return (
     <>
@@ -43,8 +107,8 @@ export default function ScanningScreen() {
         <View style={styles.animationWrapper}>
           <LottieView
             source={require('@/assets/animations/scanning.json')}
-            autoPlay
-            loop
+            autoPlay={!hasError}
+            loop={!hasError}
             style={styles.animation}
           />
           <View style={styles.dotsOverlay}>
@@ -55,8 +119,12 @@ export default function ScanningScreen() {
         </View>
 
         {/* 텍스트 */}
-        <Text style={styles.title}>보안 검사 중입니다</Text>
-        <Text style={styles.subtitle}>약 5–10초 정도 소요돼요</Text>
+        <Text style={styles.title}>
+          {hasError ? '검사를 완료하지 못했어요' : '보안 검사 중입니다'}
+        </Text>
+        <Text style={[styles.subtitle, hasError && styles.errorText]}>
+          {hasError ? errorMessage : '약 5-10초 정도 소요돼요'}
+        </Text>
 
         {/* 검사 대상 카드 */}
         <View style={styles.card}>
@@ -65,9 +133,161 @@ export default function ScanningScreen() {
             {url}
           </Text>
         </View>
+
+        {hasError && (
+          <View style={styles.buttonArea}>
+            <TouchableOpacity
+              style={styles.primaryButton}
+              onPress={() => setRetryKey((key) => key + 1)}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.primaryButtonText}>다시 검사</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.secondaryButton}
+              onPress={() => router.back()}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.secondaryButtonText}>돌아가기</Text>
+            </TouchableOpacity>
+          </View>
+        )}
       </View>
     </>
   );
+}
+
+async function runAnalysisPolling({
+  getToken,
+  url,
+  signal,
+}: {
+  getToken: () => Promise<string | null>;
+  url: string;
+  signal: AbortSignal;
+}) {
+  const deadline = Date.now() + MAX_POLLING_MS;
+  let analysis = await requestAnalysis(getToken, url, { signal });
+
+  while (!signal.aborted) {
+    const handled = handleAnalysisResult(analysis, url, signal);
+
+    if (handled) {
+      return;
+    }
+
+    const remainingMs = deadline - Date.now();
+
+    if (remainingMs <= 0) {
+      throw new Error('TIMEOUT');
+    }
+
+    await wait(Math.min(POLLING_INTERVAL_MS, remainingMs), signal);
+    analysis = await fetchAnalysis(getToken, analysis.analysisId, { signal });
+  }
+}
+
+function handleAnalysisResult(analysis: AnalysisResponse, fallbackUrl: string, signal: AbortSignal) {
+  if (analysis.status === 'queued') {
+    return false;
+  }
+
+  if (analysis.status === 'failed') {
+    throw new Error(analysis.errorMessage || 'ANALYSIS_FAILED');
+  }
+
+  if (!analysis.verdict) {
+    throw new Error('MISSING_VERDICT');
+  }
+
+  if (!signal.aborted) {
+    router.replace({
+      pathname: getResultPath(analysis.verdict),
+      params: {
+        url: analysis.originalUrl ?? fallbackUrl,
+        analysisId: analysis.analysisId,
+        verdict: analysis.verdict,
+      },
+    });
+  }
+
+  return true;
+}
+
+function getResultPath(verdict: AnalysisVerdict) {
+  switch (verdict) {
+    case 'safe':
+      return '/(tabs)/(home)/scan-result';
+    case 'caution':
+      return '/(tabs)/(home)/scan-result-caution';
+    case 'danger':
+      return '/(tabs)/(home)/scan-result-block';
+  }
+}
+
+function wait(ms: number, signal: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const handleAbort = () => {
+      clearTimeout(timer);
+      reject(createAbortError());
+    };
+
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', handleAbort);
+      resolve();
+    }, ms);
+
+    signal.addEventListener('abort', handleAbort, { once: true });
+  });
+}
+
+function createAbortError() {
+  const error = new Error('Analysis polling aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function isAbortError(error: unknown) {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}
+
+function getAnalysisErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+    }
+
+    return error.message || '링크 검사 요청에 실패했습니다. 잠시 후 다시 시도해주세요.';
+  }
+
+  if (error instanceof Error) {
+    if (error.message === 'Missing Clerk session token') {
+      return '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+    }
+
+    if (error.message === 'TIMEOUT') {
+      return '분석 결과를 기다리는 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.';
+    }
+
+    if (error.message === 'MISSING_VERDICT') {
+      return '분석 결과를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.';
+    }
+
+    if (error.message && error.message !== 'ANALYSIS_FAILED') {
+      return error.message;
+    }
+  }
+
+  return '링크 검사에 실패했습니다. 잠시 후 다시 시도해주세요.';
+}
+
+function getUrlParam(value: string | string[] | undefined) {
+  return typeof value === 'string' ? value : '';
 }
 
 const styles = StyleSheet.create({
@@ -120,6 +340,7 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     padding: 16,
     gap: 6,
+    marginBottom: 24,
   },
   cardLabel: {
     ...Typography.caption,
@@ -128,6 +349,39 @@ const styles = StyleSheet.create({
   cardUrl: {
     ...Typography.body,
     fontWeight: '700',
+    color: Colors.brand.text,
+  },
+  errorText: {
+    color: Colors.brand.textWarning,
+  },
+  buttonArea: {
+    width: '100%',
+    gap: 12,
+  },
+  primaryButton: {
+    width: '100%',
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: Colors.brand.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButtonText: {
+    ...Typography.section,
+    color: Colors.brand.onPrimary,
+  },
+  secondaryButton: {
+    width: '100%',
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: Colors.brand.surface,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonText: {
+    ...Typography.section,
     color: Colors.brand.text,
   },
 });

--- a/hooks/use-analysis-result.ts
+++ b/hooks/use-analysis-result.ts
@@ -1,0 +1,127 @@
+import { useAuth } from '@clerk/expo';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { fetchAnalysis, type AnalysisResponse } from '@/api/analyses';
+import { ApiError } from '@/api/api-client';
+
+const LOGIN_REQUIRED_MESSAGE =
+  '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+
+export function useAnalysisResult(analysisId?: string) {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+  const [analysis, setAnalysis] = useState<AnalysisResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const getTokenRef = useRef(getToken);
+
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
+
+  const loadAnalysis = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!analysisId) {
+        setAnalysis(null);
+        setIsLoading(false);
+        setErrorMessage('');
+        return;
+      }
+
+      if (!isLoaded) {
+        return;
+      }
+
+      if (!isSignedIn) {
+        setAnalysis(null);
+        setIsLoading(false);
+        setErrorMessage(LOGIN_REQUIRED_MESSAGE);
+        return;
+      }
+
+      setAnalysis(null);
+      setIsLoading(true);
+      setErrorMessage('');
+
+      try {
+        const nextAnalysis = await fetchAnalysis(
+          () => getTokenRef.current(),
+          analysisId,
+          { signal },
+        );
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        setAnalysis(nextAnalysis);
+      } catch (error) {
+        if (signal?.aborted) {
+          return;
+        }
+
+        if (isAbortError(error)) {
+          return;
+        }
+
+        setErrorMessage(getAnalysisResultErrorMessage(error));
+      } finally {
+        if (!signal?.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [analysisId, isLoaded, isSignedIn],
+  );
+
+  useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!analysisId) {
+      setAnalysis(null);
+      setIsLoading(false);
+      setErrorMessage('');
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    void loadAnalysis(abortController.signal);
+
+    return () => abortController.abort();
+  }, [analysisId, isLoaded, loadAnalysis]);
+
+  return {
+    analysis,
+    isLoading,
+    errorMessage,
+    refetch: loadAnalysis,
+  };
+}
+
+function getAnalysisResultErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return LOGIN_REQUIRED_MESSAGE;
+    }
+
+    return error.message || '분석 결과를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.';
+  }
+
+  if (error instanceof Error) {
+    if (error.message === 'Missing Clerk session token') {
+      return LOGIN_REQUIRED_MESSAGE;
+    }
+
+    if (error.message) {
+      return error.message;
+    }
+  }
+
+  return '분석 결과를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.';
+}
+
+function isAbortError(error: unknown) {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}

--- a/utils/analysis-result-display.ts
+++ b/utils/analysis-result-display.ts
@@ -1,0 +1,43 @@
+import type { AnalysisResponse } from '@/api/analyses';
+
+export function getRouteParam(value: string | string[] | undefined) {
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function getAnalysisDisplayUrl(analysis: AnalysisResponse | null, fallbackUrl?: string) {
+  return analysis?.originalUrl ?? fallbackUrl ?? '';
+}
+
+export function getAnalysisFinalUrl(analysis: AnalysisResponse | null, fallbackUrl: string) {
+  return analysis?.finalUrl ?? fallbackUrl;
+}
+
+export function getAnalysisReasonText(
+  analysis: AnalysisResponse | null,
+  fallbackReason: string,
+) {
+  const summary = analysis?.summary?.trim();
+
+  if (summary) {
+    return summary;
+  }
+
+  const reasonMessages =
+    analysis?.reasons
+      ?.map((reason) => reason.message.trim())
+      .filter((message) => message.length > 0) ?? [];
+
+  if (reasonMessages.length > 0) {
+    return reasonMessages.join('\n');
+  }
+
+  return fallbackReason;
+}
+
+export function getSiteName(url: string) {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return '정보 없음';
+  }
+}

--- a/utils/analysis-result-display.ts
+++ b/utils/analysis-result-display.ts
@@ -1,4 +1,4 @@
-import type { AnalysisResponse } from '@/api/analyses';
+import type { AnalysisResponse, AnalysisVerdict } from '@/api/analyses';
 
 export function getRouteParam(value: string | string[] | undefined) {
   return typeof value === 'string' ? value : undefined;
@@ -32,6 +32,17 @@ export function getAnalysisReasonText(
   }
 
   return fallbackReason;
+}
+
+export function getAnalysisResultPath(verdict: AnalysisVerdict) {
+  switch (verdict) {
+    case 'safe':
+      return '/(tabs)/(home)/scan-result';
+    case 'caution':
+      return '/(tabs)/(home)/scan-result-caution';
+    case 'danger':
+      return '/(tabs)/(home)/scan-result-block';
+  }
 }
 
 export function getSiteName(url: string) {


### PR DESCRIPTION
Closes #43

## 개요
링크 검사 중 화면에서 기존 mock 타이머 기반 이동 흐름을 실제 백엔드 분석 API 연동 흐름으로 교체했습니다.

기존에는 `scanning.tsx`에서 일정 시간이 지나면 mock 결과 화면으로 이동했지만, 이번 작업에서는 `POST /api/v1/analyses`로 분석을 요청하고, 응답으로 받은 `analysisId`를 기준으로 `GET /api/v1/analyses/{analysisId}`를 polling하여 실제 분석 상태를 확인하도록 구현했습니다.

분석이 완료되면 백엔드 응답의 `verdict` 값에 따라 안전, 주의, 위험 결과 화면으로 이동합니다. 결과 화면으로는 `AnalysisResponse` 전체 객체를 넘기지 않고 `analysisId`, `url`, `verdict`만 전달하며, 각 결과 화면에서 `analysisId`를 기준으로 분석 결과를 다시 조회해 화면 표시용 `AnalysisResponse`를 확보하도록 구성했습니다.

이 구조를 통해 route params를 작고 안정적으로 유지하면서도, 결과 화면 직접 진입이나 앱 상태 유실 상황에서도 `analysisId`만 있으면 분석 결과를 다시 확보할 수 있도록 했습니다.

## 주요 구현 내용
- `POST /api/v1/analyses` 분석 요청 API 연동
- Clerk `getToken()` 기반 보호 API 호출 구조 적용
- `GET /api/v1/analyses/{analysisId}` polling 구현
- polling 간격 2초 적용
- 최대 polling 대기 시간 30초 적용
- `queued` 상태에서는 polling 유지
- `failed` 상태 또는 API 에러 발생 시 사용자 안내 메시지 표시
- `succeeded` 상태에서 `verdict` 값에 따라 결과 화면 분기
- `safe` 결과는 `scan-result` 화면으로 이동
- `caution` 결과는 `scan-result-caution` 화면으로 이동
- `danger` 결과는 `scan-result-block` 화면으로 이동
- 컴포넌트 unmount 시 polling timer/request 정리
- 결과 화면 이동 시 `AnalysisResponse` 전체 객체 대신 `analysisId`, `url`, `verdict`만 전달
- 결과 화면 공통 분석 결과 조회 hook 추가
- 결과 화면 3개에서 `analysisId` 기준 `AnalysisResponse` 조회
- 분석 결과 조회 중/실패 상태에 대한 UI 메시지 표시
- `summary -> reasons -> mock reason` 순서로 판정 이유 표시
- `analysis?.originalUrl ?? url ?? ''` 기준으로 표시 URL 정리
- `analysis?.finalUrl`을 즉시 URL 접속 및 mock 저장 데이터에 반영
- safe/caution mock 저장 흐름에서 실제 `analysisId`를 우선 사용
- `POST /saved-links` 실제 저장 API 연동은 다음 작업으로 분리

## 파일별 역할
- `api/analyses.ts`: 분석 요청/조회 API 타입 및 호출 함수 추가
- `app/(tabs)/(home)/scanning.tsx`: 분석 요청, polling, 상태별 에러 처리, 결과 화면 분기 처리
- `hooks/use-analysis-result.ts`: 결과 화면에서 `analysisId` 기준으로 분석 결과를 조회하는 공통 hook 추가
- `utils/analysis-result-display.ts`: route param, 표시 URL, 최종 URL, 판정 이유, 사이트명 표시 유틸 추가
- `app/(tabs)/(home)/scan-result.tsx`: 안전 결과 화면에서 `analysisId` 수신 및 분석 결과 조회 반영
- `app/(tabs)/(home)/scan-result-caution.tsx`: 주의 결과 화면에서 `analysisId` 수신 및 분석 결과 조회 반영
- `app/(tabs)/(home)/scan-result-block.tsx`: 위험 결과 화면에서 `analysisId` 수신 및 분석 결과 조회 반영

## 해결한 이슈 목록
- [x] `scanning.tsx`의 mock 타이머 기반 결과 이동 흐름을 실제 분석 API 흐름으로 교체
- [x] 분석 요청 시 Clerk 인증 토큰 기반 보호 API 호출 적용
- [x] 분석 요청 성공 후 `analysisId` 기준 polling 수행
- [x] polling 중 `queued` 상태 처리
- [x] 분석 성공 시 `verdict`에 따라 안전/주의/위험 결과 화면으로 이동
- [x] 분석 실패 또는 API 에러 발생 시 사용자 안내 표시
- [x] unmount 시 timer/request 정리
- [x] 결과 화면으로 `analysisId`, `url`, `verdict` 전달
- [x] `AnalysisResponse` 전체 객체를 route params로 전달하지 않도록 처리
- [x] 결과 화면 3개에서 `analysisId` route param 수신
- [x] 결과 화면 3개에서 `fetchAnalysis()` 기반 분석 결과 조회
- [x] 결과 화면에서 조회 실패 시에도 기본 UI가 깨지지 않도록 fallback 처리
- [x] 백엔드 `summary` 또는 `reasons` 기반 판정 이유 표시
- [x] safe/caution mock 저장 데이터에 실제 `analysisId` 우선 반영
- [x] 저장 API 연동은 이번 PR 범위에서 제외

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 프론트 API 클라이언트 사용 규칙 준수
- [x] 결과 화면/hook에서 직접 `fetch()`를 호출하지 않음
- [x] 결과 화면/hook에서 직접 API base URL을 만들지 않음
- [x] 결과 화면/hook에서 직접 `Authorization` 헤더를 붙이지 않음
- [x] 결과 화면/hook에서 `{ data: ... }` 응답을 직접 unwrap하지 않음
- [x] 보호 API는 `authenticatedApiRequest()` 기반 `fetchAnalysis()`를 통해 호출
- [x] `/auth/me`를 수동 선호출하는 흐름을 만들지 않음
- [x] `AnalysisResponse` 전체 객체를 `JSON.stringify`해서 route params로 넘기지 않음
- [x] `POST /api/v1/saved-links` 저장 API 연동은 이번 작업에 포함하지 않음

## 검증
- [x] Swagger 기준 `GET /api/v1/analyses/{analysisId}` 응답이 `ApiResponseAnalysisResponse -> AnalysisResponse` 구조임을 확인
- [x] FastAPI 분석 엔진 health 응답 확인

## 참고
이번 PR에서는 분석 결과 화면의 저장 버튼이 아직 실제 `POST /api/v1/saved-links`를 호출하지 않습니다.

safe/caution 결과 화면의 저장 흐름은 기존 mock `addLink` 기반으로 유지하되, 이후 저장 API 연동 작업에서 바로 사용할 수 있도록 실제 `analysisId`를 우선 반영하도록 정리했습니다.

결과 화면은 앱 내부 이동 직후에도 `analysisId` 기준으로 분석 결과를 조회합니다. 따라서 polling 중 이미 받은 `AnalysisResponse`를 route params로 직접 전달하지 않고, 결과 화면에서 필요한 시점에 다시 조회하는 구조입니다.

## Screenshots or Video

- 요청 후 검사 결과가 DB에 잘 들어온 것을 확인할 수 있습니다.
<img width="1244" height="186" alt="image" src="https://github.com/user-attachments/assets/5c0348c8-4f3e-4cdd-8b81-10449236ab3f" />

- 앱에서는 받은 정보 그대로 "현재 기준으로 안전한 링크로 판단됩니다."를 띄웁니다. 
<img width="492" height="1017" alt="image" src="https://github.com/user-attachments/assets/f2d11734-8e16-4230-8070-478a44b9540e" />

- 연결 오류 등 문제가 있을때 뜨는 화면입니다.
<img width="500" height="1022" alt="image" src="https://github.com/user-attachments/assets/e33f1a9b-19fd-46a5-96f8-fd4f3e912689" />

- 최대 대기시간인 30초를 지나면 뜨는 화면입니다.
<img width="495" height="1017" alt="image" src="https://github.com/user-attachments/assets/ed89c73e-0b16-4e93-abce-8cdf0236698f" />
