### PR TITLE
[FEATURE] 회원 탈퇴 API 연동

### DIFF
--- a/api/members.ts
+++ b/api/members.ts
@@ -1,0 +1,10 @@
+import {
+  authenticatedApiRequest,
+  type ClerkTokenGetter,
+} from '@/api/api-client';
+
+export function withdrawMember(getToken: ClerkTokenGetter) {
+  return authenticatedApiRequest<void>(getToken, '/api/v1/members/me', {
+    method: 'DELETE',
+  });
+}

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { ApiError } from '@/api/api-client';
 import { SocialLoginButton } from '@/components/ui/social-login-button';
 import { Colors, Typography } from '@/constants/theme';
 import { syncAuthenticatedMember } from '@/services/auth-api';
@@ -18,6 +19,7 @@ const CLERK_REDIRECT_URL = AuthSession.makeRedirectUri({
   scheme: 'linclean',
   path: 'sso-callback',
 });
+const MEMBER_SYNC_RETRY_DELAYS_MS = [200, 500, 1000];
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -48,24 +50,15 @@ export default function LoginScreen() {
 
       await setActive({ session: createdSessionId });
       sessionActivated = true;
-      await syncAuthenticatedMember(getToken);
-
-      const sharedUrl = hasShareIntent ? getSharedUrlFromIntent(shareIntent) : null;
-
-      if (hasShareIntent) {
-        resetShareIntent(true);
-      }
-
-      if (sharedUrl) {
-        router.replace({
-          pathname: '/(tabs)/(home)/add-link',
-          params: { sharedUrl },
-        });
-      } else {
-        router.replace('/(tabs)/(home)');
-      }
+      await syncAuthenticatedMemberAfterSso();
+      navigateAfterSuccessfulLogin();
     } catch (error) {
       console.error(error);
+
+      if (error instanceof ApiError && error.status === 401) {
+        navigateAfterSuccessfulLogin();
+        return;
+      }
 
       if (sessionActivated) {
         try {
@@ -83,6 +76,49 @@ export default function LoginScreen() {
       setIsSigningIn(false);
     }
   };
+
+  function navigateAfterSuccessfulLogin() {
+    const sharedUrl = hasShareIntent ? getSharedUrlFromIntent(shareIntent) : null;
+
+    if (hasShareIntent) {
+      resetShareIntent(true);
+    }
+
+    if (sharedUrl) {
+      router.replace({
+        pathname: '/(tabs)/(home)/add-link',
+        params: { sharedUrl },
+      });
+    } else {
+      router.replace('/(tabs)/(home)');
+    }
+  }
+
+  async function syncAuthenticatedMemberAfterSso() {
+    let lastError: unknown;
+
+    for (const retryDelayMs of MEMBER_SYNC_RETRY_DELAYS_MS) {
+      await delay(retryDelayMs);
+
+      try {
+        return await syncAuthenticatedMember(() => getToken({ skipCache: true }));
+      } catch (error) {
+        lastError = error;
+
+        if (!(error instanceof ApiError) || error.status !== 401) {
+          throw error;
+        }
+      }
+    }
+
+    throw lastError;
+  }
+
+  function delay(ms: number) {
+    return new Promise<void>((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
 
   return (
     <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,10 +1,10 @@
 import { useAuth, useSSO } from '@clerk/expo';
 import * as AuthSession from 'expo-auth-session';
 import { Image } from 'expo-image';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useShareIntentContext } from 'expo-share-intent';
 import * as WebBrowser from 'expo-web-browser';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -23,12 +23,41 @@ const MEMBER_SYNC_RETRY_DELAYS_MS = [200, 500, 1000];
 
 WebBrowser.maybeCompleteAuthSession();
 
+type LoginNotice = 'withdrawal-complete' | 'session-expired';
+
+const LOGIN_NOTICE_ALERTS: Record<LoginNotice, { title: string; message: string }> = {
+  'withdrawal-complete': {
+    title: '회원탈퇴 완료',
+    message: '회원탈퇴가 완료되었습니다.',
+  },
+  'session-expired': {
+    title: '세션 만료',
+    message: '현재 세션이 유효하지 않아 로그인 화면으로 이동합니다.',
+  },
+};
+
 export default function LoginScreen() {
   const insets = useSafeAreaInsets();
   const { getToken, signOut } = useAuth();
   const { startSSOFlow } = useSSO();
   const { hasShareIntent, resetShareIntent, shareIntent } = useShareIntentContext();
+  const { notice } = useLocalSearchParams<{ notice?: LoginNotice }>();
+  const shownNoticeRef = useRef<LoginNotice | null>(null);
   const [isSigningIn, setIsSigningIn] = useState(false);
+
+  useEffect(() => {
+    if (!notice || shownNoticeRef.current === notice) {
+      return;
+    }
+
+    const alert = LOGIN_NOTICE_ALERTS[notice];
+    if (!alert) {
+      return;
+    }
+
+    shownNoticeRef.current = notice;
+    Alert.alert(alert.title, alert.message);
+  }, [notice]);
 
   const handleGoogleLogin = async () => {
     if (isSigningIn) {

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -36,6 +36,12 @@ const LOGIN_NOTICE_ALERTS: Record<LoginNotice, { title: string; message: string 
   },
 };
 
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 export default function LoginScreen() {
   const insets = useSafeAreaInsets();
   const { getToken, signOut } = useAuth();
@@ -136,12 +142,6 @@ export default function LoginScreen() {
     }
 
     throw lastError;
-  }
-
-  function delay(ms: number) {
-    return new Promise<void>((resolve) => {
-      setTimeout(resolve, ms);
-    });
   }
 
   return (

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -84,11 +84,6 @@ export default function LoginScreen() {
     } catch (error) {
       console.error(error);
 
-      if (error instanceof ApiError && error.status === 401) {
-        navigateAfterSuccessfulLogin();
-        return;
-      }
-
       if (sessionActivated) {
         try {
           await signOut();

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -57,7 +57,7 @@ export default function SettingsScreen() {
         style: 'destructive',
         onPress: async () => {
           await signOut();
-          router.replace('/login' as any);
+          router.replace('/(auth)/login');
         },
       },
     ]);
@@ -121,7 +121,7 @@ export default function SettingsScreen() {
   }
 
   function goToLoginWithAlert(title: string, message: string) {
-    router.replace('/login' as any);
+    router.replace('/(auth)/login');
     setTimeout(() => {
       Alert.alert(title, message);
     }, 0);

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -12,6 +12,7 @@ import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
 
 const version = Constants.expoConfig?.version ?? '—';
+type LoginNotice = 'withdrawal-complete' | 'session-expired';
 
 function SectionLabel({ label }: { label: string }) {
   return <Text style={styles.sectionLabel}>{label}</Text>;
@@ -93,13 +94,13 @@ export default function SettingsScreen() {
     try {
       await withdrawMember(getToken);
       await signOutSafely();
-      goToLoginWithAlert('회원탈퇴 완료', '회원탈퇴가 완료되었습니다.');
+      goToLoginWithNotice('withdrawal-complete');
     } catch (error) {
       console.error(error);
 
       if (error instanceof ApiError && error.status === 401) {
         await signOutSafely();
-        goToLoginWithAlert('세션 만료', '현재 세션이 유효하지 않아 로그인 화면으로 이동합니다.');
+        goToLoginWithNotice('session-expired');
         return;
       }
 
@@ -120,11 +121,11 @@ export default function SettingsScreen() {
     }
   }
 
-  function goToLoginWithAlert(title: string, message: string) {
-    router.replace('/(auth)/login');
-    setTimeout(() => {
-      Alert.alert(title, message);
-    }, 0);
+  function goToLoginWithNotice(notice: LoginNotice) {
+    router.replace({
+      pathname: '/(auth)/login',
+      params: { notice },
+    });
   }
 
   return (

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -93,13 +93,13 @@ export default function SettingsScreen() {
     try {
       await withdrawMember(getToken);
       await signOutSafely();
-      showLoginAlert('회원탈퇴 완료', '회원탈퇴가 완료되었습니다.');
+      goToLoginWithAlert('회원탈퇴 완료', '회원탈퇴가 완료되었습니다.');
     } catch (error) {
       console.error(error);
 
       if (error instanceof ApiError && error.status === 401) {
         await signOutSafely();
-        showLoginAlert('세션 만료', '현재 세션이 유효하지 않아 로그인 화면으로 이동합니다.');
+        goToLoginWithAlert('세션 만료', '현재 세션이 유효하지 않아 로그인 화면으로 이동합니다.');
         return;
       }
 
@@ -120,13 +120,11 @@ export default function SettingsScreen() {
     }
   }
 
-  function showLoginAlert(title: string, message: string) {
-    Alert.alert(title, message, [
-      {
-        text: '확인',
-        onPress: () => router.replace('/login' as any),
-      },
-    ]);
+  function goToLoginWithAlert(title: string, message: string) {
+    router.replace('/login' as any);
+    setTimeout(() => {
+      Alert.alert(title, message);
+    }, 0);
   }
 
   return (

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -1,9 +1,12 @@
 import { useAuth } from '@clerk/expo';
 import Constants from 'expo-constants';
 import { router } from 'expo-router';
+import { useRef, useState } from 'react';
 import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { ApiError } from '@/api/api-client';
+import { withdrawMember } from '@/api/members';
 import { AppIcon } from '@/components/ui/app-icon';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
@@ -42,7 +45,9 @@ function SettingRow({ label, onPress, rightText, destructive = false, showChevro
 }
 
 export default function SettingsScreen() {
-  const { signOut } = useAuth();
+  const { getToken, signOut } = useAuth();
+  const [isWithdrawing, setIsWithdrawing] = useState(false);
+  const isWithdrawingRef = useRef(false);
 
   function handleLogout() {
     Alert.alert('로그아웃', '로그아웃하시겠습니까?', [
@@ -54,6 +59,72 @@ export default function SettingsScreen() {
           await signOut();
           router.replace('/login' as any);
         },
+      },
+    ]);
+  }
+
+  function handleWithdraw() {
+    if (isWithdrawingRef.current) {
+      return;
+    }
+
+    Alert.alert(
+      '회원탈퇴',
+      '회원탈퇴하시겠습니까? 탈퇴 후에는 현재 계정으로 서비스를 이용할 수 없습니다.',
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '회원탈퇴',
+          style: 'destructive',
+          onPress: withdrawAccount,
+        },
+      ],
+    );
+  }
+
+  async function withdrawAccount() {
+    if (isWithdrawingRef.current) {
+      return;
+    }
+
+    isWithdrawingRef.current = true;
+    setIsWithdrawing(true);
+
+    try {
+      await withdrawMember(getToken);
+      await signOutSafely();
+      showLoginAlert('회원탈퇴 완료', '회원탈퇴가 완료되었습니다.');
+    } catch (error) {
+      console.error(error);
+
+      if (error instanceof ApiError && error.status === 401) {
+        await signOutSafely();
+        showLoginAlert('세션 만료', '현재 세션이 유효하지 않아 로그인 화면으로 이동합니다.');
+        return;
+      }
+
+      isWithdrawingRef.current = false;
+      setIsWithdrawing(false);
+      Alert.alert(
+        '회원탈퇴 실패',
+        '회원탈퇴 처리 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+    }
+  }
+
+  async function signOutSafely() {
+    try {
+      await signOut();
+    } catch (signOutError) {
+      console.error(signOutError);
+    }
+  }
+
+  function showLoginAlert(title: string, message: string) {
+    Alert.alert(title, message, [
+      {
+        text: '확인',
+        onPress: () => router.replace('/login' as any),
       },
     ]);
   }
@@ -113,7 +184,12 @@ export default function SettingsScreen() {
         <View style={styles.group}>
           <SettingRow label="로그아웃" onPress={handleLogout} />
           <View style={styles.divider} />
-          <SettingRow label="회원탈퇴" destructive />
+          <SettingRow
+            label="회원탈퇴"
+            destructive
+            rightText={isWithdrawing ? '처리 중' : undefined}
+            onPress={isWithdrawing ? undefined : handleWithdraw}
+          />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -98,7 +98,7 @@ export default function TabLayout() {
         if (isMounted) {
           syncedSessionIdRef.current = null;
           setHasSyncedMember(false);
-          router.replace('/login' as any);
+          router.replace('/(auth)/login');
         }
       });
 


### PR DESCRIPTION
Closes #49

## 개요
설정 화면의 회원탈퇴 버튼을 백엔드 Member API와 연결했습니다.

기존 `app/(tabs)/(home)/settings.tsx`의 회원탈퇴 row는 destructive 스타일만 적용되어 있고 실제 동작은 없었습니다. 이번 작업에서는 `DELETE /api/v1/members/me` API를 호출하도록 연결하고, 성공 시 Clerk 로컬 세션을 정리한 뒤 로그인 화면으로 이동하도록 구현했습니다.

회원 탈퇴 API는 백엔드 `dev` 기준 Clerk 인증 토큰이 필요한 보호 API이므로, issue #41에서 정리한 공통 API 클라이언트 패턴을 따라 `authenticatedApiRequest` 기반으로 호출합니다.

또한 탈퇴 후 같은 Google 계정으로 다시 로그인할 때 Clerk 세션 토큰 갱신 타이밍 때문에 `/auth/me` 동기화가 일시적으로 `401`을 반환할 수 있어, 로그인 직후 member 동기화에서 새 토큰을 재요청하고 재시도하도록 보완했습니다.

## 주요 구현 내용
- 회원 API 전용 파일 `api/members.ts` 추가
- `DELETE /api/v1/members/me` 회원 탈퇴 API 연동
- Clerk `getToken()` 기반 보호 API 호출 적용
- 회원탈퇴 버튼 클릭 시 확인 Alert 표시
- 사용자가 확인한 경우에만 회원 탈퇴 API 호출
- 회원탈퇴 API 호출 중 중복 클릭 방지
- 탈퇴 성공 시 Clerk `signOut()` 후 로그인 화면 이동
- 탈퇴 성공 안내 Alert 표시
- 탈퇴 실패 시 실패 Alert 표시 및 기존 세션 유지
- 회원 탈퇴 요청에서 `401 Unauthorized` 발생 시 세션 무효 상태로 보고 `signOut()` 후 로그인 화면 이동
- 탈퇴 완료 Alert 확인 후 로그인 화면이 다시 로드되는 느낌이 없도록, 로그인 화면 이동 후 Alert 표시 흐름으로 정리
- 탈퇴 후 재로그인 시 stale token으로 인한 `/auth/me` 401이 로그인 실패 Alert로 노출되지 않도록 보완
- SSO 직후 member 동기화에서 `getToken({ skipCache: true })` 기반 재시도 처리
- 공유 인텐트로 진입한 로그인 흐름의 기존 라우팅 유지

## 파일별 역할
- `api/members.ts`: 회원 탈퇴 API 타입 및 호출 함수 추가
- `app/(tabs)/(home)/settings.tsx`: 회원탈퇴 버튼 동작, 확인/성공/실패 Alert, 중복 호출 방지, 세션 정리 및 로그인 이동 처리
- `app/(auth)/login.tsx`: 탈퇴 후 재로그인 시 새 세션 토큰 기반 member 동기화 재시도 및 stale token 401 대응

## 해결한 이슈 목록
- [x] 현재 `app/(tabs)/(home)/settings.tsx`의 회원탈퇴 버튼 구조 확인
- [x] `api/members.ts`를 추가하고 회원 탈퇴 API 호출 함수를 분리
- [x] `DELETE /api/v1/members/me` 요청 시 Clerk `getToken()` 기반 인증 헤더 포함
- [x] 회원 탈퇴 API 호출에 `authenticatedApiRequest` 사용
- [x] 기능별 API 파일에서 API base URL을 새로 만들지 않음
- [x] 기능별 API 파일에서 `fetch()` 직접 호출하지 않음
- [x] 기능별 API 파일에서 `Authorization` 헤더 직접 주입하지 않음
- [x] `204 No Content` 응답을 공통 API 클라이언트 흐름에서 처리
- [x] 회원탈퇴 버튼 클릭 시 확인 Alert 표시
- [x] 사용자가 확인한 경우에만 회원 탈퇴 API 호출
- [x] API 호출 중 중복 클릭 방지
- [x] 탈퇴 성공 시 `signOut()`으로 Clerk 세션 정리 후 `/login` 이동
- [x] 탈퇴 실패 시 사용자에게 실패 안내 표시 및 세션 유지
- [x] 로그아웃 흐름과 회원탈퇴 흐름이 서로 영향 주지 않도록 분리
- [x] 네트워크 오류 등 탈퇴 처리 상태가 애매한 응답에서 세션 정리 여부와 사용자 안내 문구 검토
- [x] 회원 탈퇴 요청에서 `401 Unauthorized` 발생 시 세션 무효 상태로 보고 `signOut()` 후 로그인 화면 이동
- [x] 회원 탈퇴 API 성공 후 기존 Clerk 세션이 남지 않도록 `signOut()` 처리 보장

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 프론트 API 클라이언트 사용 규칙 준수
- [x] 회원 API 파일에서 직접 `fetch()` 호출 없음
- [x] 회원 API 파일에서 직접 API base URL 생성 없음
- [x] 회원 API 파일에서 직접 `Authorization` 헤더 주입 없음
- [x] 회원 API 파일에서 `{ data: ... }` 응답 직접 unwrap 없음
- [x] Clerk 세션 토큰이 필요한 API는 `authenticatedApiRequest` 사용
- [x] 보호 API 호출이 `/auth/me` 수동 사전 호출에 의존하지 않음
- [x] `204 No Content` 응답을 공통 API 클라이언트에서 처리

## 참고
백엔드 PR #35 기준 회원 탈퇴 API는 다음 계약을 사용합니다.

- `DELETE /api/v1/members/me`
- Clerk 인증 토큰 필요
- 성공 응답: `204 No Content`

백엔드의 회원 탈퇴는 member row를 즉시 물리 삭제하는 방식이 아니라 `deleted_at`을 채우는 soft delete 방식입니다. Clerk 계정 삭제가 성공하면 같은 Google 계정으로 재로그인 시 새 `clerk_id`가 발급되어 신규 회원처럼 생성됩니다.

이번 PR에서는 프론트에서 해당 API를 연결하고, 성공/실패/401 상태에 대한 사용자 흐름을 정리했습니다.

## Screenshots or Video
- 회원탈퇴 확인 Alert
<img width="502" height="1019" alt="image" src="https://github.com/user-attachments/assets/350a3a54-403c-414b-bc20-404127f650ed" />

- 회원탈퇴 완료 Alert
<img width="505" height="1016" alt="image" src="https://github.com/user-attachments/assets/51281f58-360a-4c98-ab42-2642b5bf9c8a" />

- 회원 DB에 정상적으로 들어오는 모습입니다.
<img width="955" height="292" alt="image" src="https://github.com/user-attachments/assets/2a86000c-f24c-4235-bdd4-343de466a104" />
