### PR TITLE
[FEATURE] 폴더 API 연동

### DIFF
--- a/api/categories.ts
+++ b/api/categories.ts
@@ -1,0 +1,71 @@
+import {
+  authenticatedApiRequest,
+  type ApiRequestOptions,
+  type ClerkTokenGetter,
+} from '@/api/api-client';
+
+export type CategoryResponse = {
+  id: number;
+  name: string;
+  displayOrder: number;
+  linkCount: number;
+  createdAt: string;
+};
+
+export type CategoryListResponse = {
+  items: CategoryResponse[];
+};
+
+export type CategoryCreateRequest = {
+  name: string;
+  linkIds?: number[];
+};
+
+export type CategoryRenameResponse = {
+  id: number;
+  name: string;
+};
+
+type CategoryRequestOptions = Pick<ApiRequestOptions, 'signal'>;
+
+export function createCategory(
+  getToken: ClerkTokenGetter,
+  body: CategoryCreateRequest,
+  options: CategoryRequestOptions = {},
+) {
+  return authenticatedApiRequest<CategoryResponse>(getToken, '/api/v1/categories', {
+    ...options,
+    method: 'POST',
+    body,
+  });
+}
+
+export function fetchCategories(
+  getToken: ClerkTokenGetter,
+  options: CategoryRequestOptions = {},
+) {
+  return authenticatedApiRequest<CategoryListResponse>(
+    getToken,
+    '/api/v1/categories',
+    options,
+  );
+}
+
+export function renameCategory(getToken: ClerkTokenGetter, id: number, name: string) {
+  return authenticatedApiRequest<CategoryRenameResponse>(
+    getToken,
+    `/api/v1/categories/${encodeURIComponent(String(id))}`,
+    {
+      method: 'PATCH',
+      body: { name },
+    },
+  );
+}
+
+export function deleteCategory(getToken: ClerkTokenGetter, id: number) {
+  return authenticatedApiRequest<void>(
+    getToken,
+    `/api/v1/categories/${encodeURIComponent(String(id))}`,
+    { method: 'DELETE' },
+  );
+}

--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -6,9 +6,10 @@ import { AddFolderButton } from '@/components/ui/add-folder-button';
 import { AppIcon } from '@/components/ui/app-icon';
 import { CardLink } from '@/components/ui/card-link';
 import { FolderContextMenu } from '@/components/ui/folder-context-menu';
+import { TitleEditModal } from '@/components/ui/title-edit-modal';
 import { Toast } from '@/components/ui/toast';
 import { Colors, Typography } from '@/constants/theme';
