### PR TITLE
[FEATURE] 저장 링크 API 연동 및 제목 수정 기능 적용

### DIFF
--- a/api/saved-links.ts
+++ b/api/saved-links.ts
@@ -133,7 +133,7 @@ function buildSavedLinkQuery(query: SavedLinkListQuery) {
     params.set('bookmarked', String(query.bookmarked));
   }
 
-  if (query.cursor) {
+  if (query.cursor != null) {
     params.set('cursor', query.cursor);
   }
 

--- a/api/saved-links.ts
+++ b/api/saved-links.ts
@@ -1,0 +1,146 @@
+import {
+  authenticatedApiRequest,
+  type ApiRequestOptions,
+  type ClerkTokenGetter,
+} from '@/api/api-client';
+
+export type SavedLinkVerdict = 'safe' | 'caution' | 'danger';
+
+export type SavedLinkResponse = {
+  id: number;
+  analysisId: string;
+  categoryId: number | null;
+  originalUrl: string;
+  finalUrl: string | null;
+  title: string;
+  description?: string | null;
+  verdict: SavedLinkVerdict;
+  isBookmarked: boolean;
+  createdAt: string;
+};
+
+export type SavedLinkListResponse = {
+  items: SavedLinkResponse[];
+  hasNext: boolean;
+  nextCursor: string | null;
+};
+
+export type SavedLinkCreateRequest = {
+  analysisId: string;
+  categoryId: number | null;
+  title: string;
+  description?: string | null;
+};
+
+export type SavedLinkListQuery = {
+  categoryId?: number | null;
+  bookmarked?: boolean;
+  cursor?: string | null;
+  size?: number;
+};
+
+export type BookmarkToggleResponse = {
+  id: number;
+  isBookmarked: boolean;
+};
+
+export type CategoryUpdateResponse = {
+  id: number;
+  categoryId: number | null;
+};
+
+export type SavedLinkTitleUpdateResponse = {
+  id: number;
+  title: string;
+};
+
+type SavedLinkRequestOptions = Pick<ApiRequestOptions, 'signal'>;
+
+export function createSavedLink(
+  getToken: ClerkTokenGetter,
+  body: SavedLinkCreateRequest,
+  options: SavedLinkRequestOptions = {},
+) {
+  return authenticatedApiRequest<SavedLinkResponse>(getToken, '/api/v1/saved-links', {
+    ...options,
+    method: 'POST',
+    body,
+  });
+}
+
+export function fetchSavedLinks(
+  getToken: ClerkTokenGetter,
+  query: SavedLinkListQuery = {},
+  options: SavedLinkRequestOptions = {},
+) {
+  return authenticatedApiRequest<SavedLinkListResponse>(
+    getToken,
+    `/api/v1/saved-links${buildSavedLinkQuery(query)}`,
+    options,
+  );
+}
+
+export function deleteSavedLink(getToken: ClerkTokenGetter, id: number) {
+  return authenticatedApiRequest<void>(
+    getToken,
+    `/api/v1/saved-links/${encodeURIComponent(String(id))}`,
+    { method: 'DELETE' },
+  );
+}
+
+export function toggleSavedLinkBookmark(getToken: ClerkTokenGetter, id: number) {
+  return authenticatedApiRequest<BookmarkToggleResponse>(
+    getToken,
+    `/api/v1/saved-links/${encodeURIComponent(String(id))}/bookmark`,
+    { method: 'PATCH' },
+  );
+}
+
+export function updateSavedLinkCategory(
+  getToken: ClerkTokenGetter,
+  id: number,
+  categoryId: number | null,
+) {
+  return authenticatedApiRequest<CategoryUpdateResponse>(
+    getToken,
+    `/api/v1/saved-links/${encodeURIComponent(String(id))}/category`,
+    {
+      method: 'PATCH',
+      body: { categoryId },
+    },
+  );
+}
+
+export function updateSavedLinkTitle(getToken: ClerkTokenGetter, id: number, title: string) {
+  return authenticatedApiRequest<SavedLinkTitleUpdateResponse>(
+    getToken,
+    `/api/v1/saved-links/${encodeURIComponent(String(id))}/title`,
+    {
+      method: 'PATCH',
+      body: { title },
+    },
+  );
+}
+
+function buildSavedLinkQuery(query: SavedLinkListQuery) {
+  const params = new URLSearchParams();
+
+  if (query.categoryId != null) {
+    params.set('categoryId', String(query.categoryId));
+  }
+
+  if (query.bookmarked != null) {
+    params.set('bookmarked', String(query.bookmarked));
+  }
+
+  if (query.cursor) {
+    params.set('cursor', query.cursor);
+  }
+
+  if (query.size != null) {
+    params.set('size', String(query.size));
+  }
+
+  const queryString = params.toString();
+  return queryString ? `?${queryString}` : '';
+}

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -35,6 +35,7 @@ export default function HomeScreen() {
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
   const [saveToastVisible, setSaveToastVisible] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
+  const [titleToastVisible, setTitleToastVisible] = useState(false);
   const titleInputRef = useRef<TextInput>(null);
   const lastToastParamRef = useRef<string | undefined>(undefined);
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
@@ -123,6 +124,7 @@ export default function HomeScreen() {
       await updateTitle(editingLink.id, trimmedTitle);
       setEditingLink(null);
       setTitleValue('');
+      setTitleToastVisible(true);
     } catch (error) {
       Alert.alert(
         '제목 수정 실패',
@@ -133,7 +135,12 @@ export default function HomeScreen() {
     }
   }, [editingLink, isUpdatingTitle, titleValue, updateTitle]);
 
-  const titleSubmitDisabled = titleValue.trim().length === 0 || titleValue.trim().length > 500 || isUpdatingTitle;
+  const trimmedTitleValue = titleValue.trim();
+  const titleSubmitDisabled =
+    trimmedTitleValue.length === 0 ||
+    trimmedTitleValue.length > 500 ||
+    trimmedTitleValue === editingLink?.title.trim() ||
+    isUpdatingTitle;
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -285,6 +292,13 @@ export default function HomeScreen() {
         placement="top"
         topOffset={96}
         onHide={() => setDeleteToastVisible(false)}
+      />
+      <Toast
+        visible={titleToastVisible}
+        message="제목이 수정되었습니다."
+        placement="top"
+        topOffset={96}
+        onHide={() => setTitleToastVisible(false)}
       />
     </SafeAreaView>
   );

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -246,7 +246,7 @@ export default function HomeScreen() {
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                   style={renameStyles.clearButton}
                 >
-                  <Text style={renameStyles.clearButtonText}>×</Text>
+                  <Text style={renameStyles.clearButtonText}>−</Text>
                 </TouchableOpacity>
               )}
             </View>

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -1,15 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
-  KeyboardAvoidingView,
-  Modal,
-  Platform,
-  Pressable,
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -19,6 +13,7 @@ import { CardLink } from '@/components/ui/card-link';
 import { FolderContextMenu } from '@/components/ui/folder-context-menu';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { SectionHeader } from '@/components/ui/section-header';
+import { TitleEditModal } from '@/components/ui/title-edit-modal';
 import { Toast } from '@/components/ui/toast';
 import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
@@ -31,12 +26,9 @@ export default function HomeScreen() {
   const { links, toggleBookmark, deleteLink, updateTitle } = useSavedLinks();
   const [menuState, setMenuState] = useState<{ visible: boolean; anchor?: AnchorPosition; linkId?: number }>({ visible: false });
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
-  const [titleValue, setTitleValue] = useState('');
-  const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
   const [saveToastVisible, setSaveToastVisible] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [titleToastVisible, setTitleToastVisible] = useState(false);
-  const titleInputRef = useRef<TextInput>(null);
   const lastToastParamRef = useRef<string | undefined>(undefined);
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
 
@@ -98,49 +90,12 @@ export default function HomeScreen() {
 
   const openTitleModal = useCallback((link: SavedLink) => {
     setEditingLink(link);
-    setTitleValue(link.title);
-    setTimeout(() => titleInputRef.current?.focus(), 100);
   }, []);
 
-  const handleTitleCancel = useCallback(() => {
-    if (isUpdatingTitle) {
-      return;
-    }
-
-    setEditingLink(null);
-    setTitleValue('');
-  }, [isUpdatingTitle]);
-
-  const handleTitleConfirm = useCallback(async () => {
-    const trimmedTitle = titleValue.trim();
-
-    if (!editingLink || trimmedTitle.length === 0 || trimmedTitle.length > 500 || isUpdatingTitle) {
-      return;
-    }
-
-    setIsUpdatingTitle(true);
-
-    try {
-      await updateTitle(editingLink.id, trimmedTitle);
-      setEditingLink(null);
-      setTitleValue('');
-      setTitleToastVisible(true);
-    } catch (error) {
-      Alert.alert(
-        '제목 수정 실패',
-        getSavedLinkErrorMessage(error, '제목을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
-      );
-    } finally {
-      setIsUpdatingTitle(false);
-    }
-  }, [editingLink, isUpdatingTitle, titleValue, updateTitle]);
-
-  const trimmedTitleValue = titleValue.trim();
-  const titleSubmitDisabled =
-    trimmedTitleValue.length === 0 ||
-    trimmedTitleValue.length > 500 ||
-    trimmedTitleValue === editingLink?.title.trim() ||
-    isUpdatingTitle;
+  const handleTitleConfirm = useCallback(async (id: number, title: string) => {
+    await updateTitle(id, title);
+    setTitleToastVisible(true);
+  }, [updateTitle]);
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -220,64 +175,11 @@ export default function HomeScreen() {
         onDismiss={() => setMenuState({ visible: false })}
       />
 
-      <Modal
-        visible={editingLink !== null}
-        transparent
-        animationType="fade"
-        onRequestClose={handleTitleCancel}
-      >
-        <KeyboardAvoidingView
-          style={renameStyles.overlay}
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        >
-          <Pressable style={renameStyles.backdrop} onPress={handleTitleCancel} />
-          <View style={renameStyles.sheet}>
-            <Text style={renameStyles.sheetTitle}>제목 수정</Text>
-            <View style={renameStyles.inputRow}>
-              <TextInput
-                ref={titleInputRef}
-                style={renameStyles.input}
-                value={titleValue}
-                onChangeText={setTitleValue}
-                placeholder="URL 제목 입력"
-                placeholderTextColor={Colors.brand.textHint}
-                returnKeyType="done"
-                onSubmitEditing={handleTitleConfirm}
-                maxLength={500}
-                editable={!isUpdatingTitle}
-                autoFocus
-              />
-              {titleValue.length > 0 && !isUpdatingTitle && (
-                <TouchableOpacity
-                  onPress={() => setTitleValue('')}
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  style={renameStyles.clearButton}
-                >
-                  <Text style={renameStyles.clearButtonText}>−</Text>
-                </TouchableOpacity>
-              )}
-            </View>
-            <View style={renameStyles.actions}>
-              <TouchableOpacity
-                style={renameStyles.cancelBtn}
-                onPress={handleTitleCancel}
-                disabled={isUpdatingTitle}
-              >
-                <Text style={renameStyles.cancelText}>취소</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[renameStyles.confirmBtn, titleSubmitDisabled && renameStyles.confirmBtnDisabled]}
-                onPress={handleTitleConfirm}
-                disabled={titleSubmitDisabled}
-              >
-                <Text style={[renameStyles.confirmText, titleSubmitDisabled && renameStyles.confirmTextDisabled]}>
-                  {isUpdatingTitle ? '저장 중...' : '저장'}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </KeyboardAvoidingView>
-      </Modal>
+      <TitleEditModal
+        editingLink={editingLink}
+        onConfirm={handleTitleConfirm}
+        onClose={() => setEditingLink(null)}
+      />
 
       <Toast
         visible={saveToastVisible}
@@ -368,93 +270,5 @@ const styles = StyleSheet.create({
 
   linkList: {
     gap: 12,
-  },
-});
-
-const renameStyles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: Colors.brand.overlayBackdrop,
-  },
-  sheet: {
-    backgroundColor: Colors.brand.surface,
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    padding: 24,
-    paddingBottom: 40,
-    gap: 16,
-  },
-  sheetTitle: {
-    ...Typography.section,
-    color: Colors.brand.text,
-    textAlign: 'center',
-  },
-  inputRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderWidth: 1.5,
-    borderColor: Colors.brand.line,
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  input: {
-    flex: 1,
-    ...Typography.body,
-    color: Colors.brand.text,
-    padding: 0,
-  },
-  clearButton: {
-    marginLeft: 8,
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: Colors.brand.softMint,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  clearButtonText: {
-    ...Typography.caption,
-    color: Colors.brand.primary,
-    lineHeight: 16,
-  },
-  actions: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  cancelBtn: {
-    flex: 1,
-    paddingVertical: 14,
-    borderRadius: 12,
-    borderWidth: 1.5,
-    borderColor: Colors.brand.line,
-    alignItems: 'center',
-  },
-  cancelText: {
-    ...Typography.body,
-    fontWeight: '700',
-    color: Colors.brand.textSecondary,
-  },
-  confirmBtn: {
-    flex: 1,
-    paddingVertical: 14,
-    borderRadius: 12,
-    backgroundColor: Colors.brand.primary,
-    alignItems: 'center',
-  },
-  confirmBtnDisabled: {
-    backgroundColor: Colors.brand.softMint,
-  },
-  confirmText: {
-    ...Typography.body,
-    fontWeight: '700',
-    color: Colors.brand.onPrimary,
-  },
-  confirmTextDisabled: {
-    color: Colors.brand.textHint,
   },
 });

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -1,5 +1,17 @@
-import { useState } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { AppIcon } from '@/components/ui/app-icon';
@@ -8,12 +20,16 @@ import { FolderContextMenu } from '@/components/ui/folder-context-menu';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { SectionHeader } from '@/components/ui/section-header';
 import { Colors, Typography } from '@/constants/theme';
-import { useSavedLinks } from '@/context/saved-links-context';
+import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 
 export default function HomeScreen() {
-  const { links, toggleBookmark, deleteLink } = useSavedLinks();
+  const { links, toggleBookmark, deleteLink, updateTitle } = useSavedLinks();
   const [menuState, setMenuState] = useState<{ visible: boolean; anchor?: AnchorPosition; linkId?: number }>({ visible: false });
+  const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
+  const [titleValue, setTitleValue] = useState('');
+  const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const titleInputRef = useRef<TextInput>(null);
 
   // 최근 저장한 링크 — createdAt 내림차순 상위 3개
   const recentLinks = links.slice(0, 3);
@@ -23,6 +39,83 @@ export default function HomeScreen() {
   };
 
   const selectedLink = links.find((l) => l.id === menuState.linkId);
+
+  const handleBookmark = useCallback(
+    async (id: number) => {
+      try {
+        await toggleBookmark(id);
+      } catch (error) {
+        Alert.alert(
+          '북마크 변경 실패',
+          getSavedLinkErrorMessage(error, '북마크 상태를 변경하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+        );
+      }
+    },
+    [toggleBookmark],
+  );
+
+  const handleDelete = useCallback(
+    (id: number) => {
+      Alert.alert('링크 삭제', '저장한 링크를 삭제할까요?', [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteLink(id);
+            } catch (error) {
+              Alert.alert(
+                '삭제 실패',
+                getSavedLinkErrorMessage(error, '링크를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+              );
+            }
+          },
+        },
+      ]);
+    },
+    [deleteLink],
+  );
+
+  const openTitleModal = useCallback((link: SavedLink) => {
+    setEditingLink(link);
+    setTitleValue(link.title);
+    setTimeout(() => titleInputRef.current?.focus(), 100);
+  }, []);
+
+  const handleTitleCancel = useCallback(() => {
+    if (isUpdatingTitle) {
+      return;
+    }
+
+    setEditingLink(null);
+    setTitleValue('');
+  }, [isUpdatingTitle]);
+
+  const handleTitleConfirm = useCallback(async () => {
+    const trimmedTitle = titleValue.trim();
+
+    if (!editingLink || trimmedTitle.length === 0 || trimmedTitle.length > 500 || isUpdatingTitle) {
+      return;
+    }
+
+    setIsUpdatingTitle(true);
+
+    try {
+      await updateTitle(editingLink.id, trimmedTitle);
+      setEditingLink(null);
+      setTitleValue('');
+    } catch (error) {
+      Alert.alert(
+        '제목 수정 실패',
+        getSavedLinkErrorMessage(error, '제목을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
+    } finally {
+      setIsUpdatingTitle(false);
+    }
+  }, [editingLink, isUpdatingTitle, titleValue, updateTitle]);
+
+  const titleSubmitDisabled = titleValue.trim().length === 0 || titleValue.trim().length > 500 || isUpdatingTitle;
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -75,7 +168,9 @@ export default function HomeScreen() {
                 originalUrl={link.originalUrl}
                 finalUrl={link.finalUrl}
                 bookmarked={link.isBookmarked}
-                onBookmark={() => toggleBookmark(link.id)}
+                onBookmark={() => {
+                  void handleBookmark(link.id);
+                }}
                 onMore={(anchor) => handleMore(link.id, anchor)}
               />
             ))}
@@ -88,17 +183,76 @@ export default function HomeScreen() {
         anchor={menuState.anchor}
         items={[
           {
-            label: selectedLink?.isBookmarked ? '북마크 제거' : '북마크 추가',
-            onPress: () => menuState.linkId != null && toggleBookmark(menuState.linkId),
+            label: '제목 수정',
+            onPress: () => selectedLink && openTitleModal(selectedLink),
           },
           {
             label: '링크 삭제',
-            onPress: () => menuState.linkId != null && deleteLink(menuState.linkId),
+            onPress: () => menuState.linkId != null && handleDelete(menuState.linkId),
             destructive: true,
           },
         ]}
         onDismiss={() => setMenuState({ visible: false })}
       />
+
+      <Modal
+        visible={editingLink !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={handleTitleCancel}
+      >
+        <KeyboardAvoidingView
+          style={renameStyles.overlay}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
+          <Pressable style={renameStyles.backdrop} onPress={handleTitleCancel} />
+          <View style={renameStyles.sheet}>
+            <Text style={renameStyles.sheetTitle}>제목 수정</Text>
+            <View style={renameStyles.inputRow}>
+              <TextInput
+                ref={titleInputRef}
+                style={renameStyles.input}
+                value={titleValue}
+                onChangeText={setTitleValue}
+                placeholder="URL 제목 입력"
+                placeholderTextColor={Colors.brand.textHint}
+                returnKeyType="done"
+                onSubmitEditing={handleTitleConfirm}
+                maxLength={500}
+                editable={!isUpdatingTitle}
+                autoFocus
+              />
+              {titleValue.length > 0 && !isUpdatingTitle && (
+                <TouchableOpacity
+                  onPress={() => setTitleValue('')}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  style={renameStyles.clearButton}
+                >
+                  <Text style={renameStyles.clearButtonText}>×</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+            <View style={renameStyles.actions}>
+              <TouchableOpacity
+                style={renameStyles.cancelBtn}
+                onPress={handleTitleCancel}
+                disabled={isUpdatingTitle}
+              >
+                <Text style={renameStyles.cancelText}>취소</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[renameStyles.confirmBtn, titleSubmitDisabled && renameStyles.confirmBtnDisabled]}
+                onPress={handleTitleConfirm}
+                disabled={titleSubmitDisabled}
+              >
+                <Text style={[renameStyles.confirmText, titleSubmitDisabled && renameStyles.confirmTextDisabled]}>
+                  {isUpdatingTitle ? '저장 중...' : '저장'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -167,5 +321,93 @@ const styles = StyleSheet.create({
 
   linkList: {
     gap: 12,
+  },
+});
+
+const renameStyles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Colors.brand.overlayBackdrop,
+  },
+  sheet: {
+    backgroundColor: Colors.brand.surface,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 24,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  sheetTitle: {
+    ...Typography.section,
+    color: Colors.brand.text,
+    textAlign: 'center',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  input: {
+    flex: 1,
+    ...Typography.body,
+    color: Colors.brand.text,
+    padding: 0,
+  },
+  clearButton: {
+    marginLeft: 8,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.softMint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clearButtonText: {
+    ...Typography.caption,
+    color: Colors.brand.primary,
+    lineHeight: 16,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cancelBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    alignItems: 'center',
+  },
+  cancelText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.textSecondary,
+  },
+  confirmBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.primary,
+    alignItems: 'center',
+  },
+  confirmBtnDisabled: {
+    backgroundColor: Colors.brand.softMint,
+  },
+  confirmText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.onPrimary,
+  },
+  confirmTextDisabled: {
+    color: Colors.brand.textHint,
   },
 });

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   KeyboardAvoidingView,
@@ -13,26 +13,43 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { AppIcon } from '@/components/ui/app-icon';
 import { CardLink } from '@/components/ui/card-link';
 import { FolderContextMenu } from '@/components/ui/folder-context-menu';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { SectionHeader } from '@/components/ui/section-header';
+import { Toast } from '@/components/ui/toast';
 import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 
 export default function HomeScreen() {
+  const { savedLinkToast: savedLinkToastParam } = useLocalSearchParams<{
+    savedLinkToast?: string | string[];
+  }>();
   const { links, toggleBookmark, deleteLink, updateTitle } = useSavedLinks();
   const [menuState, setMenuState] = useState<{ visible: boolean; anchor?: AnchorPosition; linkId?: number }>({ visible: false });
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
   const [titleValue, setTitleValue] = useState('');
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const [saveToastVisible, setSaveToastVisible] = useState(false);
+  const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const titleInputRef = useRef<TextInput>(null);
+  const lastToastParamRef = useRef<string | undefined>(undefined);
+  const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
 
   // 최근 저장한 링크 — createdAt 내림차순 상위 3개
   const recentLinks = links.slice(0, 3);
+
+  useEffect(() => {
+    if (!savedLinkToast || lastToastParamRef.current === savedLinkToast) {
+      return;
+    }
+
+    lastToastParamRef.current = savedLinkToast;
+    setSaveToastVisible(true);
+  }, [savedLinkToast]);
 
   const handleMore = (id: number, anchor: AnchorPosition) => {
     setMenuState({ visible: true, anchor, linkId: id });
@@ -64,6 +81,7 @@ export default function HomeScreen() {
           onPress: async () => {
             try {
               await deleteLink(id);
+              setDeleteToastVisible(true);
             } catch (error) {
               Alert.alert(
                 '삭제 실패',
@@ -253,6 +271,21 @@ export default function HomeScreen() {
           </View>
         </KeyboardAvoidingView>
       </Modal>
+
+      <Toast
+        visible={saveToastVisible}
+        message="링크가 저장되었습니다."
+        placement="top"
+        topOffset={96}
+        onHide={() => setSaveToastVisible(false)}
+      />
+      <Toast
+        visible={deleteToastVisible}
+        message="링크가 삭제되었습니다."
+        placement="top"
+        topOffset={96}
+        onHide={() => setDeleteToastVisible(false)}
+      />
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -63,6 +63,7 @@ export default function SavedLinksScreen() {
   const [titleValue, setTitleValue] = useState('');
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
+  const [titleToastVisible, setTitleToastVisible] = useState(false);
   const titleInputRef = useRef<TextInput>(null);
 
   const displayLinks = useMemo(() => {
@@ -163,6 +164,7 @@ export default function SavedLinksScreen() {
       await updateTitle(editingLink.id, trimmedTitle);
       setEditingLink(null);
       setTitleValue('');
+      setTitleToastVisible(true);
     } catch (error) {
       Alert.alert(
         '제목 수정 실패',
@@ -173,7 +175,12 @@ export default function SavedLinksScreen() {
     }
   }, [editingLink, isUpdatingTitle, titleValue, updateTitle]);
 
-  const titleSubmitDisabled = titleValue.trim().length === 0 || titleValue.trim().length > 500 || isUpdatingTitle;
+  const trimmedTitleValue = titleValue.trim();
+  const titleSubmitDisabled =
+    trimmedTitleValue.length === 0 ||
+    trimmedTitleValue.length > 500 ||
+    trimmedTitleValue === editingLink?.title.trim() ||
+    isUpdatingTitle;
   const showEmptyState = !isLoading && displayLinks.length === 0;
 
   return (
@@ -330,6 +337,13 @@ export default function SavedLinksScreen() {
         placement="top"
         topOffset={96}
         onHide={() => setDeleteToastVisible(false)}
+      />
+      <Toast
+        visible={titleToastVisible}
+        message="제목이 수정되었습니다."
+        placement="top"
+        topOffset={96}
+        onHide={() => setTitleToastVisible(false)}
       />
     </SafeAreaView>
   );

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -298,7 +298,7 @@ export default function SavedLinksScreen() {
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                   style={renameStyles.clearButton}
                 >
-                  <Text style={renameStyles.clearButtonText}>×</Text>
+                  <Text style={renameStyles.clearButtonText}>−</Text>
                 </TouchableOpacity>
               )}
             </View>

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -21,6 +21,7 @@ import { BookmarkChip } from '@/components/ui/bookmark-chip';
 import { CardLink } from '@/components/ui/card-link';
 import { FilterChip, type FilterChipItem } from '@/components/ui/filter-chip';
 import { FolderContextMenu, type ContextMenuItem } from '@/components/ui/folder-context-menu';
+import { Toast } from '@/components/ui/toast';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
@@ -61,6 +62,7 @@ export default function SavedLinksScreen() {
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
   const [titleValue, setTitleValue] = useState('');
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const titleInputRef = useRef<TextInput>(null);
 
   const displayLinks = useMemo(() => {
@@ -106,6 +108,7 @@ export default function SavedLinksScreen() {
           onPress: async () => {
             try {
               await deleteLink(id);
+              setDeleteToastVisible(true);
             } catch (error) {
               Alert.alert(
                 '삭제 실패',
@@ -320,6 +323,14 @@ export default function SavedLinksScreen() {
           </View>
         </KeyboardAvoidingView>
       </Modal>
+
+      <Toast
+        visible={deleteToastVisible}
+        message="링크가 삭제되었습니다."
+        placement="top"
+        topOffset={96}
+        onHide={() => setDeleteToastVisible(false)}
+      />
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -1,17 +1,11 @@
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import {
   ActivityIndicator,
   Alert,
   FlatList,
-  KeyboardAvoidingView,
-  Modal,
-  Platform,
-  Pressable,
   RefreshControl,
   StyleSheet,
   Text,
-  TextInput,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -21,6 +15,7 @@ import { BookmarkChip } from '@/components/ui/bookmark-chip';
 import { CardLink } from '@/components/ui/card-link';
 import { FilterChip, type FilterChipItem } from '@/components/ui/filter-chip';
 import { FolderContextMenu, type ContextMenuItem } from '@/components/ui/folder-context-menu';
+import { TitleEditModal } from '@/components/ui/title-edit-modal';
 import { Toast } from '@/components/ui/toast';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { Colors, Typography } from '@/constants/theme';
@@ -60,11 +55,8 @@ export default function SavedLinksScreen() {
   const [menuAnchor, setMenuAnchor] = useState<AnchorPosition | undefined>();
   const [menuItems, setMenuItems] = useState<ContextMenuItem[]>([]);
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
-  const [titleValue, setTitleValue] = useState('');
-  const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [titleToastVisible, setTitleToastVisible] = useState(false);
-  const titleInputRef = useRef<TextInput>(null);
 
   const displayLinks = useMemo(() => {
     const folderFiltered =
@@ -81,8 +73,6 @@ export default function SavedLinksScreen() {
 
   const openTitleModal = useCallback((link: SavedLink) => {
     setEditingLink(link);
-    setTitleValue(link.title);
-    setTimeout(() => titleInputRef.current?.focus(), 100);
   }, []);
 
   const handleBookmark = useCallback(
@@ -142,45 +132,11 @@ export default function SavedLinksScreen() {
     [handleDelete, openTitleModal],
   );
 
-  const handleTitleCancel = useCallback(() => {
-    if (isUpdatingTitle) {
-      return;
-    }
+  const handleTitleConfirm = useCallback(async (id: number, title: string) => {
+    await updateTitle(id, title);
+    setTitleToastVisible(true);
+  }, [updateTitle]);
 
-    setEditingLink(null);
-    setTitleValue('');
-  }, [isUpdatingTitle]);
-
-  const handleTitleConfirm = useCallback(async () => {
-    const trimmedTitle = titleValue.trim();
-
-    if (!editingLink || trimmedTitle.length === 0 || trimmedTitle.length > 500 || isUpdatingTitle) {
-      return;
-    }
-
-    setIsUpdatingTitle(true);
-
-    try {
-      await updateTitle(editingLink.id, trimmedTitle);
-      setEditingLink(null);
-      setTitleValue('');
-      setTitleToastVisible(true);
-    } catch (error) {
-      Alert.alert(
-        '제목 수정 실패',
-        getSavedLinkErrorMessage(error, '제목을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
-      );
-    } finally {
-      setIsUpdatingTitle(false);
-    }
-  }, [editingLink, isUpdatingTitle, titleValue, updateTitle]);
-
-  const trimmedTitleValue = titleValue.trim();
-  const titleSubmitDisabled =
-    trimmedTitleValue.length === 0 ||
-    trimmedTitleValue.length > 500 ||
-    trimmedTitleValue === editingLink?.title.trim() ||
-    isUpdatingTitle;
   const showEmptyState = !isLoading && displayLinks.length === 0;
 
   return (
@@ -271,65 +227,11 @@ export default function SavedLinksScreen() {
         onDismiss={() => setMenuVisible(false)}
       />
 
-      {/* 링크 제목 수정 모달 */}
-      <Modal
-        visible={editingLink !== null}
-        transparent
-        animationType="fade"
-        onRequestClose={handleTitleCancel}
-      >
-        <KeyboardAvoidingView
-          style={renameStyles.overlay}
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        >
-          <Pressable style={renameStyles.backdrop} onPress={handleTitleCancel} />
-          <View style={renameStyles.sheet}>
-            <Text style={renameStyles.sheetTitle}>제목 수정</Text>
-            <View style={renameStyles.inputRow}>
-              <TextInput
-                ref={titleInputRef}
-                style={renameStyles.input}
-                value={titleValue}
-                onChangeText={setTitleValue}
-                placeholder="URL 제목 입력"
-                placeholderTextColor={Colors.brand.textHint}
-                returnKeyType="done"
-                onSubmitEditing={handleTitleConfirm}
-                maxLength={500}
-                editable={!isUpdatingTitle}
-                autoFocus
-              />
-              {titleValue.length > 0 && !isUpdatingTitle && (
-                <TouchableOpacity
-                  onPress={() => setTitleValue('')}
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  style={renameStyles.clearButton}
-                >
-                  <Text style={renameStyles.clearButtonText}>−</Text>
-                </TouchableOpacity>
-              )}
-            </View>
-            <View style={renameStyles.actions}>
-              <TouchableOpacity
-                style={renameStyles.cancelBtn}
-                onPress={handleTitleCancel}
-                disabled={isUpdatingTitle}
-              >
-                <Text style={renameStyles.cancelText}>취소</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[renameStyles.confirmBtn, titleSubmitDisabled && renameStyles.confirmBtnDisabled]}
-                onPress={handleTitleConfirm}
-                disabled={titleSubmitDisabled}
-              >
-                <Text style={[renameStyles.confirmText, titleSubmitDisabled && renameStyles.confirmTextDisabled]}>
-                  {isUpdatingTitle ? '저장 중...' : '저장'}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </KeyboardAvoidingView>
-      </Modal>
+      <TitleEditModal
+        editingLink={editingLink}
+        onConfirm={handleTitleConfirm}
+        onClose={() => setEditingLink(null)}
+      />
 
       <Toast
         visible={deleteToastVisible}
@@ -415,93 +317,5 @@ const styles = StyleSheet.create({
   footerLoader: {
     paddingVertical: 16,
     alignItems: 'center',
-  },
-});
-
-const renameStyles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: Colors.brand.overlayBackdrop,
-  },
-  sheet: {
-    backgroundColor: Colors.brand.surface,
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    padding: 24,
-    paddingBottom: 40,
-    gap: 16,
-  },
-  sheetTitle: {
-    ...Typography.section,
-    color: Colors.brand.text,
-    textAlign: 'center',
-  },
-  inputRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderWidth: 1.5,
-    borderColor: Colors.brand.line,
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  input: {
-    flex: 1,
-    ...Typography.body,
-    color: Colors.brand.text,
-    padding: 0,
-  },
-  clearButton: {
-    marginLeft: 8,
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: Colors.brand.softMint,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  clearButtonText: {
-    ...Typography.caption,
-    color: Colors.brand.primary,
-    lineHeight: 16,
-  },
-  actions: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  cancelBtn: {
-    flex: 1,
-    paddingVertical: 14,
-    borderRadius: 12,
-    borderWidth: 1.5,
-    borderColor: Colors.brand.line,
-    alignItems: 'center',
-  },
-  cancelText: {
-    ...Typography.body,
-    fontWeight: '700',
-    color: Colors.brand.textSecondary,
-  },
-  confirmBtn: {
-    flex: 1,
-    paddingVertical: 14,
-    borderRadius: 12,
-    backgroundColor: Colors.brand.primary,
-    alignItems: 'center',
-  },
-  confirmBtnDisabled: {
-    backgroundColor: Colors.brand.softMint,
-  },
-  confirmText: {
-    ...Typography.body,
-    fontWeight: '700',
-    color: Colors.brand.onPrimary,
-  },
-  confirmTextDisabled: {
-    color: Colors.brand.textHint,
   },
 });

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -1,5 +1,19 @@
-import { useState, useMemo, useCallback } from 'react';
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import { useState, useMemo, useCallback, useRef } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { AppIcon } from '@/components/ui/app-icon';
@@ -9,7 +23,7 @@ import { FilterChip, type FilterChipItem } from '@/components/ui/filter-chip';
 import { FolderContextMenu, type ContextMenuItem } from '@/components/ui/folder-context-menu';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { Colors, Typography } from '@/constants/theme';
-import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
+import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 
 // ─── 폴더 필터 칩 아이템 ──────────────────────────────────────────────────────
 // 실제 구현 시 GET /api/v1/categories 응답으로 교체
@@ -25,7 +39,18 @@ const FOLDER_ITEMS: FilterChipItem[] = [
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
 export default function SavedLinksScreen() {
-  const { links, toggleBookmark, deleteLink } = useSavedLinks();
+  const {
+    links,
+    isLoading,
+    isLoadingMore,
+    errorMessage,
+    hasNext,
+    refreshLinks,
+    loadMoreLinks,
+    toggleBookmark,
+    deleteLink,
+    updateTitle,
+  } = useSavedLinks();
 
   const [selectedFolder, setSelectedFolder] = useState('all');
   const [bookmarkFilter, setBookmarkFilter] = useState(false);
@@ -33,6 +58,10 @@ export default function SavedLinksScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<AnchorPosition | undefined>();
   const [menuItems, setMenuItems] = useState<ContextMenuItem[]>([]);
+  const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
+  const [titleValue, setTitleValue] = useState('');
+  const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const titleInputRef = useRef<TextInput>(null);
 
   const displayLinks = useMemo(() => {
     const folderFiltered =
@@ -40,29 +69,109 @@ export default function SavedLinksScreen() {
         ? links
         : links.filter((link) => String(link.categoryId) === selectedFolder);
 
-    if (!bookmarkFilter) return folderFiltered;
+    if (!bookmarkFilter) {
+      return folderFiltered;
+    }
 
-    return [...folderFiltered].sort((a, b) => Number(b.isBookmarked) - Number(a.isBookmarked));
+    return folderFiltered.filter((link) => link.isBookmarked);
   }, [links, selectedFolder, bookmarkFilter]);
+
+  const openTitleModal = useCallback((link: SavedLink) => {
+    setEditingLink(link);
+    setTitleValue(link.title);
+    setTimeout(() => titleInputRef.current?.focus(), 100);
+  }, []);
+
+  const handleBookmark = useCallback(
+    async (id: number) => {
+      try {
+        await toggleBookmark(id);
+      } catch (error) {
+        Alert.alert(
+          '북마크 변경 실패',
+          getSavedLinkErrorMessage(error, '북마크 상태를 변경하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+        );
+      }
+    },
+    [toggleBookmark],
+  );
+
+  const handleDelete = useCallback(
+    (id: number) => {
+      Alert.alert('링크 삭제', '저장한 링크를 삭제할까요?', [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteLink(id);
+            } catch (error) {
+              Alert.alert(
+                '삭제 실패',
+                getSavedLinkErrorMessage(error, '링크를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+              );
+            }
+          },
+        },
+      ]);
+    },
+    [deleteLink],
+  );
 
   const openMoreMenu = useCallback(
     (link: SavedLink, anchor: AnchorPosition) => {
       setMenuAnchor(anchor);
       setMenuItems([
         {
-          label: link.isBookmarked ? '북마크 제거' : '북마크 추가',
-          onPress: () => toggleBookmark(link.id),
+          label: '제목 수정',
+          onPress: () => openTitleModal(link),
         },
         {
           label: '링크 삭제',
-          onPress: () => deleteLink(link.id),
+          onPress: () => handleDelete(link.id),
           destructive: true,
         },
       ]);
       setMenuVisible(true);
     },
-    [toggleBookmark, deleteLink]
+    [handleDelete, openTitleModal],
   );
+
+  const handleTitleCancel = useCallback(() => {
+    if (isUpdatingTitle) {
+      return;
+    }
+
+    setEditingLink(null);
+    setTitleValue('');
+  }, [isUpdatingTitle]);
+
+  const handleTitleConfirm = useCallback(async () => {
+    const trimmedTitle = titleValue.trim();
+
+    if (!editingLink || trimmedTitle.length === 0 || trimmedTitle.length > 500 || isUpdatingTitle) {
+      return;
+    }
+
+    setIsUpdatingTitle(true);
+
+    try {
+      await updateTitle(editingLink.id, trimmedTitle);
+      setEditingLink(null);
+      setTitleValue('');
+    } catch (error) {
+      Alert.alert(
+        '제목 수정 실패',
+        getSavedLinkErrorMessage(error, '제목을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
+    } finally {
+      setIsUpdatingTitle(false);
+    }
+  }, [editingLink, isUpdatingTitle, titleValue, updateTitle]);
+
+  const titleSubmitDisabled = titleValue.trim().length === 0 || titleValue.trim().length > 500 || isUpdatingTitle;
+  const showEmptyState = !isLoading && displayLinks.length === 0;
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -86,12 +195,33 @@ export default function SavedLinksScreen() {
         />
       </View>
 
+      {errorMessage ? (
+        <View style={styles.errorBox}>
+          <Text style={styles.errorText}>{errorMessage}</Text>
+        </View>
+      ) : null}
+
       {/* 링크 목록 */}
       <FlatList
         data={displayLinks}
         keyExtractor={(item) => String(item.id)}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={isLoading}
+            onRefresh={() => {
+              void refreshLinks();
+            }}
+            tintColor={Colors.brand.primary}
+          />
+        }
+        onEndReached={() => {
+          if (hasNext && !isLoadingMore) {
+            void loadMoreLinks();
+          }
+        }}
+        onEndReachedThreshold={0.4}
         renderItem={({ item }) => (
           <CardLink
             verdict={item.verdict}
@@ -99,11 +229,28 @@ export default function SavedLinksScreen() {
             originalUrl={item.originalUrl}
             finalUrl={item.finalUrl}
             bookmarked={item.isBookmarked}
-            onBookmark={() => toggleBookmark(item.id)}
+            onBookmark={() => {
+              void handleBookmark(item.id);
+            }}
             onMore={(anchor) => openMoreMenu(item, anchor)}
           />
         )}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
+        ListEmptyComponent={
+          showEmptyState ? (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyText}>저장한 링크가 없어요</Text>
+              <Text style={styles.emptySubtext}>검사 결과 화면에서 안전한 링크를 저장해보세요</Text>
+            </View>
+          ) : null
+        }
+        ListFooterComponent={
+          isLoadingMore ? (
+            <View style={styles.footerLoader}>
+              <ActivityIndicator color={Colors.brand.primary} />
+            </View>
+          ) : null
+        }
       />
 
       {/* 링크 컨텍스트 메뉴 */}
@@ -113,6 +260,66 @@ export default function SavedLinksScreen() {
         items={menuItems}
         onDismiss={() => setMenuVisible(false)}
       />
+
+      {/* 링크 제목 수정 모달 */}
+      <Modal
+        visible={editingLink !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={handleTitleCancel}
+      >
+        <KeyboardAvoidingView
+          style={renameStyles.overlay}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
+          <Pressable style={renameStyles.backdrop} onPress={handleTitleCancel} />
+          <View style={renameStyles.sheet}>
+            <Text style={renameStyles.sheetTitle}>제목 수정</Text>
+            <View style={renameStyles.inputRow}>
+              <TextInput
+                ref={titleInputRef}
+                style={renameStyles.input}
+                value={titleValue}
+                onChangeText={setTitleValue}
+                placeholder="URL 제목 입력"
+                placeholderTextColor={Colors.brand.textHint}
+                returnKeyType="done"
+                onSubmitEditing={handleTitleConfirm}
+                maxLength={500}
+                editable={!isUpdatingTitle}
+                autoFocus
+              />
+              {titleValue.length > 0 && !isUpdatingTitle && (
+                <TouchableOpacity
+                  onPress={() => setTitleValue('')}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  style={renameStyles.clearButton}
+                >
+                  <Text style={renameStyles.clearButtonText}>×</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+            <View style={renameStyles.actions}>
+              <TouchableOpacity
+                style={renameStyles.cancelBtn}
+                onPress={handleTitleCancel}
+                disabled={isUpdatingTitle}
+              >
+                <Text style={renameStyles.cancelText}>취소</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[renameStyles.confirmBtn, titleSubmitDisabled && renameStyles.confirmBtnDisabled]}
+                onPress={handleTitleConfirm}
+                disabled={titleSubmitDisabled}
+              >
+                <Text style={[renameStyles.confirmText, titleSubmitDisabled && renameStyles.confirmTextDisabled]}>
+                  {isUpdatingTitle ? '저장 중...' : '저장'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -143,11 +350,133 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   listContent: {
+    flexGrow: 1,
     paddingHorizontal: 20,
     paddingTop: 4,
     paddingBottom: 32,
   },
   separator: {
     height: 12,
+  },
+  errorBox: {
+    marginHorizontal: 20,
+    marginBottom: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.brand.textWarning,
+    backgroundColor: Colors.brand.surface,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  errorText: {
+    ...Typography.caption,
+    color: Colors.brand.textWarning,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingBottom: 80,
+  },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.brand.textSecondary,
+  },
+  emptySubtext: {
+    ...Typography.caption,
+    color: Colors.brand.textHint,
+  },
+  footerLoader: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+});
+
+const renameStyles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Colors.brand.overlayBackdrop,
+  },
+  sheet: {
+    backgroundColor: Colors.brand.surface,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 24,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  sheetTitle: {
+    ...Typography.section,
+    color: Colors.brand.text,
+    textAlign: 'center',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  input: {
+    flex: 1,
+    ...Typography.body,
+    color: Colors.brand.text,
+    padding: 0,
+  },
+  clearButton: {
+    marginLeft: 8,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.softMint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clearButtonText: {
+    ...Typography.caption,
+    color: Colors.brand.primary,
+    lineHeight: 16,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cancelBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    alignItems: 'center',
+  },
+  cancelText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.textSecondary,
+  },
+  confirmBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.primary,
+    alignItems: 'center',
+  },
+  confirmBtnDisabled: {
+    backgroundColor: Colors.brand.softMint,
+  },
+  confirmText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.onPrimary,
+  },
+  confirmTextDisabled: {
+    color: Colors.brand.textHint,
   },
 });

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -70,9 +70,10 @@ export default function ScanResultCautionScreen() {
         description: analysis?.summary ?? '저장된 링크입니다.',
       });
       setSaveModalVisible(false);
-      Alert.alert('저장 완료', '주의 링크가 저장되었습니다.', [
-        { text: '확인', onPress: () => router.dismissAll() },
-      ]);
+      router.replace({
+        pathname: '/(tabs)/(home)',
+        params: { savedLinkToast: String(Date.now()) },
+      });
     } catch (error) {
       Alert.alert(
         '저장 실패',

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
 import { Colors, Typography } from '@/constants/theme';
-import { useSavedLinks } from '@/context/saved-links-context';
+import { getSavedLinkErrorMessage, useSavedLinks } from '@/context/saved-links-context';
 import { LinkSaveModal } from '@/components/ui/link-save-modal';
 import { useAnalysisResult } from '@/hooks/use-analysis-result';
 import {
@@ -14,7 +14,6 @@ import {
   getAnalysisReasonText,
   getAnalysisResultPath,
   getRouteParam,
-  getSiteName,
 } from '@/utils/analysis-result-display';
 
 export default function ScanResultCautionScreen() {
@@ -30,9 +29,16 @@ export default function ScanResultCautionScreen() {
   const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('caution'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'caution');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
-  const canSave = displayUrl.trim().length > 0 && !isLoading && !shouldRedirectToVerdict;
+  const saveAnalysisId = analysis?.analysisId ?? analysisId;
+  const canSave =
+    Boolean(saveAnalysisId) &&
+    displayUrl.trim().length > 0 &&
+    !isLoading &&
+    !shouldRedirectToVerdict &&
+    !isSaving;
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'caution') {
@@ -49,27 +55,32 @@ export default function ScanResultCautionScreen() {
     });
   }, [analysis, url]);
 
-  const handleSave = (title: string) => {
-    if (!canSave) {
+  const handleSave = async (title: string) => {
+    if (!canSave || !saveAnalysisId) {
       return;
     }
 
-    // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
-    addLink({
-      id: Date.now(),
-      analysisId: analysis?.analysisId ?? analysisId ?? `mock-${Date.now()}`,
-      categoryId: null,
-      originalUrl: displayUrl,
-      finalUrl: finalUrl || null,
-      title,
-      description: analysis?.summary ?? '저장된 링크입니다.',
-      siteName: getSiteName(finalUrl || displayUrl),
-      verdict: analysis?.verdict ?? 'caution',
-      isBookmarked: false,
-      createdAt: new Date().toISOString(),
-    });
-    setSaveModalVisible(false);
-    router.dismissAll();
+    setIsSaving(true);
+
+    try {
+      await addLink({
+        analysisId: saveAnalysisId,
+        categoryId: null,
+        title,
+        description: analysis?.summary ?? '저장된 링크입니다.',
+      });
+      setSaveModalVisible(false);
+      Alert.alert('저장 완료', '주의 링크가 저장되었습니다.', [
+        { text: '확인', onPress: () => router.dismissAll() },
+      ]);
+    } catch (error) {
+      Alert.alert(
+        '저장 실패',
+        getSavedLinkErrorMessage(error, '링크를 저장하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleOpenUrl = async () => {
@@ -162,7 +173,12 @@ export default function ScanResultCautionScreen() {
       <LinkSaveModal
         visible={saveModalVisible}
         url={displayUrl}
-        onCancel={() => setSaveModalVisible(false)}
+        loading={isSaving}
+        onCancel={() => {
+          if (!isSaving) {
+            setSaveModalVisible(false);
+          }
+        }}
         onSave={handleSave}
       />
     </>

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
 import { Colors, Typography } from '@/constants/theme';
-import { useSavedLinks } from '@/context/saved-links-context';
+import { getSavedLinkErrorMessage, useSavedLinks } from '@/context/saved-links-context';
 import { LinkSaveModal } from '@/components/ui/link-save-modal';
 import { useAnalysisResult } from '@/hooks/use-analysis-result';
 import {
@@ -14,15 +14,7 @@ import {
   getAnalysisReasonText,
   getAnalysisResultPath,
   getRouteParam,
-  getSiteName,
 } from '@/utils/analysis-result-display';
-
-// TODO: 백엔드 연동 시 아래 흐름으로 교체
-// 1. scanning.tsx에서 POST /api/v1/analyses → analysisId 수신 후 params로 전달
-// 2. 여기서 POST /api/v1/saved-links { analysisId } 호출
-// 3. 응답(id, title, siteName 등)을 addLink에 전달
-// ERD: SAVED_LINK.analysis_id → ANALYSIS.analysis_id (FK)
-// API 명세: Draft of the specification.md > 4.1 링크 저장 참고
 
 export default function ScanResultScreen() {
   const {
@@ -37,9 +29,16 @@ export default function ScanResultScreen() {
   const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('safe'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'safe');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
-  const canSave = displayUrl.trim().length > 0 && !isLoading && !shouldRedirectToVerdict;
+  const saveAnalysisId = analysis?.analysisId ?? analysisId;
+  const canSave =
+    Boolean(saveAnalysisId) &&
+    displayUrl.trim().length > 0 &&
+    !isLoading &&
+    !shouldRedirectToVerdict &&
+    !isSaving;
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'safe') {
@@ -56,28 +55,32 @@ export default function ScanResultScreen() {
     });
   }, [analysis, url]);
 
-  const handleSave = (title: string) => {
-    if (!canSave) {
+  const handleSave = async (title: string) => {
+    if (!canSave || !saveAnalysisId) {
       return;
     }
 
-    // TODO: POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
-    // 현재는 URL 기반 mock 데이터로 즉시 추가
-    addLink({
-      id: Date.now(),
-      analysisId: analysis?.analysisId ?? analysisId ?? `mock-${Date.now()}`,
-      categoryId: null,
-      originalUrl: displayUrl,
-      finalUrl: finalUrl || null,
-      title,
-      description: analysis?.summary ?? '저장된 링크입니다.',
-      siteName: getSiteName(finalUrl || displayUrl),
-      verdict: analysis?.verdict ?? 'safe',
-      isBookmarked: false,
-      createdAt: new Date().toISOString(),
-    });
-    setSaveModalVisible(false);
-    router.dismissAll();
+    setIsSaving(true);
+
+    try {
+      await addLink({
+        analysisId: saveAnalysisId,
+        categoryId: null,
+        title,
+        description: analysis?.summary ?? '저장된 링크입니다.',
+      });
+      setSaveModalVisible(false);
+      Alert.alert('저장 완료', '링크가 저장되었습니다.', [
+        { text: '확인', onPress: () => router.dismissAll() },
+      ]);
+    } catch (error) {
+      Alert.alert(
+        '저장 실패',
+        getSavedLinkErrorMessage(error, '링크를 저장하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleOpenUrl = async () => {
@@ -170,7 +173,12 @@ export default function ScanResultScreen() {
       <LinkSaveModal
         visible={saveModalVisible}
         url={displayUrl}
-        onCancel={() => setSaveModalVisible(false)}
+        loading={isSaving}
+        onCancel={() => {
+          if (!isSaving) {
+            setSaveModalVisible(false);
+          }
+        }}
         onSave={handleSave}
       />
     </>

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -70,9 +70,10 @@ export default function ScanResultScreen() {
         description: analysis?.summary ?? '저장된 링크입니다.',
       });
       setSaveModalVisible(false);
-      Alert.alert('저장 완료', '링크가 저장되었습니다.', [
-        { text: '확인', onPress: () => router.dismissAll() },
-      ]);
+      router.replace({
+        pathname: '/(tabs)/(home)',
+        params: { savedLinkToast: String(Date.now()) },
+      });
     } catch (error) {
       Alert.alert(
         '저장 실패',

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -18,6 +18,7 @@ interface LinkSaveModalProps {
   url: string;
   // 향후 링크카드 more 버튼의 URL 제목 수정 기능에서 기존 제목을 초기값으로 사용합니다.
   initialTitle?: string;
+  loading?: boolean;
   onCancel: () => void;
   onSave: (title: string) => void;
 }
@@ -26,13 +27,14 @@ export function LinkSaveModal({
   visible,
   url,
   initialTitle = '',
+  loading = false,
   onCancel,
   onSave,
 }: LinkSaveModalProps) {
   const [title, setTitle] = useState(initialTitle);
 
   const trimmedTitle = title.trim();
-  const saveDisabled = trimmedTitle.length === 0;
+  const saveDisabled = loading || trimmedTitle.length === 0;
 
   useEffect(() => {
     setTitle(initialTitle);
@@ -54,7 +56,7 @@ export function LinkSaveModal({
         style={styles.overlay}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <Pressable style={styles.backdrop} onPress={onCancel} />
+        <Pressable style={styles.backdrop} onPress={loading ? undefined : onCancel} />
 
         <View style={styles.sheet}>
           <View style={styles.handle} />
@@ -74,7 +76,8 @@ export function LinkSaveModal({
               placeholderTextColor={Colors.brand.textHint}
               returnKeyType="done"
               onSubmitEditing={handleSave}
-              maxLength={50}
+              maxLength={500}
+              editable={!loading}
               autoFocus
             />
           </View>
@@ -93,6 +96,7 @@ export function LinkSaveModal({
               style={styles.cancelButton}
               onPress={onCancel}
               activeOpacity={0.8}
+              disabled={loading}
             >
               <Text style={styles.cancelButtonText}>취소</Text>
             </TouchableOpacity>
@@ -104,7 +108,7 @@ export function LinkSaveModal({
               disabled={saveDisabled}
             >
               <Text style={[styles.saveButtonText, saveDisabled && styles.saveButtonTextDisabled]}>
-                저장
+                {loading ? '저장 중...' : '저장'}
               </Text>
             </TouchableOpacity>
           </View>

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { Colors, Typography } from '@/constants/theme';
+import { getSavedLinkErrorMessage, type SavedLink } from '@/context/saved-links-context';
+
+interface TitleEditModalProps {
+  editingLink: SavedLink | null;
+  onConfirm: (id: number, title: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditModalProps) {
+  const [titleValue, setTitleValue] = useState('');
+  const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const titleInputRef = useRef<TextInput>(null);
+
+  useEffect(() => {
+    if (!editingLink) {
+      setTitleValue('');
+      return;
+    }
+
+    setTitleValue(editingLink.title);
+    const focusTimer = setTimeout(() => titleInputRef.current?.focus(), 100);
+
+    return () => clearTimeout(focusTimer);
+  }, [editingLink]);
+
+  const handleClose = useCallback(() => {
+    if (isUpdatingTitle) {
+      return;
+    }
+
+    onClose();
+  }, [isUpdatingTitle, onClose]);
+
+  const handleConfirm = useCallback(async () => {
+    const trimmedTitle = titleValue.trim();
+
+    if (!editingLink || trimmedTitle.length === 0 || trimmedTitle.length > 500 || isUpdatingTitle) {
+      return;
+    }
+
+    setIsUpdatingTitle(true);
+
+    try {
+      await onConfirm(editingLink.id, trimmedTitle);
+      onClose();
+    } catch (error) {
+      Alert.alert(
+        '제목 수정 실패',
+        getSavedLinkErrorMessage(error, '제목을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
+    } finally {
+      setIsUpdatingTitle(false);
+    }
+  }, [editingLink, isUpdatingTitle, onClose, onConfirm, titleValue]);
+
+  const trimmedTitleValue = titleValue.trim();
+  const titleSubmitDisabled =
+    trimmedTitleValue.length === 0 ||
+    trimmedTitleValue.length > 500 ||
+    trimmedTitleValue === editingLink?.title.trim() ||
+    isUpdatingTitle;
+
+  return (
+    <Modal
+      visible={editingLink !== null}
+      transparent
+      animationType="fade"
+      onRequestClose={handleClose}
+    >
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <Pressable style={styles.backdrop} onPress={handleClose} />
+        <View style={styles.sheet}>
+          <Text style={styles.sheetTitle}>제목 수정</Text>
+          <View style={styles.inputRow}>
+            <TextInput
+              ref={titleInputRef}
+              style={styles.input}
+              value={titleValue}
+              onChangeText={setTitleValue}
+              placeholder="URL 제목 입력"
+              placeholderTextColor={Colors.brand.textHint}
+              returnKeyType="done"
+              onSubmitEditing={handleConfirm}
+              maxLength={500}
+              editable={!isUpdatingTitle}
+              autoFocus
+            />
+            {titleValue.length > 0 && !isUpdatingTitle && (
+              <TouchableOpacity
+                onPress={() => setTitleValue('')}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                style={styles.clearButton}
+              >
+                <Text style={styles.clearButtonText}>−</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+          <View style={styles.actions}>
+            <TouchableOpacity
+              style={styles.cancelBtn}
+              onPress={handleClose}
+              disabled={isUpdatingTitle}
+            >
+              <Text style={styles.cancelText}>취소</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.confirmBtn, titleSubmitDisabled && styles.confirmBtnDisabled]}
+              onPress={handleConfirm}
+              disabled={titleSubmitDisabled}
+            >
+              <Text style={[styles.confirmText, titleSubmitDisabled && styles.confirmTextDisabled]}>
+                {isUpdatingTitle ? '저장 중...' : '저장'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Colors.brand.overlayBackdrop,
+  },
+  sheet: {
+    backgroundColor: Colors.brand.surface,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 24,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  sheetTitle: {
+    ...Typography.section,
+    color: Colors.brand.text,
+    textAlign: 'center',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  input: {
+    flex: 1,
+    ...Typography.body,
+    color: Colors.brand.text,
+    padding: 0,
+  },
+  clearButton: {
+    marginLeft: 8,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.softMint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clearButtonText: {
+    ...Typography.caption,
+    color: Colors.brand.primary,
+    lineHeight: 16,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cancelBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    borderWidth: 1.5,
+    borderColor: Colors.brand.line,
+    alignItems: 'center',
+  },
+  cancelText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.textSecondary,
+  },
+  confirmBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.primary,
+    alignItems: 'center',
+  },
+  confirmBtnDisabled: {
+    backgroundColor: Colors.brand.softMint,
+  },
+  confirmText: {
+    ...Typography.body,
+    fontWeight: '700',
+    color: Colors.brand.onPrimary,
+  },
+  confirmTextDisabled: {
+    color: Colors.brand.textHint,
+  },
+});

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -7,10 +7,19 @@ interface ToastProps {
   visible: boolean;
   message: string;
   duration?: number;
+  placement?: 'center' | 'top';
+  topOffset?: number;
   onHide?: () => void;
 }
 
-export function Toast({ visible, message, duration = 2500, onHide }: ToastProps) {
+export function Toast({
+  visible,
+  message,
+  duration = 2500,
+  placement = 'center',
+  topOffset = 64,
+  onHide,
+}: ToastProps) {
   const opacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -26,7 +35,14 @@ export function Toast({ visible, message, duration = 2500, onHide }: ToastProps)
   if (!visible) return null;
 
   return (
-    <Animated.View style={[styles.container, { opacity }]} pointerEvents="none">
+    <Animated.View
+      style={[
+        styles.container,
+        placement === 'top' ? [styles.topContainer, { top: topOffset }] : styles.centerContainer,
+        { opacity },
+      ]}
+      pointerEvents="none"
+    >
       <View style={styles.toast}>
         <IconSymbol name="checkmark.circle.fill" size={20} color={Colors.brand.primary} />
         <Text style={styles.message}>{message}</Text>
@@ -38,14 +54,19 @@ export function Toast({ visible, message, duration = 2500, onHide }: ToastProps)
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    top: 0,
-    bottom: 0,
     left: 0,
     right: 0,
     zIndex: 100,
-    justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: 16,
+  },
+  centerContainer: {
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+  },
+  topContainer: {
+    justifyContent: 'flex-start',
   },
   toast: {
     flexDirection: 'row',

--- a/context/saved-links-context.tsx
+++ b/context/saved-links-context.tsx
@@ -1,177 +1,239 @@
-import { createContext, useCallback, useContext, useState } from 'react';
+import { useAuth } from '@clerk/expo';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-// ERD: SAVED_LINK JOIN ANALYSIS / API 명세 4.2 응답 구조 기반
+import {
+  createSavedLink,
+  deleteSavedLink,
+  fetchSavedLinks,
+  toggleSavedLinkBookmark,
+  updateSavedLinkCategory,
+  updateSavedLinkTitle,
+  type SavedLinkCreateRequest,
+  type SavedLinkListQuery,
+  type SavedLinkResponse,
+} from '@/api/saved-links';
+import { getSiteName } from '@/utils/analysis-result-display';
 
-export interface SavedLink {
-  id: number;
-  analysisId: string;
-  categoryId: number | null;
-  originalUrl: string;
-  finalUrl: string | null;
-  title: string;
+const DEFAULT_PAGE_SIZE = 50;
+const LOGIN_REQUIRED_MESSAGE =
+  '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+
+export interface SavedLink extends SavedLinkResponse {
   description: string;
   siteName: string;
-  verdict: 'safe' | 'caution' | 'danger';
-  isBookmarked: boolean;
-  createdAt: string;
 }
 
 interface SavedLinksContextValue {
   links: SavedLink[];
-  addLink: (link: SavedLink) => void;
-  toggleBookmark: (id: number) => void;
-  deleteLink: (id: number) => void;
-  assignCategory: (ids: number[], categoryId: number | null) => void;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  errorMessage: string;
+  hasNext: boolean;
+  nextCursor: string | null;
+  refreshLinks: (query?: SavedLinkListQuery) => Promise<void>;
+  loadMoreLinks: () => Promise<void>;
+  addLink: (request: SavedLinkCreateRequest) => Promise<SavedLink>;
+  toggleBookmark: (id: number) => Promise<void>;
+  deleteLink: (id: number) => Promise<void>;
+  updateTitle: (id: number, title: string) => Promise<void>;
+  assignCategory: (ids: number[], categoryId: number | null) => Promise<void>;
 }
-
-// ─── Mock Data ────────────────────────────────────────────────────────────────
-// 실제 구현 시 GET /api/v1/saved-links 응답으로 교체
-
-const MOCK_LINKS: SavedLink[] = [
-  {
-    id: 1,
-    analysisId: 'a1b2c3d4-0001-0001-0001-000000000001',
-    categoryId: 1,
-    originalUrl: 'https://blog.naver.com/food1',
-    finalUrl: 'https://blog.naver.com/food1',
-    title: '용인시장 맛집 Top 100',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'NAVER',
-    verdict: 'safe',
-    isBookmarked: false,
-    createdAt: '2026-04-24T10:00:00Z',
-  },
-  {
-    id: 2,
-    analysisId: 'a1b2c3d4-0002-0002-0002-000000000002',
-    categoryId: 1,
-    originalUrl: 'https://blog.naver.com/food2',
-    finalUrl: 'https://blog.naver.com/food2',
-    title: '명지대학교 맛집',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'NAVER',
-    verdict: 'safe',
-    isBookmarked: true,
-    createdAt: '2026-04-24T09:00:00Z',
-  },
-  {
-    id: 3,
-    analysisId: 'a1b2c3d4-0003-0003-0003-000000000003',
-    categoryId: 2,
-    originalUrl: 'https://blog.naver.com/study1',
-    finalUrl: 'https://blog.naver.com/study1',
-    title: '알고리즘 이론',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'NAVER',
-    verdict: 'safe',
-    isBookmarked: false,
-    createdAt: '2026-04-24T08:00:00Z',
-  },
-  {
-    id: 4,
-    analysisId: 'a1b2c3d4-0004-0004-0004-000000000004',
-    categoryId: 2,
-    originalUrl: 'https://velog.io/typescript',
-    finalUrl: 'https://velog.io/typescript',
-    title: 'TypeScript 완전 정복',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'Velog',
-    verdict: 'safe',
-    isBookmarked: true,
-    createdAt: '2026-04-23T10:00:00Z',
-  },
-  {
-    id: 5,
-    analysisId: 'a1b2c3d4-0005-0005-0005-000000000005',
-    categoryId: null,
-    originalUrl: 'https://www.notion.so/LinClean',
-    finalUrl: 'https://www.notion.so/LinClean',
-    title: 'LinClean 기획서',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'Notion',
-    verdict: 'caution',
-    isBookmarked: true,
-    createdAt: '2026-04-23T08:00:00Z',
-  },
-  {
-    id: 6,
-    analysisId: 'a1b2c3d4-0006-0006-0006-000000000006',
-    categoryId: 3,
-    originalUrl: 'https://blog.naver.com/invest1',
-    finalUrl: 'https://blog.naver.com/invest1',
-    title: '주식 투자 꿀팁 모음',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'NAVER',
-    verdict: 'safe',
-    isBookmarked: false,
-    createdAt: '2026-04-22T10:00:00Z',
-  },
-  {
-    id: 7,
-    analysisId: 'a1b2c3d4-0007-0007-0007-000000000007',
-    categoryId: 2,
-    originalUrl: 'https://youtube.com/rn',
-    finalUrl: 'https://youtube.com/rn',
-    title: 'React Native 강의',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'YouTube',
-    verdict: 'safe',
-    isBookmarked: true,
-    createdAt: '2026-04-22T08:00:00Z',
-  },
-  {
-    id: 8,
-    analysisId: 'a1b2c3d4-0008-0008-0008-000000000008',
-    categoryId: null,
-    originalUrl: 'https://github.com/expo-router',
-    finalUrl: 'https://github.com/expo-router',
-    title: 'Expo Router 공식 문서',
-    description: '요약된 한줄짜리 글~',
-    siteName: 'GitHub',
-    verdict: 'safe',
-    isBookmarked: false,
-    createdAt: '2026-04-21T10:00:00Z',
-  },
-];
-
-// ─── Context ──────────────────────────────────────────────────────────────────
 
 const SavedLinksContext = createContext<SavedLinksContextValue | null>(null);
 
 export function SavedLinksProvider({ children }: { children: React.ReactNode }) {
-  const [links, setLinks] = useState<SavedLink[]>(MOCK_LINKS);
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+  const [links, setLinks] = useState<SavedLink[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [hasNext, setHasNext] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const lastQueryRef = useRef<SavedLinkListQuery>({ size: DEFAULT_PAGE_SIZE });
+  const getTokenRef = useRef(getToken);
 
-  const addLink = useCallback((link: SavedLink) => {
-    // TODO: 백엔드 연동 시 POST /api/v1/saved-links { analysisId } 호출 후 응답으로 교체
-    setLinks((prev) => [link, ...prev]);
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
+
+  const refreshLinks = useCallback(
+    async (query: SavedLinkListQuery = {}) => {
+      if (!isLoaded) {
+        return;
+      }
+
+      if (!isSignedIn) {
+        setLinks([]);
+        setErrorMessage(LOGIN_REQUIRED_MESSAGE);
+        setHasNext(false);
+        setNextCursor(null);
+        return;
+      }
+
+      const nextQuery = { size: DEFAULT_PAGE_SIZE, ...query, cursor: null };
+      lastQueryRef.current = nextQuery;
+      setIsLoading(true);
+      setErrorMessage('');
+
+      try {
+        const response = await fetchSavedLinks(() => getTokenRef.current(), nextQuery);
+        setLinks(response.items.map(normalizeSavedLink));
+        setHasNext(response.hasNext);
+        setNextCursor(response.nextCursor);
+      } catch (error) {
+        setErrorMessage(getSavedLinkErrorMessage(error, '저장한 링크를 불러오지 못했습니다.'));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [isLoaded, isSignedIn],
+  );
+
+  const loadMoreLinks = useCallback(async () => {
+    if (!isLoaded || !isSignedIn || !hasNext || !nextCursor || isLoadingMore) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    setErrorMessage('');
+
+    try {
+      const response = await fetchSavedLinks(() => getTokenRef.current(), {
+        ...lastQueryRef.current,
+        cursor: nextCursor,
+      });
+
+      setLinks((prev) => mergeLinks(prev, response.items.map(normalizeSavedLink)));
+      setHasNext(response.hasNext);
+      setNextCursor(response.nextCursor);
+    } catch (error) {
+      setErrorMessage(getSavedLinkErrorMessage(error, '저장한 링크를 더 불러오지 못했습니다.'));
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [hasNext, isLoaded, isLoadingMore, isSignedIn, nextCursor]);
+
+  useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!isSignedIn) {
+      setLinks([]);
+      setHasNext(false);
+      setNextCursor(null);
+      setErrorMessage('');
+      return;
+    }
+
+    void refreshLinks();
+  }, [isLoaded, isSignedIn, refreshLinks]);
+
+  const addLink = useCallback(async (request: SavedLinkCreateRequest) => {
+    const savedLink = normalizeSavedLink(
+      await createSavedLink(() => getTokenRef.current(), request),
+    );
+    setLinks((prev) => [savedLink, ...prev.filter((link) => link.id !== savedLink.id)]);
+    return savedLink;
   }, []);
 
-  const toggleBookmark = useCallback((id: number) => {
-    // 실제 구현 시 PATCH /api/v1/saved-links/{id}/bookmark 호출
+  const toggleBookmark = useCallback(async (id: number) => {
+    const previousLinks = links;
     setLinks((prev) =>
       prev.map((link) =>
-        link.id === id ? { ...link, isBookmarked: !link.isBookmarked } : link
-      )
+        link.id === id ? { ...link, isBookmarked: !link.isBookmarked } : link,
+      ),
     );
-  }, []);
 
-  const deleteLink = useCallback((id: number) => {
-    // 실제 구현 시 DELETE /api/v1/saved-links/{id} 호출
+    try {
+      const response = await toggleSavedLinkBookmark(() => getTokenRef.current(), id);
+      setLinks((prev) =>
+        prev.map((link) =>
+          link.id === id ? { ...link, isBookmarked: response.isBookmarked } : link,
+        ),
+      );
+    } catch (error) {
+      setLinks(previousLinks);
+      throw error;
+    }
+  }, [links]);
+
+  const deleteLink = useCallback(async (id: number) => {
+    const previousLinks = links;
     setLinks((prev) => prev.filter((link) => link.id !== id));
-  }, []);
 
-  const assignCategory = useCallback((ids: number[], categoryId: number | null) => {
-    // 실제 구현 시 ids.forEach → PATCH /api/v1/saved-links/{id} { categoryId } 호출
+    try {
+      await deleteSavedLink(() => getTokenRef.current(), id);
+    } catch (error) {
+      setLinks(previousLinks);
+      throw error;
+    }
+  }, [links]);
+
+  const updateTitle = useCallback(async (id: number, title: string) => {
+    const previousLinks = links;
     setLinks((prev) =>
-      prev.map((link) =>
-        ids.includes(link.id) ? { ...link, categoryId } : link
-      )
+      prev.map((link) => (link.id === id ? { ...link, title } : link)),
     );
-  }, []);
+
+    try {
+      const response = await updateSavedLinkTitle(() => getTokenRef.current(), id, title);
+      setLinks((prev) =>
+        prev.map((link) =>
+          link.id === id ? { ...link, title: response.title } : link,
+        ),
+      );
+    } catch (error) {
+      setLinks(previousLinks);
+      throw error;
+    }
+  }, [links]);
+
+  const assignCategory = useCallback(async (ids: number[], categoryId: number | null) => {
+    if (ids.length === 0) {
+      return;
+    }
+
+    const previousLinks = links;
+    setLinks((prev) =>
+      prev.map((link) => (ids.includes(link.id) ? { ...link, categoryId } : link)),
+    );
+
+    try {
+      const responses = await Promise.all(
+        ids.map((id) => updateSavedLinkCategory(() => getTokenRef.current(), id, categoryId)),
+      );
+
+      setLinks((prev) =>
+        prev.map((link) => {
+          const response = responses.find((item) => item.id === link.id);
+          return response ? { ...link, categoryId: response.categoryId } : link;
+        }),
+      );
+    } catch (error) {
+      setLinks(previousLinks);
+      throw error;
+    }
+  }, [links]);
 
   return (
-    <SavedLinksContext.Provider value={{ links, addLink, toggleBookmark, deleteLink, assignCategory }}>
+    <SavedLinksContext.Provider
+      value={{
+        links,
+        isLoading,
+        isLoadingMore,
+        errorMessage,
+        hasNext,
+        nextCursor,
+        refreshLinks,
+        loadMoreLinks,
+        addLink,
+        toggleBookmark,
+        deleteLink,
+        updateTitle,
+        assignCategory,
+      }}
+    >
       {children}
     </SavedLinksContext.Provider>
   );
@@ -181,4 +243,40 @@ export function useSavedLinks(): SavedLinksContextValue {
   const ctx = useContext(SavedLinksContext);
   if (!ctx) throw new Error('useSavedLinks must be used within SavedLinksProvider');
   return ctx;
+}
+
+export function getSavedLinkErrorMessage(error: unknown, fallbackMessage: string) {
+  if (error instanceof Error) {
+    if (error.message === 'Missing Clerk session token') {
+      return LOGIN_REQUIRED_MESSAGE;
+    }
+
+    if (error.message) {
+      return error.message;
+    }
+  }
+
+  return fallbackMessage;
+}
+
+function normalizeSavedLink(link: SavedLinkResponse): SavedLink {
+  const displayUrl = link.finalUrl ?? link.originalUrl;
+
+  return {
+    ...link,
+    finalUrl: link.finalUrl ?? null,
+    categoryId: link.categoryId ?? null,
+    description: link.description ?? '',
+    siteName: getSiteName(displayUrl),
+  };
+}
+
+function mergeLinks(previousLinks: SavedLink[], nextLinks: SavedLink[]) {
+  const linkMap = new Map<number, SavedLink>();
+
+  [...previousLinks, ...nextLinks].forEach((link) => {
+    linkMap.set(link.id, link);
+  });
+
+  return [...linkMap.values()];
 }


### PR DESCRIPTION
Closes #45

## 개요
safe/caution 검사 결과 화면과 저장 링크 목록 화면에서 기존 mock 기반 저장 링크 흐름을 실제 백엔드 Saved Link API 연동 흐름으로 교체했습니다.

분석 완료 후 전달받은 `analysisId`를 기준으로 `POST /api/v1/saved-links`를 호출해 링크를 저장하고, 저장 링크 목록은 `GET /api/v1/saved-links` 응답의 `items`, `hasNext`, `nextCursor` 구조를 기준으로 표시하도록 정리했습니다.

또한 저장 링크 카드의 더보기 메뉴에서 기존 `북마크 추가` 항목을 `제목 수정`으로 변경하고, 제목 수정 모달을 통해 `PATCH /api/v1/saved-links/{id}/title` API와 연동했습니다. 북마크 변경과 링크 삭제 역시 각각 `PATCH /api/v1/saved-links/{id}/bookmark`, `DELETE /api/v1/saved-links/{id}` API 호출 결과를 화면 상태에 반영하도록 변경했습니다.

## 주요 구현 내용
- 저장 링크 API 전용 파일 `api/saved-links.ts` 추가
- `POST /api/v1/saved-links` 저장 API 연동
- `GET /api/v1/saved-links` 목록 조회 API 연동
- `DELETE /api/v1/saved-links/{id}` 삭제 API 연동
- `PATCH /api/v1/saved-links/{id}/bookmark` 북마크 변경 API 연동
- `PATCH /api/v1/saved-links/{id}/title` 제목 수정 API 연동
- 저장 링크 context의 mock 목록을 API 기반 상태로 교체
- 목록 응답의 `items`, `hasNext`, `nextCursor` 상태 반영
- 저장 링크 목록 로딩, 빈 목록, API 에러, 더 불러오기 상태 처리
- safe/caution 결과 화면에서 `analysisId`, `categoryId`, `title`, `description` 구조로 저장 요청
- 저장 중 중복 클릭 방지
- danger 결과 화면에는 저장 기능 미추가
- 저장/삭제/제목 수정 성공 시 상단 토스트 표시
- 제목 수정 모달에서 현재 제목을 초기값으로 표시
- 제목이 비어 있거나 500자를 초과하거나 기존 제목과 동일하면 저장 버튼 비활성화
- 공용 `Toast` 컴포넌트에 `placement`, `topOffset` 옵션 추가

## 파일별 역할
- `api/saved-links.ts`: 저장 링크 생성/조회/삭제/북마크/카테고리/제목 수정 API 타입 및 호출 함수 추가
- `context/saved-links-context.tsx`: 저장 링크 API 기반 목록 상태, pagination 상태, 저장/북마크/삭제/제목 수정 액션 관리
- `app/(tabs)/(home)/scan-result.tsx`: 안전 결과 화면의 실제 저장 API 호출, 저장 중 상태, 저장 성공 후 홈 이동 및 토스트 처리
- `app/(tabs)/(home)/scan-result-caution.tsx`: 주의 결과 화면의 실제 저장 API 호출, 저장 중 상태, 저장 성공 후 홈 이동 및 토스트 처리
- `app/(tabs)/(home)/saved-links.tsx`: 저장 링크 목록 조회 상태 표시, 북마크/삭제/제목 수정 API 연동, 제목 수정 모달 및 토스트 처리
- `app/(tabs)/(home)/index.tsx`: 홈 최근 저장 링크 카드의 제목 수정/삭제/북마크 흐름 및 토스트 처리
- `components/ui/link-save-modal.tsx`: 저장 중 상태, 500자 제목 제한, 중복 저장 클릭 방지 UI 반영
- `components/ui/toast.tsx`: 상단 배치 옵션 및 offset 옵션 추가

## 해결한 이슈 목록
- [x] safe 결과 링크 저장 흐름 확인 및 실제 저장 API 연동
- [x] caution 결과 링크 저장 흐름 확인 및 실제 저장 API 연동
- [x] 결과 화면에서 전달받은 `analysisId`로 `POST /api/v1/saved-links` 호출
- [x] 저장 요청 구조를 `analysisId`, `categoryId`, `title`, `description`으로 구성
- [x] 저장 성공/실패/중복 저장/API 에러 피드백 처리
- [x] 저장 중 버튼 중복 클릭 방지
- [x] danger 결과 화면에는 저장 기능 미추가
- [x] `saved-links-context.tsx`의 mock 저장 링크 상태를 API 기반 상태로 교체
- [x] 저장 링크 목록 조회를 `GET /api/v1/saved-links`와 연동
- [x] 목록 응답의 `items`, `hasNext`, `nextCursor` 구조 반영
- [x] 목록 로딩/빈 목록/API 에러 상태 처리
- [x] 북마크 변경을 `PATCH /api/v1/saved-links/{id}/bookmark`와 연동
- [x] 북마크 변경 성공 시 응답의 `isBookmarked` 값 반영
- [x] 링크 삭제를 `DELETE /api/v1/saved-links/{id}`와 연동
- [x] 삭제 성공 시 목록에서 해당 링크 제거
- [x] 북마크/삭제 실패 시 기존 상태로 rollback 처리
- [x] 더보기 메뉴의 `북마크 추가` 항목을 `제목 수정`으로 변경
- [x] `제목 수정` 클릭 시 폴더명 수정과 동일한 형태의 모달 표시
- [x] 제목 수정 모달에서 현재 링크 제목을 초기값으로 표시
- [x] 입력한 제목으로 `PATCH /api/v1/saved-links/{id}/title` 호출
- [x] 제목 수정 성공 시 응답의 `title` 값을 목록/context 상태에 반영
- [x] 빈 제목, 500자 초과, 중복 제목 등 에러 상황 안내 또는 저장 비활성화 처리
- [x] 제목 수정 취소 시 기존 제목과 목록 상태 유지
- [x] issue #41 공통 API 클라이언트 패턴 준수
- [x] 기능별 API 파일에서 API base URL 새로 생성하지 않음
- [x] 기능별 API 파일에서 `fetch()` 직접 호출하지 않음
- [x] 기능별 API 파일에서 `Authorization` 헤더 직접 주입하지 않음
- [x] 기능별 API 파일에서 `{ data: ... }` 응답 직접 unwrap하지 않음
- [x] Clerk 세션 토큰이 필요한 API는 `authenticatedApiRequest` 사용
- [x] 보호 API 호출이 `/auth/me` 수동 사전 호출에 의존하지 않음
- [x] `204 No Content` 삭제 API가 공통 클라이언트 흐름에서 처리되도록 구성

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 프론트 API 클라이언트 사용 규칙 준수
- [x] 저장 링크 API 파일에서 직접 `fetch()` 호출 없음
- [x] 저장 링크 API 파일에서 직접 API base URL 생성 없음
- [x] 저장 링크 API 파일에서 직접 `Authorization` 헤더 주입 없음
- [x] 저장 링크 API 파일에서 `{ data: ... }` 응답 직접 unwrap 없음

## 참고
카테고리/폴더 API 실제 연동은 이번 PR 범위에서 제외했습니다.

저장 링크 목록 화면의 폴더 필터 칩은 기존 화면 흐름을 유지하되, 저장 링크 API 호출 함수에서는 `categoryId`, `bookmarked`, `cursor`, `size` query를 지원하도록 준비했습니다.

`DELETE /api/v1/saved-links/{id}`는 백엔드가 `204 No Content`를 반환하는 계약이므로, 공통 API 클라이언트의 `204` 처리 흐름을 그대로 사용합니다.

## 스크린샷
- 북마크 추가 버튼 대신 제목 수정 버튼을 삽입
<img width="499" height="1023" alt="image" src="https://github.com/user-attachments/assets/8b7db8e9-71a1-4e80-86f1-31d944661137" />

- 링크 삭제 누를 때 뜨는 확인창
<img width="500" height="1011" alt="image" src="https://github.com/user-attachments/assets/d4daf0a9-0c95-4942-bf3a-56637292a8a6" />

- 삭제 후 뜨는 toast 화면
<img width="493" height="1019" alt="image" src="https://github.com/user-attachments/assets/55b470c8-b4d2-4bf3-9bff-f51a2d39fcf0" />

