### PR TITLE
[DESIGN] URL 추가 화면 체크 상태 UI 개선

### DIFF
--- a/app/(tabs)/(folder)/folder-add-url.tsx
+++ b/app/(tabs)/(folder)/folder-add-url.tsx
@@ -233,6 +233,8 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: 0,
     justifyContent: 'center',
+    zIndex: 10,
+    elevation: 10,
   },
 
   emptyState: {

--- a/app/(tabs)/(folder)/folder-add-url.tsx
+++ b/app/(tabs)/(folder)/folder-add-url.tsx
@@ -9,43 +9,10 @@ import {
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 
 import { Button } from '@/components/ui/button';
-import { CardLink } from '@/components/ui/card-link';
-import { SelectionCircle } from '@/components/ui/selection-circle';
+import { SelectableLinkCard } from '@/components/ui/selectable-link-card';
 import { Colors, Typography } from '@/constants/theme';
 import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
-import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
-
-// ─── Selectable card row ──────────────────────────────────────────────────────
-
-interface SelectableCardProps {
-  link: SavedLink;
-  selected: boolean;
-  onToggle: (id: number) => void;
-}
-
-function SelectableCard({ link, selected, onToggle }: SelectableCardProps) {
-  return (
-    <View style={styles.selectableCard}>
-      <View style={styles.cardLayer}>
-        <CardLink
-          verdict={link.verdict}
-          title={link.title}
-          originalUrl={link.originalUrl}
-          finalUrl={link.finalUrl}
-          bookmarked={link.isBookmarked}
-          icon={false}
-          onPress={() => onToggle(link.id)}
-        />
-        {selected && (
-          <View style={styles.selectedOverlay} pointerEvents="none" />
-        )}
-      </View>
-      <View style={styles.checkOverlay} pointerEvents="none">
-        <SelectionCircle selected={selected} />
-      </View>
-    </View>
-  );
-}
+import { useSavedLinks } from '@/context/saved-links-context';
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
@@ -134,7 +101,7 @@ export default function FolderAddUrlScreen() {
             data={uncategorizedLinks}
             keyExtractor={(item) => String(item.id)}
             renderItem={({ item }) => (
-              <SelectableCard
+              <SelectableLinkCard
                 link={item}
                 selected={selectedIds.has(item.id)}
                 onToggle={toggleSelect}
@@ -216,30 +183,6 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: 8,
-  },
-
-  selectableCard: {
-    position: 'relative',
-  },
-  cardLayer: {
-    position: 'relative',
-    borderRadius: 22,
-    overflow: 'hidden',
-  },
-  selectedOverlay: {
-    position: 'absolute',
-    inset: 0,
-    borderRadius: 22,
-    backgroundColor: Colors.brand.overlaySelected,
-  },
-  checkOverlay: {
-    position: 'absolute',
-    right: 16,
-    top: 0,
-    bottom: 0,
-    justifyContent: 'center',
-    zIndex: 10,
-    elevation: 10,
   },
 
   emptyState: {

--- a/app/(tabs)/(folder)/folder-add-url.tsx
+++ b/app/(tabs)/(folder)/folder-add-url.tsx
@@ -25,19 +25,21 @@ interface SelectableCardProps {
 
 function SelectableCard({ link, selected, onToggle }: SelectableCardProps) {
   return (
-    <View style={styles.cardRow}>
-      <CardLink
-        verdict={link.verdict}
-        title={link.title}
-        originalUrl={link.originalUrl}
-        finalUrl={link.finalUrl}
-        bookmarked={link.isBookmarked}
-        icon={false}
-        onPress={() => onToggle(link.id)}
-      />
-      {selected && (
-        <View style={styles.selectedOverlay} pointerEvents="none" />
-      )}
+    <View style={styles.selectableCard}>
+      <View style={styles.cardLayer}>
+        <CardLink
+          verdict={link.verdict}
+          title={link.title}
+          originalUrl={link.originalUrl}
+          finalUrl={link.finalUrl}
+          bookmarked={link.isBookmarked}
+          icon={false}
+          onPress={() => onToggle(link.id)}
+        />
+        {selected && (
+          <View style={styles.selectedOverlay} pointerEvents="none" />
+        )}
+      </View>
       <View style={styles.checkOverlay} pointerEvents="none">
         <SelectionCircle selected={selected} />
       </View>
@@ -216,7 +218,10 @@ const styles = StyleSheet.create({
     height: 8,
   },
 
-  cardRow: {
+  selectableCard: {
+    position: 'relative',
+  },
+  cardLayer: {
     position: 'relative',
     borderRadius: 22,
     overflow: 'hidden',

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -241,6 +241,8 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: 0,
     justifyContent: 'center',
+    zIndex: 10,
+    elevation: 10,
   },
 
   emptyState: {

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -9,44 +9,10 @@ import {
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 
 import { Button } from '@/components/ui/button';
-import { CardLink } from '@/components/ui/card-link';
-import { SelectionCircle } from '@/components/ui/selection-circle';
+import { SelectableLinkCard } from '@/components/ui/selectable-link-card';
 import { Colors, Typography } from '@/constants/theme';
 import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
-import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
-
-// ─── Selectable card row ──────────────────────────────────────────────────────
-
-interface SelectableCardProps {
-  link: SavedLink;
-  selected: boolean;
-  onToggle: (id: number) => void;
-}
-
-function SelectableCard({ link, selected, onToggle }: SelectableCardProps) {
-  return (
-    <View style={styles.selectableCard}>
-      <View style={styles.cardLayer}>
-        <CardLink
-          verdict={link.verdict}
-          title={link.title}
-          originalUrl={link.originalUrl}
-          finalUrl={link.finalUrl}
-          bookmarked={link.isBookmarked}
-          icon={false}
-          onPress={() => onToggle(link.id)}
-        />
-        {/* 선택 시 카드 위에 어두운 오버레이 */}
-        {selected && (
-          <View style={styles.selectedOverlay} pointerEvents="none" />
-        )}
-      </View>
-      <View style={styles.checkOverlay} pointerEvents="none">
-        <SelectionCircle selected={selected} />
-      </View>
-    </View>
-  );
-}
+import { useSavedLinks } from '@/context/saved-links-context';
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
@@ -138,7 +104,7 @@ export default function FolderUrlSelectScreen() {
             data={links}
             keyExtractor={(item) => String(item.id)}
             renderItem={({ item }) => (
-              <SelectableCard
+              <SelectableLinkCard
                 link={item}
                 selected={selectedIds.has(item.id)}
                 onToggle={toggleSelect}
@@ -223,31 +189,6 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: 8,
-  },
-
-  // Selectable card
-  selectableCard: {
-    position: 'relative',
-  },
-  cardLayer: {
-    position: 'relative',
-    borderRadius: 22,
-    overflow: 'hidden',
-  },
-  selectedOverlay: {
-    position: 'absolute',
-    inset: 0,
-    borderRadius: 22,
-    backgroundColor: Colors.brand.overlaySelected,
-  },
-  checkOverlay: {
-    position: 'absolute',
-    right: 16,
-    top: 0,
-    bottom: 0,
-    justifyContent: 'center',
-    zIndex: 10,
-    elevation: 10,
   },
 
   emptyState: {

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -25,20 +25,22 @@ interface SelectableCardProps {
 
 function SelectableCard({ link, selected, onToggle }: SelectableCardProps) {
   return (
-    <View style={styles.cardRow}>
-      <CardLink
-        verdict={link.verdict}
-        title={link.title}
-        originalUrl={link.originalUrl}
-        finalUrl={link.finalUrl}
-        bookmarked={link.isBookmarked}
-        icon={false}
-        onPress={() => onToggle(link.id)}
-      />
-      {/* 선택 시 카드 위에 어두운 오버레이 */}
-      {selected && (
-        <View style={styles.selectedOverlay} pointerEvents="none" />
-      )}
+    <View style={styles.selectableCard}>
+      <View style={styles.cardLayer}>
+        <CardLink
+          verdict={link.verdict}
+          title={link.title}
+          originalUrl={link.originalUrl}
+          finalUrl={link.finalUrl}
+          bookmarked={link.isBookmarked}
+          icon={false}
+          onPress={() => onToggle(link.id)}
+        />
+        {/* 선택 시 카드 위에 어두운 오버레이 */}
+        {selected && (
+          <View style={styles.selectedOverlay} pointerEvents="none" />
+        )}
+      </View>
       <View style={styles.checkOverlay} pointerEvents="none">
         <SelectionCircle selected={selected} />
       </View>
@@ -224,7 +226,10 @@ const styles = StyleSheet.create({
   },
 
   // Selectable card
-  cardRow: {
+  selectableCard: {
+    position: 'relative',
+  },
+  cardLayer: {
     position: 'relative',
     borderRadius: 22,
     overflow: 'hidden',

--- a/components/ui/selectable-link-card.tsx
+++ b/components/ui/selectable-link-card.tsx
@@ -1,0 +1,62 @@
+import { StyleSheet, View } from 'react-native';
+
+import { Colors } from '@/constants/theme';
+import type { SavedLink } from '@/context/saved-links-context';
+import { CardLink } from './card-link';
+import { SelectionCircle } from './selection-circle';
+
+interface SelectableLinkCardProps {
+  link: SavedLink;
+  selected: boolean;
+  onToggle: (id: number) => void;
+}
+
+export function SelectableLinkCard({ link, selected, onToggle }: SelectableLinkCardProps) {
+  return (
+    <View style={styles.selectableCard}>
+      <View style={styles.cardLayer}>
+        <CardLink
+          verdict={link.verdict}
+          title={link.title}
+          originalUrl={link.originalUrl}
+          finalUrl={link.finalUrl}
+          bookmarked={link.isBookmarked}
+          icon={false}
+          onPress={() => onToggle(link.id)}
+        />
+        {selected && (
+          <View style={styles.selectedOverlay} pointerEvents="none" />
+        )}
+      </View>
+      <View style={styles.checkOverlay} pointerEvents="none">
+        <SelectionCircle selected={selected} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  selectableCard: {
+    position: 'relative',
+  },
+  cardLayer: {
+    position: 'relative',
+    borderRadius: 22,
+    overflow: 'hidden',
+  },
+  selectedOverlay: {
+    position: 'absolute',
+    inset: 0,
+    borderRadius: 22,
+    backgroundColor: Colors.brand.overlaySelected,
+  },
+  checkOverlay: {
+    position: 'absolute',
+    right: 16,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    zIndex: 10,
+    elevation: 10,
+  },
+});

--- a/components/ui/selection-circle.tsx
+++ b/components/ui/selection-circle.tsx
@@ -30,6 +30,7 @@ const styles = StyleSheet.create({
     borderRadius: CIRCLE_SIZE / 2,
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'visible',
   },
   unselected: {
     backgroundColor: Colors.brand.surface,
@@ -46,6 +47,8 @@ const styles = StyleSheet.create({
     borderBottomWidth: 2,
     borderRightWidth: 2,
     borderColor: Colors.brand.onPrimary,
+    zIndex: 2,
+    elevation: 2,
     transform: [{ rotate: '45deg' }, { translateY: -2 }],
   },
 });

--- a/components/ui/selection-circle.tsx
+++ b/components/ui/selection-circle.tsx
@@ -47,6 +47,8 @@ const styles = StyleSheet.create({
     borderBottomWidth: 2,
     borderRightWidth: 2,
     borderColor: Colors.brand.onPrimary,
+    zIndex: 2,
+    elevation: 2,
     transform: [{ rotate: '45deg' }, { translateY: -2 }],
   },
 });

--- a/components/ui/selection-circle.tsx
+++ b/components/ui/selection-circle.tsx
@@ -47,8 +47,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 2,
     borderRightWidth: 2,
     borderColor: Colors.brand.onPrimary,
-    zIndex: 2,
-    elevation: 2,
     transform: [{ rotate: '45deg' }, { translateY: -2 }],
   },
 });


### PR DESCRIPTION
Closes #53

## 개요
폴더 URL 추가/선택 화면에서 URL 선택 상태를 나타내는 체크아이콘이 Android 실기기에서 명확하게 보이지 않는 문제를 개선했습니다.

기존 구조에서는 `CardLink` 카드와 선택 오버레이, 체크아이콘이 같은 카드 레이어 안에서 함께 렌더링되고 있었습니다. Android에서는 카드의 `elevation`과 absolute overlay 렌더링 순서가 겹치면서, 선택된 URL의 체크 표시가 카드 뒤쪽에 깔린 것처럼 희미하게 보일 수 있었습니다.

이번 작업에서는 카드 본문과 선택 오버레이를 `cardLayer`로 분리하고, 체크아이콘은 별도 sibling overlay 레이어로 분리했습니다. 이를 통해 카드의 clipping 영역과 선택 오버레이는 기존처럼 유지하면서, 오른쪽 체크아이콘만 카드보다 앞에 표시되도록 보완했습니다.

## 주요 구현 내용
- 폴더 URL 추가 화면의 선택 카드 레이어 구조 분리
- 새 폴더 생성 중 URL 선택 화면의 선택 카드 레이어 구조 분리
- 카드 본문과 선택 오버레이를 `cardLayer` 내부로 유지
- 체크아이콘을 카드 레이어 밖의 별도 overlay sibling으로 분리
- 체크 overlay에 `zIndex`, Android `elevation` 적용
- 선택 원 내부 체크 표시가 잘리지 않도록 `SelectionCircle`의 overflow 처리 보완
- 기존 URL 선택/해제 동작과 선택 개수 반영 흐름 유지

## 파일별 역할
- `app/(tabs)/(folder)/folder-add-url.tsx`: 기존 폴더에 URL을 추가하는 화면에서 선택 체크아이콘 레이어 분리
- `app/(tabs)/(folder)/folder-url-select.tsx`: 새 폴더 생성 중 URL 선택 화면에서 선택 체크아이콘 레이어 분리
- `components/ui/selection-circle.tsx`: 선택 원 내부 체크 표시가 잘리지 않도록 overflow 및 레이어 처리 보완

## 해결한 이슈 목록
- [x] 폴더 URL 추가 화면의 선택 체크아이콘 렌더링 구조 확인
- [x] 새 폴더 생성 중 URL 선택 화면의 선택 체크아이콘 렌더링 구조 확인
- [x] Android에서 체크아이콘이 카드/오버레이 뒤에 깔려 보일 수 있는 레이어 구조 확인
- [x] 체크아이콘을 카드 본문 레이어와 분리
- [x] 체크아이콘 overlay가 카드보다 앞에 표시되도록 `zIndex`, `elevation` 적용
- [x] 선택 오버레이는 기존 카드 영역 안에 유지해 카드 레이아웃이 깨지지 않도록 처리
- [x] 선택된 URL과 선택되지 않은 URL의 상태를 상시 구분할 수 있도록 보완
- [x] 기존 URL 선택/해제 동작 유지
- [x] 하단 선택 개수 및 추가/생성 버튼 흐름 유지

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 폴더 URL 추가 흐름 유지
- [x] 기존 새 폴더 생성 중 URL 선택 흐름 유지
- [x] 선택 체크아이콘 외 카드 UI 구조가 불필요하게 변경되지 않도록 처리

## Screenshots or Video
- 체크표시 전 뜨는 화면입니다
<img width="1080" height="2220" alt="Screenshot_20260526-005102_LinClean" src="https://github.com/user-attachments/assets/a51aa8c7-bb01-459e-9c7d-d6505cd57601" />

- 체크표시 이후 뜨는 화면입니다
<img width="1080" height="2220" alt="Screenshot_20260526-012623_LinClean" src="https://github.com/user-attachments/assets/0cf151e7-ce01-4b5a-9298-58433be16b09" />