-import { getSavedLinkErrorMessage, useSavedLinks } from '@/context/saved-links-context';
+import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import { useFolders } from '@/context/folders-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { useEffect, useState } from 'react';
@@ -24,14 +25,16 @@ export default function FolderDetailScreen() {
   const router = useRouter();
   const folderId = Number(id);
 
-  const { links, toggleBookmark, assignCategory } = useSavedLinks();
+  const { links, toggleBookmark, assignCategory, updateTitle } = useSavedLinks();
   const { folders, refreshFolders } = useFolders();
   const folderLinks = links.filter((l) => l.categoryId === folderId);
   const folderName = folders.find((f) => f.id === folderId)?.name ?? '폴더';
 
   const [menuState, setMenuState] = useState<MoreMenuState>({ visible: false });
+  const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
   const [toastVisible, setToastVisible] = useState(false);
   const [addToastVisible, setAddToastVisible] = useState(false);
+  const [titleToastVisible, setTitleToastVisible] = useState(false);
 
   useEffect(() => {
     if (urlAdded === '1') setAddToastVisible(true);
@@ -79,6 +82,11 @@ export default function FolderDetailScreen() {
   };
 
   const currentLink = folderLinks.find((l) => l.id === menuState.linkId);
+
+  const handleTitleConfirm = async (linkId: number, title: string) => {
+    await updateTitle(linkId, title);
+    setTitleToastVisible(true);
+  };
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -146,11 +154,10 @@ export default function FolderDetailScreen() {
         anchor={menuState.anchor}
         items={[
           {
-            label: currentLink?.isBookmarked ? '북마크 해제' : '북마크 추가',
+            label: '제목 수정',
             onPress: () => {
-              if (menuState.linkId == null) return;
-              // API: PATCH /saved-links/{id}/bookmark
-              toggleBookmark(menuState.linkId);
+              if (!currentLink) return;
+              setEditingLink(currentLink);
             },
           },
           {
@@ -163,6 +170,20 @@ export default function FolderDetailScreen() {
           },
         ]}
         onDismiss={() => setMenuState({ visible: false })}
+      />
+
+      <TitleEditModal
+        editingLink={editingLink}
+        onConfirm={handleTitleConfirm}
+        onClose={() => setEditingLink(null)}
+      />
+
+      <Toast
+        visible={titleToastVisible}
+        message="제목이 수정되었습니다."
+        placement="top"
+        topOffset={96}
+        onHide={() => setTitleToastVisible(false)}
       />
     </SafeAreaView>
   );

--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -1,4 +1,4 @@
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
@@ -8,7 +8,7 @@ import { CardLink } from '@/components/ui/card-link';
 import { FolderContextMenu } from '@/components/ui/folder-context-menu';
 import { Toast } from '@/components/ui/toast';
 import { Colors, Typography } from '@/constants/theme';
-import { useSavedLinks } from '@/context/saved-links-context';
+import { getSavedLinkErrorMessage, useSavedLinks } from '@/context/saved-links-context';
 import { useFolders } from '@/context/folders-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { useEffect, useState } from 'react';
@@ -25,7 +25,7 @@ export default function FolderDetailScreen() {
   const folderId = Number(id);
 
   const { links, toggleBookmark, assignCategory } = useSavedLinks();
-  const { folders } = useFolders();
+  const { folders, refreshFolders } = useFolders();
   const folderLinks = links.filter((l) => l.categoryId === folderId);
   const folderName = folders.find((f) => f.id === folderId)?.name ?? '폴더';
 
@@ -41,10 +41,17 @@ export default function FolderDetailScreen() {
     setMenuState({ visible: true, anchor, linkId });
   };
 
-  const handleDelete = (linkId: number) => {
-    // API: PATCH /api/v1/saved-links/{id} { categoryId: null }
-    assignCategory([linkId], null);
-    setToastVisible(true);
+  const handleDelete = async (linkId: number) => {
+    try {
+      await assignCategory([linkId], null);
+      await refreshFolders();
+      setToastVisible(true);
+    } catch (error) {
+      Alert.alert(
+        '폴더에서 삭제 실패',
+        getSavedLinkErrorMessage(error, '링크를 폴더에서 제외하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
+    }
   };
 
   const handleAddUrl = () => {
@@ -134,8 +141,7 @@ export default function FolderDetailScreen() {
             destructive: true,
             onPress: () => {
               if (menuState.linkId == null) return;
-              // API: PATCH /api/v1/saved-links/{id} { categoryId: null }
-              handleDelete(menuState.linkId);
+              void handleDelete(menuState.linkId);
             },
           },
         ]}

--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -54,6 +54,23 @@ export default function FolderDetailScreen() {
     }
   };
 
+  const confirmDeleteFromFolder = (linkId: number) => {
+    Alert.alert(
+      '폴더에서 삭제할까요?',
+      '링크는 삭제되지 않아요.\n현재 폴더에서만 제외돼요.',
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '폴더에서 삭제',
+          style: 'destructive',
+          onPress: () => {
+            void handleDelete(linkId);
+          },
+        },
+      ],
+    );
+  };
+
   const handleAddUrl = () => {
     router.push({
       pathname: '/(tabs)/(folder)/folder-add-url',
@@ -141,7 +158,7 @@ export default function FolderDetailScreen() {
             destructive: true,
             onPress: () => {
               if (menuState.linkId == null) return;
-              void handleDelete(menuState.linkId);
+              confirmDeleteFromFolder(menuState.linkId);
             },
           },
         ]}

--- a/app/(tabs)/(folder)/_layout.tsx
+++ b/app/(tabs)/(folder)/_layout.tsx
@@ -1,14 +1,5 @@
 import { Stack } from 'expo-router';
 
-import { FoldersProvider } from '@/context/folders-context';
-import { SavedLinksProvider } from '@/context/saved-links-context';
-
 export default function FolderLayout() {
-  return (
-    <SavedLinksProvider>
-      <FoldersProvider>
-        <Stack screenOptions={{ headerShown: false }} />
-      </FoldersProvider>
-    </SavedLinksProvider>
-  );
+  return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/app/(tabs)/(folder)/folder-add-url.tsx
+++ b/app/(tabs)/(folder)/folder-add-url.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import {
+  Alert,
   FlatList,
   StyleSheet,
   Text,
@@ -11,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { CardLink } from '@/components/ui/card-link';
 import { SelectionCircle } from '@/components/ui/selection-circle';
 import { Colors, Typography } from '@/constants/theme';
+import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
 import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 
 // ─── Selectable card row ──────────────────────────────────────────────────────
@@ -51,6 +53,7 @@ export default function FolderAddUrlScreen() {
     folderName: string;
   }>();
   const { links, assignCategory } = useSavedLinks();
+  const { refreshFolders } = useFolders();
 
   // 미분류 URL만 표시 (categoryId === null)
   const uncategorizedLinks = links.filter((l) => l.categoryId === null);
@@ -74,12 +77,17 @@ export default function FolderAddUrlScreen() {
     if (isAdding || selectedIds.size === 0) return;
     setIsAdding(true);
     try {
-      // PATCH /api/v1/saved-links/{id} { categoryId } — 선택한 링크들을 폴더에 추가
-      assignCategory([...selectedIds], Number(folderId));
+      await assignCategory([...selectedIds], Number(folderId));
+      await refreshFolders();
       router.replace({
         pathname: '/(tabs)/(folder)/[id]',
         params: { id: folderId, urlAdded: '1' },
       });
+    } catch (error) {
+      Alert.alert(
+        'URL 추가 실패',
+        getFolderErrorMessage(error, '선택한 URL을 폴더에 추가하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
     } finally {
       setIsAdding(false);
     }

--- a/app/(tabs)/(folder)/folder-name.tsx
+++ b/app/(tabs)/(folder)/folder-name.tsx
@@ -12,17 +12,31 @@ import { router, Stack } from 'expo-router';
 
 import { Button } from '@/components/ui/button';
 import { Colors, Typography } from '@/constants/theme';
+import { useFolders } from '@/context/folders-context';
 
 export default function FolderNameScreen() {
   const [folderName, setFolderName] = useState('');
   const [isFocused, setIsFocused] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const { folders } = useFolders();
 
   const canProceed = folderName.trim().length > 0;
 
   const handleNext = () => {
+    const trimmedName = folderName.trim();
+    const hasDuplicateName = folders.some(
+      (folder) => normalizeFolderName(folder.name) === normalizeFolderName(trimmedName),
+    );
+
+    if (hasDuplicateName) {
+      setErrorMessage('이미 같은 이름의 폴더가 있어요.');
+      return;
+    }
+
+    setErrorMessage('');
     router.push({
       pathname: '/(tabs)/(folder)/folder-url-select',
-      params: { folderName: folderName.trim() },
+      params: { folderName: trimmedName },
     });
   };
 
@@ -57,7 +71,12 @@ export default function FolderNameScreen() {
                 <TextInput
                   style={styles.input}
                   value={folderName}
-                  onChangeText={setFolderName}
+                  onChangeText={(value) => {
+                    setFolderName(value);
+                    if (errorMessage) {
+                      setErrorMessage('');
+                    }
+                  }}
                   onFocus={() => setIsFocused(true)}
                   onBlur={() => setIsFocused(false)}
                   placeholder="폴더 이름 입력"
@@ -76,6 +95,7 @@ export default function FolderNameScreen() {
                   </TouchableOpacity>
                 )}
               </View>
+              {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
               <Text style={styles.helperText}>
                 {'이 이름으로 폴더가 생성되고,\n다음 단계에서 URL을 고를 수 있어요.'}
               </Text>
@@ -168,7 +188,15 @@ const styles = StyleSheet.create({
     color: Colors.brand.textSecondary,
     lineHeight: 20,
   },
+  errorText: {
+    ...Typography.caption,
+    color: Colors.brand.textWarning,
+  },
   buttonArea: {
     marginTop: 32,
   },
 });
+
+function normalizeFolderName(name: string) {
+  return name.trim().toLocaleLowerCase();
+}

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import {
+  Alert,
   FlatList,
   StyleSheet,
   Text,
@@ -11,7 +12,7 @@ import { Button } from '@/components/ui/button';
 import { CardLink } from '@/components/ui/card-link';
 import { SelectionCircle } from '@/components/ui/selection-circle';
 import { Colors, Typography } from '@/constants/theme';
-import { useFolders } from '@/context/folders-context';
+import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
 import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 
 // ─── Selectable card row ──────────────────────────────────────────────────────
@@ -52,8 +53,9 @@ export default function FolderUrlSelectScreen() {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [isCreating, setIsCreating] = useState(false);
   const { addFolder } = useFolders();
-  const { links: allLinks, assignCategory } = useSavedLinks();
+  const { links: allLinks, refreshLinks } = useSavedLinks();
   const links = allLinks.filter((l) => l.categoryId === null);
+  const name = (folderName ?? '새 폴더').trim();
 
   const toggleSelect = useCallback((id: number) => {
     setSelectedIds((prev) => {
@@ -71,19 +73,20 @@ export default function FolderUrlSelectScreen() {
     if (isCreating) return;
     setIsCreating(true);
     try {
-      // TODO: POST /api/v1/categories { name: folderName } 로 교체
-      const newId = addFolder(folderName ?? '새 폴더');
-      if (selectedIds.size > 0) {
-        assignCategory([...selectedIds], newId);
-      }
+      await addFolder(name, [...selectedIds]);
+      await refreshLinks();
       router.dismissAll();
+    } catch (error) {
+      Alert.alert(
+        '폴더 생성 실패',
+        getFolderErrorMessage(error, '폴더를 생성하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
     } finally {
       setIsCreating(false);
     }
   };
 
   const selectedCount = selectedIds.size;
-  const name = folderName ?? '새 폴더';
 
   return (
     <>

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -76,6 +76,10 @@ export default function FolderUrlSelectScreen() {
       await addFolder(name, [...selectedIds]);
       await refreshLinks();
       router.dismissAll();
+      router.replace({
+        pathname: '/(tabs)/(folder)',
+        params: { folderCreated: String(Date.now()) },
+      });
     } catch (error) {
       Alert.alert(
         '폴더 생성 실패',

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -74,20 +74,28 @@ export default function FolderUrlSelectScreen() {
     setIsCreating(true);
     try {
       await addFolder(name, [...selectedIds]);
-      await refreshLinks();
-      router.dismissAll();
-      router.replace({
-        pathname: '/(tabs)/(folder)',
-        params: { folderCreated: String(Date.now()) },
-      });
     } catch (error) {
       Alert.alert(
         '폴더 생성 실패',
         getFolderErrorMessage(error, '폴더를 생성하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
+      setIsCreating(false);
+      return;
+    }
+
+    try {
+      await refreshLinks();
+    } catch {
+      // Link refresh is best-effort after the folder has already been created.
     } finally {
       setIsCreating(false);
     }
+
+    router.dismissAll();
+    router.replace({
+      pathname: '/(tabs)/(folder)',
+      params: { folderCreated: String(Date.now()) },
+    });
   };
 
   const selectedCount = selectedIds.size;

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -14,11 +14,12 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { AddFolderButton } from '@/components/ui/add-folder-button';
 import { FolderCard } from '@/components/ui/folder-card';
 import { FolderContextMenu } from '@/components/ui/folder-context-menu';
 import { SectionHeader } from '@/components/ui/section-header';
+import { Toast } from '@/components/ui/toast';
 import { Colors, Typography } from '@/constants/theme';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { useSavedLinks } from '@/context/saved-links-context';
@@ -32,6 +33,9 @@ type MenuState = {
 
 export default function FolderScreen() {
   const router = useRouter();
+  const { folderCreated: folderCreatedParam } = useLocalSearchParams<{
+    folderCreated?: string | string[];
+  }>();
   const { refreshLinks } = useSavedLinks();
   const {
     folders: rawFolders,
@@ -46,7 +50,11 @@ export default function FolderScreen() {
     value: '',
   });
   const [isMutating, setIsMutating] = useState(false);
+  const [createToastVisible, setCreateToastVisible] = useState(false);
+  const [deleteToastVisible, setDeleteToastVisible] = useState(false);
+  const lastCreatedToastRef = useRef<string | undefined>(undefined);
   const renameInputRef = useRef<TextInput>(null);
+  const folderCreated = typeof folderCreatedParam === 'string' ? folderCreatedParam : undefined;
 
   const folders = useMemo(
     () => rawFolders.map((folder) => ({ ...folder })),
@@ -56,6 +64,15 @@ export default function FolderScreen() {
   const handleMorePress = (folderId: number, anchor: AnchorPosition) => {
     setMenuState({ visible: true, anchor, folderId });
   };
+
+  useEffect(() => {
+    if (!folderCreated || lastCreatedToastRef.current === folderCreated) {
+      return;
+    }
+
+    lastCreatedToastRef.current = folderCreated;
+    setCreateToastVisible(true);
+  }, [folderCreated]);
 
   const handleEditName = () => {
     if (menuState.folderId == null) return;
@@ -100,6 +117,7 @@ export default function FolderScreen() {
           try {
             await deleteFolder(folderId);
             await refreshLinks();
+            setDeleteToastVisible(true);
           } catch (error) {
             Alert.alert(
               '폴더 삭제 실패',
@@ -176,6 +194,21 @@ export default function FolderScreen() {
         onEditName={handleEditName}
         onDelete={handleDelete}
         onDismiss={() => setMenuState({ visible: false })}
+      />
+
+      <Toast
+        visible={deleteToastVisible}
+        message="폴더가 삭제되었어요"
+        placement="top"
+        topOffset={96}
+        onHide={() => setDeleteToastVisible(false)}
+      />
+      <Toast
+        visible={createToastVisible}
+        message="폴더가 생성되었어요"
+        placement="top"
+        topOffset={96}
+        onHide={() => setCreateToastVisible(false)}
       />
 
       {/* 폴더명 수정 모달 */}

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import {
+  ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -20,7 +22,7 @@ import { SectionHeader } from '@/components/ui/section-header';
 import { Colors, Typography } from '@/constants/theme';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { useSavedLinks } from '@/context/saved-links-context';
-import { useFolders } from '@/context/folders-context';
+import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
 
 type MenuState = {
   visible: boolean;
@@ -30,21 +32,25 @@ type MenuState = {
 
 export default function FolderScreen() {
   const router = useRouter();
-  const { links, assignCategory } = useSavedLinks();
-  const { folders: rawFolders, renameFolder, deleteFolder } = useFolders();
+  const { refreshLinks } = useSavedLinks();
+  const {
+    folders: rawFolders,
+    isLoading,
+    errorMessage,
+    renameFolder,
+    deleteFolder,
+  } = useFolders();
   const [menuState, setMenuState] = useState<MenuState>({ visible: false });
   const [renameState, setRenameState] = useState<{ visible: boolean; folderId?: number; value: string }>({
     visible: false,
     value: '',
   });
+  const [isMutating, setIsMutating] = useState(false);
   const renameInputRef = useRef<TextInput>(null);
 
   const folders = useMemo(
-    () => rawFolders.map((f) => ({
-      ...f,
-      linkCount: links.filter((l) => l.categoryId === f.id).length,
-    })),
-    [links, rawFolders]
+    () => rawFolders.map((folder) => ({ ...folder })),
+    [rawFolders],
   );
 
   const handleMorePress = (folderId: number, anchor: AnchorPosition) => {
@@ -58,11 +64,21 @@ export default function FolderScreen() {
     setTimeout(() => renameInputRef.current?.focus(), 100);
   };
 
-  const handleRenameConfirm = () => {
+  const handleRenameConfirm = async () => {
     const trimmed = renameState.value.trim();
-    if (renameState.folderId == null || !trimmed) return;
-    renameFolder(renameState.folderId, trimmed);
-    setRenameState({ visible: false, value: '' });
+    if (renameState.folderId == null || !trimmed || isMutating) return;
+    setIsMutating(true);
+    try {
+      await renameFolder(renameState.folderId, trimmed);
+      setRenameState({ visible: false, value: '' });
+    } catch (error) {
+      Alert.alert(
+        '폴더명 수정 실패',
+        getFolderErrorMessage(error, '폴더 이름을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+      );
+    } finally {
+      setIsMutating(false);
+    }
   };
 
   const handleRenameCancel = () => {
@@ -72,11 +88,29 @@ export default function FolderScreen() {
   const handleDelete = () => {
     if (menuState.folderId == null) return;
     const folderId = menuState.folderId;
-    const linkIds = links.filter((link) => link.categoryId === folderId).map((link) => link.id);
-    if (linkIds.length > 0) {
-      assignCategory(linkIds, null);
-    }
-    deleteFolder(folderId);
+
+    Alert.alert('폴더 삭제', '폴더를 삭제할까요? 폴더 안의 링크는 미분류 상태로 이동합니다.', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '삭제',
+        style: 'destructive',
+        onPress: async () => {
+          if (isMutating) return;
+          setIsMutating(true);
+          try {
+            await deleteFolder(folderId);
+            await refreshLinks();
+          } catch (error) {
+            Alert.alert(
+              '폴더 삭제 실패',
+              getFolderErrorMessage(error, '폴더를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+            );
+          } finally {
+            setIsMutating(false);
+          }
+        },
+      },
+    ]);
   };
 
   const handleAddFolder = () => {
@@ -103,7 +137,17 @@ export default function FolderScreen() {
             rightSlot={<AddFolderButton onPress={handleAddFolder} />}
           />
 
-          {folders.length > 0 ? (
+          {errorMessage ? (
+            <View style={styles.errorBox}>
+              <Text style={styles.errorText}>{errorMessage}</Text>
+            </View>
+          ) : null}
+
+          {isLoading ? (
+            <View style={styles.loadingState}>
+              <ActivityIndicator color={Colors.brand.primary} />
+            </View>
+          ) : folders.length > 0 ? (
             <View style={styles.grid}>
               {folders.map((folder) => (
                 <FolderCard
@@ -178,7 +222,7 @@ export default function FolderScreen() {
               <TouchableOpacity
                 style={[renameStyles.confirmBtn, !renameState.value.trim() && renameStyles.confirmBtnDisabled]}
                 onPress={handleRenameConfirm}
-                disabled={!renameState.value.trim()}
+                disabled={!renameState.value.trim() || isMutating}
               >
                 <Text style={[renameStyles.confirmText, !renameState.value.trim() && renameStyles.confirmTextDisabled]}>
                   저장
@@ -231,6 +275,22 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 12,
+  },
+  errorBox: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.brand.textWarning,
+    backgroundColor: Colors.brand.surface,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  errorText: {
+    ...Typography.caption,
+    color: Colors.brand.textWarning,
+  },
+  loadingState: {
+    paddingVertical: 40,
+    alignItems: 'center',
   },
 
   emptyState: {

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -52,6 +52,7 @@ export default function FolderScreen() {
   const [isMutating, setIsMutating] = useState(false);
   const [createToastVisible, setCreateToastVisible] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
+  const [renameToastVisible, setRenameToastVisible] = useState(false);
   const lastCreatedToastRef = useRef<string | undefined>(undefined);
   const renameInputRef = useRef<TextInput>(null);
   const folderCreated = typeof folderCreatedParam === 'string' ? folderCreatedParam : undefined;
@@ -88,6 +89,7 @@ export default function FolderScreen() {
     try {
       await renameFolder(renameState.folderId, trimmed);
       setRenameState({ visible: false, value: '' });
+      setRenameToastVisible(true);
     } catch (error) {
       Alert.alert(
         '폴더명 수정 실패',
@@ -209,6 +211,13 @@ export default function FolderScreen() {
         placement="top"
         topOffset={96}
         onHide={() => setCreateToastVisible(false)}
+      />
+      <Toast
+        visible={renameToastVisible}
+        message="폴더명이 수정되었어요"
+        placement="top"
+        topOffset={96}
+        onHide={() => setRenameToastVisible(false)}
       />
 
       {/* 폴더명 수정 모달 */}

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -45,9 +45,15 @@ export default function FolderScreen() {
     deleteFolder,
   } = useFolders();
   const [menuState, setMenuState] = useState<MenuState>({ visible: false });
-  const [renameState, setRenameState] = useState<{ visible: boolean; folderId?: number; value: string }>({
+  const [renameState, setRenameState] = useState<{
+    visible: boolean;
+    folderId?: number;
+    value: string;
+    currentName: string;
+  }>({
     visible: false,
     value: '',
+    currentName: '',
   });
   const [isMutating, setIsMutating] = useState(false);
   const [createToastVisible, setCreateToastVisible] = useState(false);
@@ -78,17 +84,18 @@ export default function FolderScreen() {
   const handleEditName = () => {
     if (menuState.folderId == null) return;
     const current = folders.find((f) => f.id === menuState.folderId)?.name ?? '';
-    setRenameState({ visible: true, folderId: menuState.folderId, value: current });
+    setRenameState({ visible: true, folderId: menuState.folderId, value: current, currentName: current });
     setTimeout(() => renameInputRef.current?.focus(), 100);
   };
 
   const handleRenameConfirm = async () => {
     const trimmed = renameState.value.trim();
-    if (renameState.folderId == null || !trimmed || isMutating) return;
+    const currentName = renameState.currentName.trim();
+    if (renameState.folderId == null || !trimmed || trimmed === currentName || isMutating) return;
     setIsMutating(true);
     try {
       await renameFolder(renameState.folderId, trimmed);
-      setRenameState({ visible: false, value: '' });
+      setRenameState({ visible: false, value: '', currentName: '' });
       setRenameToastVisible(true);
     } catch (error) {
       Alert.alert(
@@ -101,7 +108,7 @@ export default function FolderScreen() {
   };
 
   const handleRenameCancel = () => {
-    setRenameState({ visible: false, value: '' });
+    setRenameState({ visible: false, value: '', currentName: '' });
   };
 
   const handleDelete = () => {
@@ -136,6 +143,12 @@ export default function FolderScreen() {
   const handleAddFolder = () => {
     router.push('/folder-name');
   };
+
+  const trimmedRenameValue = renameState.value.trim();
+  const renameSubmitDisabled =
+    trimmedRenameValue.length === 0 ||
+    trimmedRenameValue === renameState.currentName.trim() ||
+    isMutating;
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -262,11 +275,11 @@ export default function FolderScreen() {
                 <Text style={renameStyles.cancelText}>취소</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={[renameStyles.confirmBtn, !renameState.value.trim() && renameStyles.confirmBtnDisabled]}
+                style={[renameStyles.confirmBtn, renameSubmitDisabled && renameStyles.confirmBtnDisabled]}
                 onPress={handleRenameConfirm}
-                disabled={!renameState.value.trim() || isMutating}
+                disabled={renameSubmitDisabled}
               >
-                <Text style={[renameStyles.confirmText, !renameState.value.trim() && renameStyles.confirmTextDisabled]}>
+                <Text style={[renameStyles.confirmText, renameSubmitDisabled && renameStyles.confirmTextDisabled]}>
                   저장
                 </Text>
               </TouchableOpacity>

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -16,6 +16,7 @@ import { SectionHeader } from '@/components/ui/section-header';
 import { TitleEditModal } from '@/components/ui/title-edit-modal';
 import { Toast } from '@/components/ui/toast';
 import { Colors, Typography } from '@/constants/theme';
+import { useFolders } from '@/context/folders-context';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 
@@ -24,6 +25,7 @@ export default function HomeScreen() {
     savedLinkToast?: string | string[];
   }>();
   const { links, toggleBookmark, deleteLink, updateTitle } = useSavedLinks();
+  const { refreshFolders } = useFolders();
   const [menuState, setMenuState] = useState<{ visible: boolean; anchor?: AnchorPosition; linkId?: number }>({ visible: false });
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
   const [saveToastVisible, setSaveToastVisible] = useState(false);
@@ -74,6 +76,7 @@ export default function HomeScreen() {
           onPress: async () => {
             try {
               await deleteLink(id);
+              await refreshFolders();
               setDeleteToastVisible(true);
             } catch (error) {
               Alert.alert(
@@ -85,7 +88,7 @@ export default function HomeScreen() {
         },
       ]);
     },
-    [deleteLink],
+    [deleteLink, refreshFolders],
   );
 
   const openTitleModal = useCallback((link: SavedLink) => {

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -19,18 +19,8 @@ import { TitleEditModal } from '@/components/ui/title-edit-modal';
 import { Toast } from '@/components/ui/toast';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { Colors, Typography } from '@/constants/theme';
+import { useFolders } from '@/context/folders-context';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
-
-// ─── 폴더 필터 칩 아이템 ──────────────────────────────────────────────────────
-// 실제 구현 시 GET /api/v1/categories 응답으로 교체
-
-// 폴더명은 folder/index.tsx MOCK_FOLDERS와 동일하게 유지 (API 연동 시 GET /categories로 교체)
-const FOLDER_ITEMS: FilterChipItem[] = [
-  { label: '전체', value: 'all' },
-  { label: '맛집 정보', value: '1' },
-  { label: '취업', value: '2' },
-  { label: '취미', value: '3' },
-];
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
@@ -47,6 +37,11 @@ export default function SavedLinksScreen() {
     deleteLink,
     updateTitle,
   } = useSavedLinks();
+  const {
+    folders,
+    errorMessage: folderErrorMessage,
+    refreshFolders,
+  } = useFolders();
 
   const [selectedFolder, setSelectedFolder] = useState('all');
   const [bookmarkFilter, setBookmarkFilter] = useState(false);
@@ -57,6 +52,14 @@ export default function SavedLinksScreen() {
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [titleToastVisible, setTitleToastVisible] = useState(false);
+
+  const folderItems = useMemo<FilterChipItem[]>(
+    () => [
+      { label: '전체', value: 'all' },
+      ...folders.map((folder) => ({ label: folder.name, value: String(folder.id) })),
+    ],
+    [folders],
+  );
 
   const displayLinks = useMemo(() => {
     const folderFiltered =
@@ -70,6 +73,16 @@ export default function SavedLinksScreen() {
 
     return folderFiltered.filter((link) => link.isBookmarked);
   }, [links, selectedFolder, bookmarkFilter]);
+
+  useEffect(() => {
+    if (selectedFolder === 'all') {
+      return;
+    }
+
+    if (!folders.some((folder) => String(folder.id) === selectedFolder)) {
+      setSelectedFolder('all');
+    }
+  }, [folders, selectedFolder]);
 
   const openTitleModal = useCallback((link: SavedLink) => {
     setEditingLink(link);
@@ -99,6 +112,7 @@ export default function SavedLinksScreen() {
           onPress: async () => {
             try {
               await deleteLink(id);
+              await refreshFolders();
               setDeleteToastVisible(true);
             } catch (error) {
               Alert.alert(
@@ -110,7 +124,7 @@ export default function SavedLinksScreen() {
         },
       ]);
     },
-    [deleteLink],
+    [deleteLink, refreshFolders],
   );
 
   const openMoreMenu = useCallback(
@@ -151,7 +165,7 @@ export default function SavedLinksScreen() {
       <View style={styles.chipRow}>
         <FilterChip
           variant="active"
-          items={FOLDER_ITEMS}
+          items={folderItems}
           selectedValue={selectedFolder}
           onSelect={setSelectedFolder}
         />
@@ -166,6 +180,11 @@ export default function SavedLinksScreen() {
           <Text style={styles.errorText}>{errorMessage}</Text>
         </View>
       ) : null}
+      {folderErrorMessage ? (
+        <View style={styles.errorBox}>
+          <Text style={styles.errorText}>{folderErrorMessage}</Text>
+        </View>
+      ) : null}
 
       {/* 링크 목록 */}
       <FlatList
@@ -177,7 +196,7 @@ export default function SavedLinksScreen() {
           <RefreshControl
             refreshing={isLoading}
             onRefresh={() => {
-              void refreshLinks();
+              void Promise.all([refreshLinks(), refreshFolders()]);
             }}
             tintColor={Colors.brand.primary}
           />

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { ShareIntentRouter } from '@/components/share-intent-router';
 import { BottomTabBar, type TabVariant } from '@/components/ui/bottom-tab-bar';
+import { FoldersProvider } from '@/context/folders-context';
 import { SavedLinksProvider } from '@/context/saved-links-context';
 import { syncAuthenticatedMember } from '@/services/auth-api';
 
@@ -121,15 +122,17 @@ export default function TabLayout() {
 
   return (
     <SavedLinksProvider>
-      <ShareIntentRouter />
-      <Tabs
-        tabBar={(props) => <CustomTabBar {...props} />}
-        screenOptions={{ headerShown: false }}
-      >
-        <Tabs.Screen name="(home)" />
-        <Tabs.Screen name="(folder)" />
-        <Tabs.Screen name="(explore)" options={{ href: null }} />
-      </Tabs>
+      <FoldersProvider>
+        <ShareIntentRouter />
+        <Tabs
+          tabBar={(props) => <CustomTabBar {...props} />}
+          screenOptions={{ headerShown: false }}
+        >
+          <Tabs.Screen name="(home)" />
+          <Tabs.Screen name="(folder)" />
+          <Tabs.Screen name="(explore)" options={{ href: null }} />
+        </Tabs>
+      </FoldersProvider>
     </SavedLinksProvider>
   );
 }

--- a/context/folders-context.tsx
+++ b/context/folders-context.tsx
@@ -1,49 +1,138 @@
-import { createContext, useCallback, useContext, useState } from 'react';
+import { useAuth } from '@clerk/expo';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
-export interface Folder {
-  id: number;
-  name: string;
-}
+import {
+  createCategory,
+  deleteCategory,
+  fetchCategories,
+  renameCategory,
+  type CategoryCreateRequest,
+  type CategoryResponse,
+} from '@/api/categories';
+
+const LOGIN_REQUIRED_MESSAGE =
+  '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+
+export type Folder = CategoryResponse;
 
 interface FoldersContextValue {
   folders: Folder[];
-  addFolder: (name: string) => number;
-  renameFolder: (id: number, name: string) => void;
-  deleteFolder: (id: number) => void;
+  isLoading: boolean;
+  errorMessage: string;
+  refreshFolders: () => Promise<void>;
+  addFolder: (name: string, linkIds?: number[]) => Promise<Folder>;
+  renameFolder: (id: number, name: string) => Promise<void>;
+  deleteFolder: (id: number) => Promise<void>;
 }
-
-const MOCK_FOLDERS: Folder[] = [
-  { id: 1, name: '맛집 정보' },
-  { id: 2, name: '취업' },
-  { id: 3, name: '취미' },
-];
-
-let nextId = MOCK_FOLDERS.length + 1;
 
 const FoldersContext = createContext<FoldersContextValue | null>(null);
 
 export function FoldersProvider({ children }: { children: React.ReactNode }) {
-  const [folders, setFolders] = useState<Folder[]>(MOCK_FOLDERS);
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const getTokenRef = useRef(getToken);
 
-  const addFolder = useCallback((name: string): number => {
-    // TODO: 백엔드 연동 시 POST /api/v1/categories { name } 호출 후 응답 id로 교체
-    const id = nextId++;
-    setFolders((prev) => [...prev, { id, name }]);
-    return id;
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
+
+  const refreshFolders = useCallback(async () => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!isSignedIn) {
+      setFolders([]);
+      setErrorMessage(LOGIN_REQUIRED_MESSAGE);
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      const response = await fetchCategories(() => getTokenRef.current());
+      setFolders(sortFolders(response.items));
+    } catch (error) {
+      setErrorMessage(getFolderErrorMessage(error, '폴더 목록을 불러오지 못했습니다.'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoaded, isSignedIn]);
+
+  useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!isSignedIn) {
+      setFolders([]);
+      setErrorMessage('');
+      return;
+    }
+
+    void refreshFolders();
+  }, [isLoaded, isSignedIn, refreshFolders]);
+
+  const addFolder = useCallback(async (name: string, linkIds: number[] = []) => {
+    const request: CategoryCreateRequest = {
+      name,
+      ...(linkIds.length > 0 ? { linkIds } : {}),
+    };
+
+    const folder = await createCategory(() => getTokenRef.current(), request);
+    setFolders((prev) => sortFolders([...prev.filter((item) => item.id !== folder.id), folder]));
+    setErrorMessage('');
+    return folder;
   }, []);
 
-  const renameFolder = useCallback((id: number, name: string) => {
-    // TODO: PATCH /api/v1/categories/{id}
-    setFolders((prev) => prev.map((f) => (f.id === id ? { ...f, name } : f)));
-  }, []);
+  const renameFolder = useCallback(async (id: number, name: string) => {
+    const previousFolders = folders;
+    setFolders((prev) =>
+      prev.map((folder) => (folder.id === id ? { ...folder, name } : folder)),
+    );
 
-  const deleteFolder = useCallback((id: number) => {
-    // TODO: DELETE /api/v1/categories/{id}
-    setFolders((prev) => prev.filter((f) => f.id !== id));
-  }, []);
+    try {
+      const response = await renameCategory(() => getTokenRef.current(), id, name);
+      setFolders((prev) =>
+        prev.map((folder) =>
+          folder.id === response.id ? { ...folder, name: response.name } : folder,
+        ),
+      );
+      setErrorMessage('');
+    } catch (error) {
+      setFolders(previousFolders);
+      throw error;
+    }
+  }, [folders]);
+
+  const deleteFolder = useCallback(async (id: number) => {
+    const previousFolders = folders;
+    setFolders((prev) => prev.filter((folder) => folder.id !== id));
+
+    try {
+      await deleteCategory(() => getTokenRef.current(), id);
+      setErrorMessage('');
+    } catch (error) {
+      setFolders(previousFolders);
+      throw error;
+    }
+  }, [folders]);
 
   return (
-    <FoldersContext.Provider value={{ folders, addFolder, renameFolder, deleteFolder }}>
+    <FoldersContext.Provider
+      value={{
+        folders,
+        isLoading,
+        errorMessage,
+        refreshFolders,
+        addFolder,
+        renameFolder,
+        deleteFolder,
+      }}
+    >
       {children}
     </FoldersContext.Provider>
   );
@@ -53,4 +142,28 @@ export function useFolders(): FoldersContextValue {
   const ctx = useContext(FoldersContext);
   if (!ctx) throw new Error('useFolders must be used within FoldersProvider');
   return ctx;
+}
+
+export function getFolderErrorMessage(error: unknown, fallbackMessage: string) {
+  if (error instanceof Error) {
+    if (error.message === 'Missing Clerk session token') {
+      return LOGIN_REQUIRED_MESSAGE;
+    }
+
+    if (error.message) {
+      return error.message;
+    }
+  }
+
+  return fallbackMessage;
+}
+
+function sortFolders(folders: Folder[]) {
+  return [...folders].sort((a, b) => {
+    if (a.displayOrder !== b.displayOrder) {
+      return a.displayOrder - b.displayOrder;
+    }
+
+    return a.id - b.id;
+  });
 }


### PR DESCRIPTION
Closes #51

## 개요
폴더 화면에서 사용하던 mock 폴더 상태를 백엔드 Category API 기반 흐름으로 교체했습니다.

기존 `context/folders-context.tsx`는 `MOCK_FOLDERS`를 기준으로 폴더 생성, 이름 수정, 삭제를 로컬 상태에서만 처리하고 있었습니다. 이번 작업에서는 백엔드 `LinClean-BE-spring`의 폴더 API 개발 PR 기준으로 `GET /api/v1/categories`, `POST /api/v1/categories`, `PATCH /api/v1/categories/{id}`, `DELETE /api/v1/categories/{id}`를 실제 화면 흐름에 연결했습니다.

Category API는 Clerk 인증 토큰이 필요한 보호 API이므로, issue #41에서 정리한 공통 API 클라이언트 패턴을 사용했습니다. 기능별 API 파일에서는 API base URL을 새로 만들지 않고, `fetch()`나 `Authorization` 헤더를 직접 다루지 않도록 구성했습니다.

또한 폴더 생성, 삭제, 이름 수정, 폴더 내 링크 제외 흐름에서 사용자 안내 toast와 확인창을 정리하고, 저장 링크 목록과 폴더 목록의 상태가 함께 갱신되도록 보완했습니다.

## 주요 구현 내용
- Category API 전용 파일 `api/categories.ts` 추가
- `GET /api/v1/categories` 폴더 목록 조회 연동
- `POST /api/v1/categories` 폴더 생성 연동
- 폴더 생성 시 선택한 링크 목록을 `linkIds`로 함께 전달
- 새 폴더 생성 시 기존 `assignCategory` 중복 호출 제거
- `PATCH /api/v1/categories/{id}` 폴더명 수정 연동
- `DELETE /api/v1/categories/{id}` 폴더 삭제 연동
- 폴더 삭제 시 선행 `assignCategory(..., null)` 호출 제거
- `FoldersProvider` 위치를 탭 layout 기준으로 정리
- 폴더 목록 로딩, 빈 목록, API 에러 상태 처리
- 폴더명 입력 후 `다음` 클릭 시 중복 폴더명 검증
- 폴더 생성, 삭제, 이름 수정 성공 시 상단 toast 표시
- 폴더 내 링크 제외 시 확인창 표시
- 폴더 내 링크 제외 후 저장 링크 목록과 폴더 목록 refresh 처리
- 폴더 상세 링크 카드의 제목 수정 흐름을 메인 링크 카드와 동일하게 연결
- 홈 저장 링크 필터 칩에 실제 Category 목록 반영
- 폴더명 수정 시 입력값이 현재 폴더명과 동일하면 저장 버튼 비활성화
- 폴더명 수정 submit guard에도 동일 이름 검증 추가

## 파일별 역할
- `api/categories.ts`: Category API 타입 및 생성/조회/수정/삭제 호출 함수 추가
- `context/folders-context.tsx`: mock 폴더 상태를 Category API 기반 상태와 액션으로 교체
- `app/(tabs)/_layout.tsx`: `FoldersProvider` 위치 조정
- `app/(tabs)/(folder)/_layout.tsx`: 중복 provider 제거
- `app/(tabs)/(folder)/index.tsx`: 폴더 목록 조회, 로딩/빈 목록/에러, 삭제 toast 처리
- `app/(tabs)/(folder)/index.tsx`: 폴더명 수정 모달에서 현재 폴더명과 동일한 입력값일 때 저장 버튼 비활성화 처리
- `app/(tabs)/(folder)/folder-name.tsx`: 폴더명 입력, 중복명 검증, 생성/수정 흐름 연결
- `app/(tabs)/(folder)/folder-url-select.tsx`: 폴더 생성 시 선택 링크 `linkIds` 전달
- `app/(tabs)/(folder)/folder-add-url.tsx`: 기존 링크의 폴더 추가 흐름 유지 및 폴더 목록 refresh 처리
- `app/(tabs)/(folder)/[id].tsx`: 폴더 상세 링크 제외, 제목 수정, toast, refresh 처리
- `app/(tabs)/(home)/index.tsx`: 링크 삭제 후 폴더 목록 refresh 처리
- `app/(tabs)/(home)/saved-links.tsx`: 실제 Category 목록 기반 필터 칩 표시


## 해결한 이슈 목록
- [x] 현재 폴더 화면과 `context/folders-context.tsx`의 mock 상태 구조 확인
- [x] `api/categories.ts` 추가 및 Category API 타입/호출 함수 분리
- [x] Category API 호출에 `authenticatedApiRequest` 사용
- [x] 기능별 API 파일에서 API base URL 새로 생성하지 않음
- [x] 기능별 API 파일에서 `fetch()` 직접 호출하지 않음
- [x] 기능별 API 파일에서 `Authorization` 헤더 직접 주입하지 않음
- [x] `GET /api/v1/categories` 응답의 `items` 구조를 폴더 상태에 반영
- [x] `POST /api/v1/categories` 요청에 `name`, `linkIds` 전달
- [x] 새 폴더 생성 시 `assignCategory` 중복 호출 없이 `linkIds` 일괄 배치 기능 사용
- [x] `PATCH /api/v1/categories/{id}` 폴더명 수정 흐름 연결
- [x] `DELETE /api/v1/categories/{id}` 폴더 삭제 흐름 연결
- [x] 폴더 삭제 시 프론트의 불필요한 선행 `assignCategory(..., null)` 호출 제거
- [x] 폴더 생성/수정/삭제 후 저장 링크 목록과 폴더 목록이 일관되게 반영되도록 처리
- [x] 폴더 목록 로딩/빈 목록/API 에러 상태 처리
- [x] 중복 폴더명, 인증 실패, 네트워크 오류 등 실패 상황 사용자 안내 처리
- [x] `SavedLinksProvider`와 `FoldersProvider` 위치 검토 및 중복 생성 정리
- [x] 폴더 상세 화면의 기존 URL 추가/제거 흐름 유지
- [x] 폴더 상세 링크 카드의 제목 수정 로직을 메인 화면 링크 카드와 동일하게 처리
- [x] 폴더 생성/삭제/이름 수정 toast 처리
- [x] 폴더에서 링크 제외 시 실제 URL 삭제가 아닌 폴더 제외 의미의 확인창 표시
- [x] 폴더명 수정 시 현재 폴더명과 동일한 경우 수정 버튼 비활성화
- [x] 폴더명 수정 버튼 비활성화 조건과 실제 API 호출 방어 조건 일치

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 프론트 API 클라이언트 사용 규칙 준수
- [x] 폴더명 수정 시 빈 값, 동일 이름, 수정 중 상태에서 저장 요청이 발생하지 않도록 처리
- [x] Category API 파일에서 직접 `fetch()` 호출 없음
- [x] Category API 파일에서 직접 API base URL 생성 없음
- [x] Category API 파일에서 직접 `Authorization` 헤더 주입 없음
- [x] Category API 파일에서 `{ data: ... }` 응답 직접 unwrap 없음
- [x] 보호 API 호출 전 `/auth/me` 수동 선호출 없음
- [x] `DELETE /api/v1/categories/{id}`의 `204 No Content` 응답 처리

## 참고
폴더 삭제 시 연결된 저장 링크의 `categoryId` 정리는 백엔드에서 처리하므로, 프론트에서는 별도의 선행 링크 이동 API를 호출하지 않습니다.

기존 저장 링크의 폴더 이동/제거 흐름은 `PATCH /api/v1/saved-links/{id}/category` 기반 흐름을 유지했습니다.

폴더 생성 시 선택한 링크가 있는 경우에는 `POST /api/v1/categories` 요청의 `linkIds`를 사용해 한 번에 연결되도록 처리했습니다.

## 스크린샷
- 저장한 링크에서 폴더별로 뜨는 모습입니다.
<img width="498" height="1023" alt="image" src="https://github.com/user-attachments/assets/36c1998b-0158-4639-b1d2-a5e24d79b17e" />

- 폴더 이름 생성 단계에서 중복을 체크하는 화면입니다.
<img width="501" height="1022" alt="image" src="https://github.com/user-attachments/assets/465355b2-3f5e-430e-9e44-1ead6a94df41" />

- 폴더명 수정 시 같은 이름은 저장버튼이 비활성화 됩니다.
<img width="508" height="1022" alt="image" src="https://github.com/user-attachments/assets/84ac4f02-6270-4886-971d-d0aca7da2626" />

- 데이터베이스에도 잘 들어온 모습입니다.
<img width="784" height="110" alt="image" src="https://github.com/user-attachments/assets/229cf72d-24d8-46c4-bdd3-f9c8d5f1024e" />
