### PR TITLE
[FIX] 입력 모달 키보드 대응 개선 및 완료 키 저장 동작 제거

### DIFF
--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -2,9 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
-  KeyboardAvoidingView,
+  Keyboard,
   Modal,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -56,6 +55,7 @@ export default function FolderScreen() {
     currentName: '',
   });
   const [isMutating, setIsMutating] = useState(false);
+  const [renameKeyboardInset, setRenameKeyboardInset] = useState(0);
   const [createToastVisible, setCreateToastVisible] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [renameToastVisible, setRenameToastVisible] = useState(false);
@@ -80,6 +80,25 @@ export default function FolderScreen() {
     lastCreatedToastRef.current = folderCreated;
     setCreateToastVisible(true);
   }, [folderCreated]);
+
+  useEffect(() => {
+    if (!renameState.visible) {
+      setRenameKeyboardInset(0);
+      return;
+    }
+
+    const showSubscription = Keyboard.addListener('keyboardDidShow', (event) => {
+      setRenameKeyboardInset(event.endCoordinates.height);
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setRenameKeyboardInset(0);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, [renameState.visible]);
 
   const handleEditName = () => {
     if (menuState.folderId == null) return;
@@ -240,52 +259,63 @@ export default function FolderScreen() {
         animationType="fade"
         onRequestClose={handleRenameCancel}
       >
-        <KeyboardAvoidingView
-          style={renameStyles.overlay}
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        <View
+          style={[
+            renameStyles.overlay,
+            renameKeyboardInset > 0 && { paddingBottom: renameKeyboardInset },
+          ]}
         >
           <Pressable style={renameStyles.backdrop} onPress={handleRenameCancel} />
           <View style={renameStyles.sheet}>
-            <Text style={renameStyles.sheetTitle}>폴더명 수정</Text>
-            <View style={renameStyles.inputRow}>
-              <TextInput
-                ref={renameInputRef}
-                style={renameStyles.input}
-                value={renameState.value}
-                onChangeText={(v) => setRenameState((s) => ({ ...s, value: v }))}
-                placeholder="폴더 이름 입력"
-                placeholderTextColor={Colors.brand.textHint}
-                returnKeyType="done"
-                onSubmitEditing={handleRenameConfirm}
-                maxLength={50}
-                autoFocus
-              />
-              {renameState.value.length > 0 && (
+            <ScrollView
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={renameStyles.sheetContent}
+            >
+              <Text style={renameStyles.sheetTitle}>폴더명 수정</Text>
+              <View style={renameStyles.inputRow}>
+                <TextInput
+                  ref={renameInputRef}
+                  style={renameStyles.input}
+                  value={renameState.value}
+                  onChangeText={(v) => setRenameState((s) => ({ ...s, value: v }))}
+                  placeholder="폴더 이름 입력"
+                  placeholderTextColor={Colors.brand.textHint}
+                  returnKeyType="done"
+                  onSubmitEditing={Keyboard.dismiss}
+                  maxLength={50}
+                  autoFocus
+                />
+                {renameState.value.length > 0 && (
+                  <TouchableOpacity
+                    onPress={() => setRenameState((s) => ({ ...s, value: '' }))}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    style={renameStyles.clearButton}
+                  >
+                    <Text style={renameStyles.clearButtonText}>−</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+              <View style={renameStyles.actions}>
                 <TouchableOpacity
-                  onPress={() => setRenameState((s) => ({ ...s, value: '' }))}
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  style={renameStyles.clearButton}
+                  style={renameStyles.cancelBtn}
+                  onPress={handleRenameCancel}
                 >
-                  <Text style={renameStyles.clearButtonText}>−</Text>
+                  <Text style={renameStyles.cancelText}>취소</Text>
                 </TouchableOpacity>
-              )}
-            </View>
-            <View style={renameStyles.actions}>
-              <TouchableOpacity style={renameStyles.cancelBtn} onPress={handleRenameCancel}>
-                <Text style={renameStyles.cancelText}>취소</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[renameStyles.confirmBtn, renameSubmitDisabled && renameStyles.confirmBtnDisabled]}
-                onPress={handleRenameConfirm}
-                disabled={renameSubmitDisabled}
-              >
-                <Text style={[renameStyles.confirmText, renameSubmitDisabled && renameStyles.confirmTextDisabled]}>
-                  저장
-                </Text>
-              </TouchableOpacity>
-            </View>
+                <TouchableOpacity
+                  style={[renameStyles.confirmBtn, renameSubmitDisabled && renameStyles.confirmBtnDisabled]}
+                  onPress={handleRenameConfirm}
+                  disabled={renameSubmitDisabled}
+                >
+                  <Text style={[renameStyles.confirmText, renameSubmitDisabled && renameStyles.confirmTextDisabled]}>
+                    저장
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
           </View>
-        </KeyboardAvoidingView>
+        </View>
       </Modal>
     </SafeAreaView>
   );
@@ -373,9 +403,14 @@ const renameStyles = StyleSheet.create({
     backgroundColor: Colors.brand.overlayBackdrop,
   },
   sheet: {
+    width: '100%',
+    maxHeight: '80%',
     backgroundColor: Colors.brand.surface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
+    overflow: 'hidden',
+  },
+  sheetContent: {
     padding: 24,
     paddingBottom: 40,
     gap: 16,

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -12,7 +12,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { AddFolderButton } from '@/components/ui/add-folder-button';
 import { FolderCard } from '@/components/ui/folder-card';
@@ -30,7 +30,11 @@ type MenuState = {
   folderId?: number;
 };
 
+const RENAME_MODAL_BOTTOM_GAP = 16;
+const RENAME_KEYBOARD_TOP_GAP = 8;
+
 export default function FolderScreen() {
+  const insets = useSafeAreaInsets();
   const router = useRouter();
   const { folderCreated: folderCreatedParam } = useLocalSearchParams<{
     folderCreated?: string | string[];
@@ -168,6 +172,10 @@ export default function FolderScreen() {
     trimmedRenameValue.length === 0 ||
     trimmedRenameValue === renameState.currentName.trim() ||
     isMutating;
+  const renameRestingBottomInset = Math.max(insets.bottom, RENAME_MODAL_BOTTOM_GAP);
+  const renameModalBottomInset = renameKeyboardInset > 0
+    ? renameKeyboardInset + RENAME_KEYBOARD_TOP_GAP
+    : renameRestingBottomInset;
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -262,7 +270,7 @@ export default function FolderScreen() {
         <View
           style={[
             renameStyles.overlay,
-            renameKeyboardInset > 0 && { paddingBottom: renameKeyboardInset },
+            { paddingBottom: renameModalBottomInset },
           ]}
         >
           <Pressable style={renameStyles.backdrop} onPress={handleRenameCancel} />

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -132,7 +132,6 @@ export default function FolderScreen() {
     if (menuState.folderId == null) return;
     const current = folders.find((f) => f.id === menuState.folderId)?.name ?? '';
     setRenameState({ visible: true, folderId: menuState.folderId, value: current, currentName: current });
-    setTimeout(() => renameInputRef.current?.focus(), 100);
   };
 
   const handleRenameConfirm = async () => {

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -87,6 +87,7 @@ export default function FolderScreen() {
   const [renameToastVisible, setRenameToastVisible] = useState(false);
   const lastCreatedToastRef = useRef<string | undefined>(undefined);
   const renameInputRef = useRef<TextInput>(null);
+  const renameFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const folderCreated = typeof folderCreatedParam === 'string' ? folderCreatedParam : undefined;
 
   const folders = useMemo(
@@ -106,6 +107,14 @@ export default function FolderScreen() {
     lastCreatedToastRef.current = folderCreated;
     setCreateToastVisible(true);
   }, [folderCreated]);
+
+  useEffect(() => {
+    return () => {
+      if (renameFocusTimerRef.current) {
+        clearTimeout(renameFocusTimerRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!renameState.visible) {
@@ -141,6 +150,10 @@ export default function FolderScreen() {
     setIsMutating(true);
     try {
       await renameFolder(renameState.folderId, trimmed);
+      if (renameFocusTimerRef.current) {
+        clearTimeout(renameFocusTimerRef.current);
+        renameFocusTimerRef.current = null;
+      }
       setRenameState({ visible: false, value: '', currentName: '' });
       setRenameToastVisible(true);
     } catch (error) {
@@ -154,7 +167,22 @@ export default function FolderScreen() {
   };
 
   const handleRenameCancel = () => {
+    if (renameFocusTimerRef.current) {
+      clearTimeout(renameFocusTimerRef.current);
+      renameFocusTimerRef.current = null;
+    }
     setRenameState({ visible: false, value: '', currentName: '' });
+  };
+
+  const handleRenameModalShow = () => {
+    if (renameFocusTimerRef.current) {
+      clearTimeout(renameFocusTimerRef.current);
+    }
+
+    renameFocusTimerRef.current = setTimeout(() => {
+      renameInputRef.current?.focus();
+      renameFocusTimerRef.current = null;
+    }, 100);
   };
 
   const handleDelete = () => {
@@ -289,6 +317,7 @@ export default function FolderScreen() {
         transparent
         animationType="fade"
         onRequestClose={handleRenameCancel}
+        onShow={handleRenameModalShow}
       >
         <View
           style={[
@@ -315,7 +344,6 @@ export default function FolderScreen() {
                   returnKeyType="done"
                   onSubmitEditing={Keyboard.dismiss}
                   maxLength={50}
-                  autoFocus
                 />
                 {renameState.value.length > 0 && (
                   <TouchableOpacity

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -3,7 +3,9 @@ import {
   ActivityIndicator,
   Alert,
   Keyboard,
+  LayoutAnimation,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -11,6 +13,7 @@ import {
   TextInput,
   TouchableOpacity,
   View,
+  type KeyboardEvent,
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -32,6 +35,25 @@ type MenuState = {
 
 const RENAME_MODAL_BOTTOM_GAP = 16;
 const RENAME_KEYBOARD_TOP_GAP = 8;
+
+const showKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+const hideKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+const syncKeyboardLayoutAnimation = (event: KeyboardEvent) => {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+
+  const duration = event.duration > 10 ? event.duration : 10;
+
+  LayoutAnimation.configureNext({
+    duration,
+    update: {
+      duration,
+      type: LayoutAnimation.Types[event.easing] || LayoutAnimation.Types.keyboard,
+    },
+  });
+};
 
 export default function FolderScreen() {
   const insets = useSafeAreaInsets();
@@ -91,10 +113,12 @@ export default function FolderScreen() {
       return;
     }
 
-    const showSubscription = Keyboard.addListener('keyboardDidShow', (event) => {
+    const showSubscription = Keyboard.addListener(showKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
       setRenameKeyboardInset(event.endCoordinates.height);
     });
-    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+    const hideSubscription = Keyboard.addListener(hideKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
       setRenameKeyboardInset(0);
     });
 

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
+  Keyboard,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -75,7 +76,7 @@ export function LinkSaveModal({
               placeholder="예: 네이버 블로그"
               placeholderTextColor={Colors.brand.textHint}
               returnKeyType="done"
-              onSubmitEditing={handleSave}
+              onSubmitEditing={Keyboard.dismiss}
               maxLength={500}
               editable={!loading}
               autoFocus

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Keyboard,
+  LayoutAnimation,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -10,6 +12,7 @@ import {
   TextInput,
   TouchableOpacity,
   View,
+  type KeyboardEvent,
 } from 'react-native';
 
 import { Colors, Typography } from '@/constants/theme';
@@ -18,6 +21,25 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const MODAL_BOTTOM_GAP = 16;
 const KEYBOARD_TOP_GAP = 8;
+
+const showKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+const hideKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+const syncKeyboardLayoutAnimation = (event: KeyboardEvent) => {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+
+  const duration = event.duration > 10 ? event.duration : 10;
+
+  LayoutAnimation.configureNext({
+    duration,
+    update: {
+      duration,
+      type: LayoutAnimation.Types[event.easing] || LayoutAnimation.Types.keyboard,
+    },
+  });
+};
 
 interface TitleEditModalProps {
   editingLink: SavedLink | null;
@@ -50,10 +72,12 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       return;
     }
 
-    const showSubscription = Keyboard.addListener('keyboardDidShow', (event) => {
+    const showSubscription = Keyboard.addListener(showKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
       setKeyboardInset(event.endCoordinates.height);
     });
-    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+    const hideSubscription = Keyboard.addListener(hideKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
       setKeyboardInset(0);
     });
 

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -14,6 +14,10 @@ import {
 
 import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, type SavedLink } from '@/context/saved-links-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const MODAL_BOTTOM_GAP = 16;
+const KEYBOARD_TOP_GAP = 8;
 
 interface TitleEditModalProps {
   editingLink: SavedLink | null;
@@ -22,6 +26,7 @@ interface TitleEditModalProps {
 }
 
 export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditModalProps) {
+  const insets = useSafeAreaInsets();
   const [titleValue, setTitleValue] = useState('');
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
   const [keyboardInset, setKeyboardInset] = useState(0);
@@ -94,6 +99,10 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
     trimmedTitleValue.length > 500 ||
     trimmedTitleValue === editingLink?.title.trim() ||
     isUpdatingTitle;
+  const restingBottomInset = Math.max(insets.bottom, MODAL_BOTTOM_GAP);
+  const modalBottomInset = keyboardInset > 0
+    ? keyboardInset + KEYBOARD_TOP_GAP
+    : restingBottomInset;
 
   return (
     <Modal
@@ -105,7 +114,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       <View
         style={[
           styles.overlay,
-          keyboardInset > 0 && { paddingBottom: keyboardInset },
+          { paddingBottom: modalBottomInset },
         ]}
       >
         <Pressable style={styles.backdrop} onPress={handleClose} />

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -53,19 +53,27 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
   const [keyboardInset, setKeyboardInset] = useState(0);
   const titleInputRef = useRef<TextInput>(null);
+  const titleFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTitleFocusTimer = useCallback(() => {
+    if (titleFocusTimerRef.current) {
+      clearTimeout(titleFocusTimerRef.current);
+      titleFocusTimerRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     if (!editingLink) {
       setTitleValue('');
       setKeyboardInset(0);
+      clearTitleFocusTimer();
       return;
     }
 
     setTitleValue(editingLink.title);
-    const focusTimer = setTimeout(() => titleInputRef.current?.focus(), 100);
+  }, [clearTitleFocusTimer, editingLink]);
 
-    return () => clearTimeout(focusTimer);
-  }, [editingLink]);
+  useEffect(() => clearTitleFocusTimer, [clearTitleFocusTimer]);
 
   useEffect(() => {
     if (!editingLink) {
@@ -92,8 +100,18 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       return;
     }
 
+    clearTitleFocusTimer();
     onClose();
-  }, [isUpdatingTitle, onClose]);
+  }, [clearTitleFocusTimer, isUpdatingTitle, onClose]);
+
+  const handleModalShow = useCallback(() => {
+    clearTitleFocusTimer();
+
+    titleFocusTimerRef.current = setTimeout(() => {
+      titleInputRef.current?.focus();
+      titleFocusTimerRef.current = null;
+    }, 100);
+  }, [clearTitleFocusTimer]);
 
   const handleConfirm = useCallback(async () => {
     const trimmedTitle = titleValue.trim();
@@ -106,6 +124,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
 
     try {
       await onConfirm(editingLink.id, trimmedTitle);
+      clearTitleFocusTimer();
       onClose();
     } catch (error) {
       Alert.alert(
@@ -115,7 +134,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
     } finally {
       setIsUpdatingTitle(false);
     }
-  }, [editingLink, isUpdatingTitle, onClose, onConfirm, titleValue]);
+  }, [clearTitleFocusTimer, editingLink, isUpdatingTitle, onClose, onConfirm, titleValue]);
 
   const trimmedTitleValue = titleValue.trim();
   const titleSubmitDisabled =
@@ -134,6 +153,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       transparent
       animationType="fade"
       onRequestClose={handleClose}
+      onShow={handleModalShow}
     >
       <View
         style={[
@@ -161,7 +181,6 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
                 onSubmitEditing={Keyboard.dismiss}
                 maxLength={500}
                 editable={!isUpdatingTitle}
-                autoFocus
               />
               {titleValue.length > 0 && !isUpdatingTitle && (
                 <TouchableOpacity

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
-  KeyboardAvoidingView,
+  Keyboard,
   Modal,
-  Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -24,11 +24,13 @@ interface TitleEditModalProps {
 export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditModalProps) {
   const [titleValue, setTitleValue] = useState('');
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const [keyboardInset, setKeyboardInset] = useState(0);
   const titleInputRef = useRef<TextInput>(null);
 
   useEffect(() => {
     if (!editingLink) {
       setTitleValue('');
+      setKeyboardInset(0);
       return;
     }
 
@@ -36,6 +38,24 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
     const focusTimer = setTimeout(() => titleInputRef.current?.focus(), 100);
 
     return () => clearTimeout(focusTimer);
+  }, [editingLink]);
+
+  useEffect(() => {
+    if (!editingLink) {
+      return;
+    }
+
+    const showSubscription = Keyboard.addListener('keyboardDidShow', (event) => {
+      setKeyboardInset(event.endCoordinates.height);
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardInset(0);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
   }, [editingLink]);
 
   const handleClose = useCallback(() => {
@@ -82,57 +102,65 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       animationType="fade"
       onRequestClose={handleClose}
     >
-      <KeyboardAvoidingView
-        style={styles.overlay}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      <View
+        style={[
+          styles.overlay,
+          keyboardInset > 0 && { paddingBottom: keyboardInset },
+        ]}
       >
         <Pressable style={styles.backdrop} onPress={handleClose} />
         <View style={styles.sheet}>
-          <Text style={styles.sheetTitle}>제목 수정</Text>
-          <View style={styles.inputRow}>
-            <TextInput
-              ref={titleInputRef}
-              style={styles.input}
-              value={titleValue}
-              onChangeText={setTitleValue}
-              placeholder="URL 제목 입력"
-              placeholderTextColor={Colors.brand.textHint}
-              returnKeyType="done"
-              onSubmitEditing={handleConfirm}
-              maxLength={500}
-              editable={!isUpdatingTitle}
-              autoFocus
-            />
-            {titleValue.length > 0 && !isUpdatingTitle && (
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.sheetContent}
+          >
+            <Text style={styles.sheetTitle}>제목 수정</Text>
+            <View style={styles.inputRow}>
+              <TextInput
+                ref={titleInputRef}
+                style={styles.input}
+                value={titleValue}
+                onChangeText={setTitleValue}
+                placeholder="URL 제목 입력"
+                placeholderTextColor={Colors.brand.textHint}
+                returnKeyType="done"
+                onSubmitEditing={Keyboard.dismiss}
+                maxLength={500}
+                editable={!isUpdatingTitle}
+                autoFocus
+              />
+              {titleValue.length > 0 && !isUpdatingTitle && (
+                <TouchableOpacity
+                  onPress={() => setTitleValue('')}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  style={styles.clearButton}
+                >
+                  <Text style={styles.clearButtonText}>−</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+            <View style={styles.actions}>
               <TouchableOpacity
-                onPress={() => setTitleValue('')}
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                style={styles.clearButton}
+                style={styles.cancelBtn}
+                onPress={handleClose}
+                disabled={isUpdatingTitle}
               >
-                <Text style={styles.clearButtonText}>−</Text>
+                <Text style={styles.cancelText}>취소</Text>
               </TouchableOpacity>
-            )}
-          </View>
-          <View style={styles.actions}>
-            <TouchableOpacity
-              style={styles.cancelBtn}
-              onPress={handleClose}
-              disabled={isUpdatingTitle}
-            >
-              <Text style={styles.cancelText}>취소</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[styles.confirmBtn, titleSubmitDisabled && styles.confirmBtnDisabled]}
-              onPress={handleConfirm}
-              disabled={titleSubmitDisabled}
-            >
-              <Text style={[styles.confirmText, titleSubmitDisabled && styles.confirmTextDisabled]}>
-                {isUpdatingTitle ? '저장 중...' : '저장'}
-              </Text>
-            </TouchableOpacity>
-          </View>
+              <TouchableOpacity
+                style={[styles.confirmBtn, titleSubmitDisabled && styles.confirmBtnDisabled]}
+                onPress={handleConfirm}
+                disabled={titleSubmitDisabled}
+              >
+                <Text style={[styles.confirmText, titleSubmitDisabled && styles.confirmTextDisabled]}>
+                  {isUpdatingTitle ? '저장 중...' : '저장'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </ScrollView>
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 }
@@ -147,9 +175,14 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brand.overlayBackdrop,
   },
   sheet: {
+    width: '100%',
+    maxHeight: '80%',
     backgroundColor: Colors.brand.surface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
+    overflow: 'hidden',
+  },
+  sheetContent: {
     padding: 24,
     paddingBottom: 40,
     gap: 16,


### PR DESCRIPTION
Closes #54

## 개요
입력 모달에서 키보드 노출 시 입력창과 저장/취소 버튼이 가려지는 문제를 개선하고, 키보드의 완료/done 키로 저장이 실행되는 동작을 제거했습니다.

기존 제목 수정 모달과 폴더명 수정 모달은 화면 하단에 붙어 표시되는 구조라 Android 키보드가 올라왔을 때 모달 영역이 가려질 수 있었습니다. 이번 작업에서는 키보드 show/hide 이벤트를 기준으로 모달 하단 여백을 직접 조정해, 키보드가 올라온 상태에서도 입력창과 버튼을 확인할 수 있도록 보완했습니다.

또한 URL 제목 저장 모달, 링크 제목 수정 모달, 폴더명 수정 모달에서 `TextInput`의 완료/done 키가 저장 핸들러를 실행하지 않도록 변경했습니다. 이제 실제 저장은 모달 내부의 `저장` 버튼을 눌렀을 때만 실행됩니다.

Android 환경에서는 하단 시스템 내비게이션 바가 표시되는 경우 모달의 버튼 영역이 일부 가려질 수 있어, 모달의 기본 하단 위치에 안전 여백을 적용했습니다. 키보드가 닫힌 뒤에도 이 보정된 위치로 복귀하도록 처리해 하단 메뉴바와 겹치지 않도록 개선했습니다.

## 주요 구현 내용
- 링크 제목 수정 모달의 키보드 대응 방식 개선
- 폴더명 수정 모달의 키보드 대응 방식 개선
- 키보드 노출 시 모달이 키보드 위로 올라오도록 하단 inset 처리
- 키보드 완료/done 키 입력 후 모달이 기존 위치로 자연스럽게 복귀하도록 처리
- Android 하단 내비게이션 바가 있는 환경에서 모달이 가려지지 않도록 기본 하단 여백 보정
- 제목 수정/폴더명 수정 모달 내부를 `ScrollView`로 감싸 작은 화면 대응 보완
- URL 제목 저장 모달의 완료 키 저장 동작 제거
- 링크 제목 수정 모달의 완료 키 저장 동작 제거
- 폴더명 수정 모달의 완료 키 저장 동작 제거
- 완료/done 키는 `Keyboard.dismiss`만 실행하도록 변경
- 저장 버튼의 기존 저장 흐름과 비활성화 조건 유지

## 파일별 역할
- `components/ui/link-save-modal.tsx`: URL 제목 저장 모달에서 완료/done 키 입력 시 저장 대신 키보드만 닫히도록 수정
- `components/ui/title-edit-modal.tsx`: 링크 제목 수정 모달의 키보드 대응, 하단 위치 보정, 완료 키 저장 동작 제거
- `app/(tabs)/(folder)/index.tsx`: 폴더명 수정 모달의 키보드 대응, 하단 위치 보정, 완료 키 저장 동작 제거

## 해결한 이슈 목록
- [x] URL 제목 저장 모달의 `TextInput` 완료 키 동작 확인
- [x] 링크 제목 수정 모달의 `TextInput` 완료 키 동작 확인
- [x] 폴더명 수정 모달의 `TextInput` 완료 키 동작 확인
- [x] `onSubmitEditing`에 저장 핸들러가 연결된 지점 확인
- [x] 키보드의 완료/done 키를 눌러도 저장 API가 호출되지 않도록 수정
- [x] 키보드의 완료/done 키는 키보드 닫기 용도로만 동작하도록 수정
- [x] 실제 저장은 모달 내부의 `저장` 버튼을 눌렀을 때만 실행되도록 유지
- [x] 저장 버튼의 비활성화 조건 유지
- [x] 저장 중 중복 클릭 방지 동작 유지
- [x] 입력값이 비어 있거나 기존 값과 동일할 때 저장 버튼 비활성화 유지
- [x] 링크 제목 수정 모달의 키보드 노출 시 위치 보정
- [x] 폴더명 수정 모달의 키보드 노출 시 위치 보정
- [x] 키보드가 닫힌 뒤 모달이 보정된 하단 위치로 복귀하도록 수정
- [x] Android 하단 내비게이션 바에 모달 버튼 영역이 가려지지 않도록 하단 여백 보정

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 저장 버튼을 통한 기존 저장 API 호출 흐름 유지
- [x] 키보드 완료 키 입력 시 저장 핸들러가 호출되지 않도록 처리

## Screenshots or Video
- 키보드가 활성화 된 모달 화면입니다
<img width="477" height="587" alt="image" src="https://github.com/user-attachments/assets/a01e3f95-65c1-44ee-b6cb-33a4eb6b1f56" />

- 이미지와 같이 하단 메뉴바에 가리던 것을 수정하였습니다.
<img width="479" height="272" alt="스크린샷 2026-05-26 010151" src="https://github.com/user-attachments/assets/fb755d30-9a8d-4fcf-807b-9f4bc1c9aaba" />

- 수정된 하단 모달
<img width="480" height="324" alt="image" src="https://github.com/user-attachments/assets/3e538da6-8966-47d3-a6ad-9411af432efb" />

