### PR TITLE
[DESIGN] 작은 화면 주요 UI 깨짐 대응

### DIFF
--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -13,6 +13,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { AddFolderButton } from '@/components/ui/add-folder-button';
@@ -31,8 +32,15 @@ type MenuState = {
   folderId?: number;
 };
 
+const CONTENT_HORIZONTAL_PADDING = 24;
+const CANVAS_PADDING = 16;
+const FOLDER_GRID_GAP = 12;
+const DEFAULT_FOLDER_CARD_WIDTH = 144;
+const MIN_TWO_COLUMN_CARD_WIDTH = 120;
+
 export default function FolderScreen() {
   const router = useRouter();
+  const tabBarHeight = useBottomTabBarHeight();
   const { folderCreated: folderCreatedParam } = useLocalSearchParams<{
     folderCreated?: string | string[];
   }>();
@@ -59,6 +67,7 @@ export default function FolderScreen() {
   const [createToastVisible, setCreateToastVisible] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [renameToastVisible, setRenameToastVisible] = useState(false);
+  const [gridWidth, setGridWidth] = useState(0);
   const lastCreatedToastRef = useRef<string | undefined>(undefined);
   const renameInputRef = useRef<TextInput>(null);
   const folderCreated = typeof folderCreatedParam === 'string' ? folderCreatedParam : undefined;
@@ -67,6 +76,27 @@ export default function FolderScreen() {
     () => rawFolders.map((folder) => ({ ...folder })),
     [rawFolders],
   );
+  const folderCardWidth = useMemo(() => {
+    const availableWidth = gridWidth;
+
+    if (availableWidth <= 0) {
+      return DEFAULT_FOLDER_CARD_WIDTH;
+    }
+
+    const defaultTwoColumnWidth = DEFAULT_FOLDER_CARD_WIDTH * 2 + FOLDER_GRID_GAP;
+
+    if (availableWidth >= defaultTwoColumnWidth) {
+      return DEFAULT_FOLDER_CARD_WIDTH;
+    }
+
+    const compactTwoColumnWidth = Math.floor((availableWidth - FOLDER_GRID_GAP) / 2);
+
+    if (compactTwoColumnWidth >= MIN_TWO_COLUMN_CARD_WIDTH) {
+      return compactTwoColumnWidth;
+    }
+
+    return availableWidth;
+  }, [gridWidth]);
 
   const handleMorePress = (folderId: number, anchor: AnchorPosition) => {
     setMenuState({ visible: true, anchor, folderId });
@@ -154,7 +184,7 @@ export default function FolderScreen() {
     <SafeAreaView style={styles.safeArea} edges={['top']}>
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[styles.content, { paddingBottom: tabBarHeight + 24 }]}
         showsVerticalScrollIndicator={false}
       >
         {/* 상단 헤더 */}
@@ -181,12 +211,16 @@ export default function FolderScreen() {
               <ActivityIndicator color={Colors.brand.primary} />
             </View>
           ) : folders.length > 0 ? (
-            <View style={styles.grid}>
+            <View
+              style={styles.grid}
+              onLayout={(event) => setGridWidth(event.nativeEvent.layout.width)}
+            >
               {folders.map((folder) => (
                 <FolderCard
                   key={folder.id}
                   folderName={folder.name}
                   urlCount={folder.linkCount}
+                  width={folderCardWidth}
                   onPress={() => router.push({ pathname: '/(tabs)/(folder)/[id]' as any, params: { id: folder.id } })}
                   onMorePress={(anchor) => handleMorePress(folder.id, anchor)}
                 />
@@ -300,7 +334,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   content: {
-    paddingHorizontal: 24,
+    paddingHorizontal: CONTENT_HORIZONTAL_PADDING,
     paddingBottom: 32,
     gap: 20,
   },
@@ -323,13 +357,14 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     borderWidth: 1,
     borderColor: Colors.brand.line,
-    padding: 16,
+    padding: CANVAS_PADDING,
     gap: 16,
   },
   grid: {
+    width: '100%',
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 12,
+    gap: FOLDER_GRID_GAP,
   },
   errorBox: {
     borderRadius: 12,

--- a/app/(tabs)/(home)/add-link.tsx
+++ b/app/(tabs)/(home)/add-link.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
@@ -13,6 +14,9 @@ import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { ScanButton } from '@/components/ui/scan-button';
 import { Colors, Typography } from '@/constants/theme';
 import { normalizeHttpUrlInput } from '@/utils/shared-url';
+
+const COMPACT_WIDTH = 380;
+const SHORT_SCREEN_HEIGHT = 760;
 
 function getSharedUrlParam(value: string | string[] | undefined): string {
   if (typeof value !== 'string') {
@@ -24,9 +28,11 @@ function getSharedUrlParam(value: string | string[] | undefined): string {
 
 export default function AddLinkScreen() {
   const { sharedUrl } = useLocalSearchParams<{ sharedUrl?: string }>();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const initialSharedUrl = getSharedUrlParam(sharedUrl);
   const [url, setUrl] = useState(initialSharedUrl);
   const [error, setError] = useState('');
+  const isCompact = windowWidth < COMPACT_WIDTH || windowHeight <= SHORT_SCREEN_HEIGHT;
 
   useEffect(() => {
     const nextSharedUrl = getSharedUrlParam(sharedUrl);
@@ -89,19 +95,21 @@ export default function AddLinkScreen() {
           style={styles.flex}
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
-          <View style={styles.container}>
+          <View style={[styles.container, isCompact && styles.containerCompact]}>
             {/* 타이틀 */}
-            <View style={styles.titleRow}>
-              <Text style={styles.titleGreen}>링크를</Text>
-              <Text style={styles.titleDark}> 입력해주세요</Text>
+            <View style={[styles.titleRow, isCompact && styles.titleRowCompact]}>
+              <Text style={[styles.titleGreen, isCompact && styles.titleCompact]}>링크를</Text>
+              <Text style={[styles.titleDark, isCompact && styles.titleCompact]}> 입력해주세요</Text>
             </View>
 
             {/* 부제목 */}
-            <Text style={styles.subtitle}>보안검사 후 저장할 수 있습니다.</Text>
+            <Text style={[styles.subtitle, isCompact && styles.subtitleCompact]}>
+              보안검사 후 저장할 수 있습니다.
+            </Text>
 
             {/* URL 입력 + 검사 버튼 */}
-            <View style={styles.inputRow}>
-              <View style={[styles.inputWrapper, hasError && styles.inputError]}>
+            <View style={[styles.inputRow, isCompact && styles.inputRowCompact]}>
+              <View style={[styles.inputWrapper, isCompact && styles.inputWrapperCompact, hasError && styles.inputError]}>
                 <TextInput
                   style={styles.input}
                   placeholder="https://example.com"
@@ -128,10 +136,10 @@ export default function AddLinkScreen() {
             </View>
 
             {/* 에러 메시지 */}
-            {hasError && <Text style={styles.errorText}>{error}</Text>}
+            {hasError && <Text style={[styles.errorText, isCompact && styles.errorTextCompact]}>{error}</Text>}
 
             {/* 안내 박스 */}
-            <View style={styles.infoBox}>
+            <View style={[styles.infoBox, isCompact && styles.infoBoxCompact]}>
               <Text style={styles.infoLabel}>안내</Text>
               <Text style={styles.infoBody}>
                 검사 후 안전한 사이트이라면, 저장하실 수 있습니다.
@@ -157,12 +165,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingTop: 16,
   },
+  containerCompact: {
+    paddingHorizontal: 20,
+    paddingTop: 8,
+  },
 
   // 타이틀
   titleRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     marginBottom: 12,
+  },
+  titleRowCompact: {
+    marginBottom: 8,
   },
   titleGreen: {
     ...Typography.display,
@@ -172,12 +187,19 @@ const styles = StyleSheet.create({
     ...Typography.display,
     color: Colors.brand.text,
   },
+  titleCompact: {
+    ...Typography.pageTitle,
+  },
 
   // 부제목
   subtitle: {
     ...Typography.body,
     color: Colors.brand.textSecondary,
     marginBottom: 32,
+  },
+  subtitleCompact: {
+    ...Typography.summary,
+    marginBottom: 24,
   },
 
   // 입력 행
@@ -186,6 +208,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
     marginBottom: 8,
+  },
+  inputRowCompact: {
+    gap: 6,
   },
   inputWrapper: {
     flex: 1,
@@ -197,6 +222,10 @@ const styles = StyleSheet.create({
     borderColor: Colors.brand.line,
     backgroundColor: Colors.brand.surface,
     paddingHorizontal: 16,
+  },
+  inputWrapperCompact: {
+    height: 56,
+    paddingHorizontal: 14,
   },
   inputError: {
     borderColor: Colors.brand.textWarning,
@@ -226,6 +255,10 @@ const styles = StyleSheet.create({
     color: Colors.brand.textWarning,
     marginBottom: 16,
   },
+  errorTextCompact: {
+    ...Typography.summary,
+    marginBottom: 12,
+  },
 
   // 안내 박스
   infoBox: {
@@ -234,6 +267,10 @@ const styles = StyleSheet.create({
     padding: 16,
     marginTop: 16,
     gap: 6,
+  },
+  infoBoxCompact: {
+    padding: 14,
+    marginTop: 12,
   },
   infoLabel: {
     ...Typography.caption,

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -4,8 +4,10 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { AppIcon } from '@/components/ui/app-icon';
@@ -20,10 +22,14 @@ import { useFolders } from '@/context/folders-context';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 
+const COMPACT_WIDTH = 380;
+
 export default function HomeScreen() {
   const { savedLinkToast: savedLinkToastParam } = useLocalSearchParams<{
     savedLinkToast?: string | string[];
   }>();
+  const { width: windowWidth } = useWindowDimensions();
+  const tabBarHeight = useBottomTabBarHeight();
   const { links, toggleBookmark, deleteLink, updateTitle } = useSavedLinks();
   const { refreshFolders } = useFolders();
   const [menuState, setMenuState] = useState<{ visible: boolean; anchor?: AnchorPosition; linkId?: number }>({ visible: false });
@@ -33,6 +39,7 @@ export default function HomeScreen() {
   const [titleToastVisible, setTitleToastVisible] = useState(false);
   const lastToastParamRef = useRef<string | undefined>(undefined);
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
+  const isCompactWidth = windowWidth < COMPACT_WIDTH;
 
   // 최근 저장한 링크 — createdAt 내림차순 상위 3개
   const recentLinks = links.slice(0, 3);
@@ -104,7 +111,11 @@ export default function HomeScreen() {
     <SafeAreaView style={styles.safeArea} edges={['top']}>
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[
+          styles.content,
+          isCompactWidth && styles.contentCompact,
+          { paddingBottom: tabBarHeight + 24 },
+        ]}
         showsVerticalScrollIndicator={false}
       >
         {/* 상단 헤더 */}
@@ -115,23 +126,23 @@ export default function HomeScreen() {
               size={30}
               color={Colors.brand.primary}
             />
-            <Text style={styles.brandText}>LinClean</Text>
+            <Text style={[styles.brandText, isCompactWidth && styles.brandTextCompact]}>LinClean</Text>
           </View>
           <AppIcon name="settings" size={28} label="설정" onPress={() => router.push('/(tabs)/(home)/settings')} />
         </View>
 
         {/* 서브타이틀 */}
-        <Text style={styles.subtitle}>오늘도 안전하게 정리해요</Text>
+        <Text style={[styles.subtitle, isCompactWidth && styles.subtitleCompact]}>오늘도 안전하게 정리해요</Text>
 
         {/* 보안 등급별 링크 현황 */}
         <View style={styles.section}>
-          <SectionHeader label="보안 등급별 링크 현황" />
-          <View style={styles.statPlaceholder}>
-            <View style={styles.statGrid}>
-              <View style={styles.statItem} />
-              <View style={styles.statItem} />
-              <View style={styles.statItem} />
-              <View style={styles.statItem} />
+          <SectionHeader label="보안 등급별 링크 현황" compact={isCompactWidth} />
+          <View style={[styles.statPlaceholder, isCompactWidth && styles.statPlaceholderCompact]}>
+            <View style={[styles.statGrid, isCompactWidth && styles.statGridCompact]}>
+              <View style={[styles.statItem, isCompactWidth && styles.statItemCompact]} />
+              <View style={[styles.statItem, isCompactWidth && styles.statItemCompact]} />
+              <View style={[styles.statItem, isCompactWidth && styles.statItemCompact]} />
+              <View style={[styles.statItem, isCompactWidth && styles.statItemCompact]} />
             </View>
           </View>
         </View>
@@ -141,6 +152,7 @@ export default function HomeScreen() {
           <SectionHeader
             label="최근 저장한 링크"
             onViewAll={() => router.push('/saved-links')}
+            compact={isCompactWidth}
           />
           <View style={styles.linkList}>
             {recentLinks.map((link) => (
@@ -222,6 +234,10 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     gap: 24,
   },
+  contentCompact: {
+    paddingHorizontal: 20,
+    gap: 18,
+  },
 
   header: {
     flexDirection: 'row',
@@ -238,11 +254,17 @@ const styles = StyleSheet.create({
     ...Typography.displayMedium,
     color: Colors.brand.primary,
   },
+  brandTextCompact: {
+    ...Typography.pageTitle,
+  },
 
   subtitle: {
     ...Typography.caption,
     color: Colors.brand.textSecondary,
     marginTop: -16,
+  },
+  subtitleCompact: {
+    marginTop: -10,
   },
 
   section: {
@@ -256,10 +278,16 @@ const styles = StyleSheet.create({
     borderColor: Colors.brand.line,
     padding: 16,
   },
+  statPlaceholderCompact: {
+    padding: 14,
+  },
   statGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 12,
+  },
+  statGridCompact: {
+    gap: 10,
   },
   statItem: {
     flex: 1,
@@ -269,6 +297,9 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     borderColor: Colors.brand.line,
     borderStyle: 'dashed',
+  },
+  statItemCompact: {
+    height: 48,
   },
 
   linkList: {

--- a/app/(tabs)/(home)/scan-result-block.tsx
+++ b/app/(tabs)/(home)/scan-result-block.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
@@ -13,11 +14,16 @@ import {
   getRouteParam,
 } from '@/utils/analysis-result-display';
 
+const COMPACT_RESULT_HEIGHT = 760;
+const VERY_COMPACT_RESULT_HEIGHT = 700;
+
 export default function ScanResultBlockScreen() {
   const {
     analysisId: analysisIdParam,
     url: urlParam,
   } = useLocalSearchParams<{ analysisId?: string | string[]; url?: string | string[] }>();
+  const { height: windowHeight } = useWindowDimensions();
+  const tabBarHeight = useBottomTabBarHeight();
   const analysisId = getRouteParam(analysisIdParam);
   const url = getRouteParam(urlParam);
   const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
@@ -25,6 +31,8 @@ export default function ScanResultBlockScreen() {
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('danger'));
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'danger');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
+  const isCompactResult = windowHeight <= COMPACT_RESULT_HEIGHT;
+  const isVeryCompactResult = windowHeight <= VERY_COMPACT_RESULT_HEIGHT;
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'danger') {
@@ -77,24 +85,30 @@ export default function ScanResultBlockScreen() {
       />
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={styles.container}
+        contentContainerStyle={[
+          styles.container,
+          isCompactResult && styles.containerCompact,
+          { paddingBottom: tabBarHeight + (isCompactResult ? 16 : 24) },
+        ]}
         showsVerticalScrollIndicator={false}
       >
         {/* 차단 배지 */}
-        <View style={styles.badgeArea}>
-          <ResultStatusIcon variant="block" label="차단" size="large" />
+        <View style={[styles.badgeArea, isCompactResult && styles.badgeAreaCompact]}>
+          <ResultStatusIcon variant="block" label="차단" size="large" compact={isCompactResult} />
         </View>
 
         {/* 결과 텍스트 */}
-        <Text style={styles.resultTitle}>차단된 위험 링크입니다.</Text>
+        <Text style={[styles.resultTitle, isCompactResult && styles.resultTitleCompact]}>
+          차단된 위험 링크입니다.
+        </Text>
 
         {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-        <ScanResultReason reason={reason} style={styles.reasonCard} />
+        <ScanResultReason reason={reason} style={[styles.reasonCard, isCompactResult && styles.reasonCardCompact]} />
 
         {/* 검사 대상 카드 */}
-        <View style={styles.card}>
+        <View style={[styles.card, isCompactResult && styles.cardCompact]}>
           <Text style={styles.cardLabel}>검사 대상</Text>
           <Text style={styles.cardUrl} numberOfLines={1} ellipsizeMode="tail">
             {displayUrl}
@@ -104,7 +118,7 @@ export default function ScanResultBlockScreen() {
         {/* 확인 버튼 */}
         <View style={styles.buttonArea}>
           <TouchableOpacity
-            style={styles.confirmButton}
+            style={[styles.confirmButton, isVeryCompactResult && styles.buttonVeryCompact]}
             onPress={() => router.dismissAll()}
             activeOpacity={0.8}
           >
@@ -128,10 +142,16 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     alignItems: 'center',
   },
+  containerCompact: {
+    paddingTop: 0,
+  },
 
   badgeArea: {
     alignItems: 'center',
     marginBottom: 20,
+  },
+  badgeAreaCompact: {
+    marginBottom: 12,
   },
 
   resultTitle: {
@@ -140,8 +160,15 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 10,
   },
+  resultTitleCompact: {
+    ...Typography.pageTitle,
+    marginBottom: 8,
+  },
   reasonCard: {
     marginBottom: 24,
+  },
+  reasonCardCompact: {
+    marginBottom: 16,
   },
   statusText: {
     ...Typography.caption,
@@ -170,6 +197,10 @@ const styles = StyleSheet.create({
     gap: 6,
     marginBottom: 28,
   },
+  cardCompact: {
+    padding: 14,
+    marginBottom: 20,
+  },
   cardLabel: {
     ...Typography.caption,
     color: Colors.brand.textHint,
@@ -189,6 +220,10 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brand.textWarning,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  buttonVeryCompact: {
+    height: 52,
+    borderRadius: 26,
   },
   confirmButtonText: {
     ...Typography.section,

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
@@ -16,12 +17,17 @@ import {
   getRouteParam,
 } from '@/utils/analysis-result-display';
 
+const COMPACT_RESULT_HEIGHT = 760;
+const VERY_COMPACT_RESULT_HEIGHT = 700;
+
 export default function ScanResultCautionScreen() {
   const {
     analysisId: analysisIdParam,
     url: urlParam,
   } = useLocalSearchParams<{ analysisId?: string | string[]; url?: string | string[] }>();
   const { addLink } = useSavedLinks();
+  const { height: windowHeight } = useWindowDimensions();
+  const tabBarHeight = useBottomTabBarHeight();
   const analysisId = getRouteParam(analysisIdParam);
   const url = getRouteParam(urlParam);
   const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
@@ -39,6 +45,8 @@ export default function ScanResultCautionScreen() {
     !isLoading &&
     !shouldRedirectToVerdict &&
     !isSaving;
+  const isCompactResult = windowHeight <= COMPACT_RESULT_HEIGHT;
+  const isVeryCompactResult = windowHeight <= VERY_COMPACT_RESULT_HEIGHT;
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'caution') {
@@ -130,24 +138,30 @@ export default function ScanResultCautionScreen() {
       />
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={styles.container}
+        contentContainerStyle={[
+          styles.container,
+          isCompactResult && styles.containerCompact,
+          { paddingBottom: tabBarHeight + (isCompactResult ? 16 : 24) },
+        ]}
         showsVerticalScrollIndicator={false}
       >
         {/* 주의 배지 */}
-        <View style={styles.badgeArea}>
-          <ResultStatusIcon variant="caution" label="주의" size="large" />
+        <View style={[styles.badgeArea, isCompactResult && styles.badgeAreaCompact]}>
+          <ResultStatusIcon variant="caution" label="주의" size="large" compact={isCompactResult} />
         </View>
 
         {/* 결과 텍스트 */}
-        <Text style={styles.resultTitle}>주의가 필요한 링크입니다.</Text>
+        <Text style={[styles.resultTitle, isCompactResult && styles.resultTitleCompact]}>
+          주의가 필요한 링크입니다.
+        </Text>
 
         {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-        <ScanResultReason reason={reason} style={styles.reasonCard} />
+        <ScanResultReason reason={reason} style={[styles.reasonCard, isCompactResult && styles.reasonCardCompact]} />
 
         {/* 검사 대상 카드 */}
-        <View style={styles.card}>
+        <View style={[styles.card, isCompactResult && styles.cardCompact]}>
           <Text style={styles.cardLabel}>검사 대상</Text>
           <Text style={styles.cardUrl} numberOfLines={1} ellipsizeMode="tail">
             {displayUrl}
@@ -155,9 +169,13 @@ export default function ScanResultCautionScreen() {
         </View>
 
         {/* 버튼 영역 */}
-        <View style={styles.buttonArea}>
+        <View style={[styles.buttonArea, isCompactResult && styles.buttonAreaCompact]}>
           <TouchableOpacity
-            style={[styles.cautionButton, !canSave && styles.disabledButton]}
+            style={[
+              styles.cautionButton,
+              isVeryCompactResult && styles.buttonVeryCompact,
+              !canSave && styles.disabledButton,
+            ]}
             onPress={() => setSaveModalVisible(true)}
             activeOpacity={0.8}
             disabled={!canSave}
@@ -165,7 +183,11 @@ export default function ScanResultCautionScreen() {
             <Text style={styles.cautionButtonText}>주의 후 저장</Text>
           </TouchableOpacity>
 
-          <TouchableOpacity style={styles.secondaryButton} onPress={handleOpenUrl} activeOpacity={0.8}>
+          <TouchableOpacity
+            style={[styles.secondaryButton, isVeryCompactResult && styles.buttonVeryCompact]}
+            onPress={handleOpenUrl}
+            activeOpacity={0.8}
+          >
             <Text style={styles.secondaryButtonText}>즉시 URL 접속</Text>
           </TouchableOpacity>
         </View>
@@ -198,10 +220,16 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     alignItems: 'center',
   },
+  containerCompact: {
+    paddingTop: 0,
+  },
 
   badgeArea: {
     alignItems: 'center',
     marginBottom: 20,
+  },
+  badgeAreaCompact: {
+    marginBottom: 12,
   },
 
   resultTitle: {
@@ -210,8 +238,15 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 10,
   },
+  resultTitleCompact: {
+    ...Typography.pageTitle,
+    marginBottom: 8,
+  },
   reasonCard: {
     marginBottom: 24,
+  },
+  reasonCardCompact: {
+    marginBottom: 16,
   },
   statusText: {
     ...Typography.caption,
@@ -240,6 +275,10 @@ const styles = StyleSheet.create({
     gap: 6,
     marginBottom: 28,
   },
+  cardCompact: {
+    padding: 14,
+    marginBottom: 20,
+  },
   cardLabel: {
     ...Typography.caption,
     color: Colors.brand.textHint,
@@ -253,6 +292,9 @@ const styles = StyleSheet.create({
     width: '100%',
     gap: 12,
   },
+  buttonAreaCompact: {
+    gap: 10,
+  },
   cautionButton: {
     width: '100%',
     height: 56,
@@ -260,6 +302,10 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brand.textCaution,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  buttonVeryCompact: {
+    height: 52,
+    borderRadius: 26,
   },
   cautionButtonText: {
     ...Typography.section,

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
@@ -16,12 +17,17 @@ import {
   getRouteParam,
 } from '@/utils/analysis-result-display';
 
+const COMPACT_RESULT_HEIGHT = 760;
+const VERY_COMPACT_RESULT_HEIGHT = 700;
+
 export default function ScanResultScreen() {
   const {
     analysisId: analysisIdParam,
     url: urlParam,
   } = useLocalSearchParams<{ analysisId?: string | string[]; url?: string | string[] }>();
   const { addLink } = useSavedLinks();
+  const { height: windowHeight } = useWindowDimensions();
+  const tabBarHeight = useBottomTabBarHeight();
   const analysisId = getRouteParam(analysisIdParam);
   const url = getRouteParam(urlParam);
   const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
@@ -39,6 +45,8 @@ export default function ScanResultScreen() {
     !isLoading &&
     !shouldRedirectToVerdict &&
     !isSaving;
+  const isCompactResult = windowHeight <= COMPACT_RESULT_HEIGHT;
+  const isVeryCompactResult = windowHeight <= VERY_COMPACT_RESULT_HEIGHT;
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'safe') {
@@ -130,24 +138,30 @@ export default function ScanResultScreen() {
       />
       <ScrollView
         style={styles.scroll}
-        contentContainerStyle={styles.container}
+        contentContainerStyle={[
+          styles.container,
+          isCompactResult && styles.containerCompact,
+          { paddingBottom: tabBarHeight + (isCompactResult ? 16 : 24) },
+        ]}
         showsVerticalScrollIndicator={false}
       >
         {/* 안전 배지 영역 */}
-        <View style={styles.badgeArea}>
-          <ResultStatusIcon variant="safe" label="안전" size="large" />
+        <View style={[styles.badgeArea, isCompactResult && styles.badgeAreaCompact]}>
+          <ResultStatusIcon variant="safe" label="안전" size="large" compact={isCompactResult} />
         </View>
 
         {/* 결과 텍스트 */}
-        <Text style={styles.resultTitle}>안전한 웹사이트입니다.</Text>
+        <Text style={[styles.resultTitle, isCompactResult && styles.resultTitleCompact]}>
+          안전한 웹사이트입니다.
+        </Text>
 
         {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-        <ScanResultReason reason={reason} style={styles.reasonCard} />
+        <ScanResultReason reason={reason} style={[styles.reasonCard, isCompactResult && styles.reasonCardCompact]} />
 
         {/* 검사 대상 카드 */}
-        <View style={styles.card}>
+        <View style={[styles.card, isCompactResult && styles.cardCompact]}>
           <Text style={styles.cardLabel}>검사 대상</Text>
           <Text style={styles.cardUrl} numberOfLines={1} ellipsizeMode="tail">
             {displayUrl}
@@ -155,9 +169,13 @@ export default function ScanResultScreen() {
         </View>
 
         {/* 버튼 영역 */}
-        <View style={styles.buttonArea}>
+        <View style={[styles.buttonArea, isCompactResult && styles.buttonAreaCompact]}>
           <TouchableOpacity
-            style={[styles.primaryButton, !canSave && styles.disabledButton]}
+            style={[
+              styles.primaryButton,
+              isVeryCompactResult && styles.buttonVeryCompact,
+              !canSave && styles.disabledButton,
+            ]}
             onPress={() => setSaveModalVisible(true)}
             activeOpacity={0.8}
             disabled={!canSave}
@@ -165,7 +183,11 @@ export default function ScanResultScreen() {
             <Text style={styles.primaryButtonText}>저장</Text>
           </TouchableOpacity>
 
-          <TouchableOpacity style={styles.secondaryButton} onPress={handleOpenUrl} activeOpacity={0.8}>
+          <TouchableOpacity
+            style={[styles.secondaryButton, isVeryCompactResult && styles.buttonVeryCompact]}
+            onPress={handleOpenUrl}
+            activeOpacity={0.8}
+          >
             <Text style={styles.secondaryButtonText}>즉시 URL 접속</Text>
           </TouchableOpacity>
         </View>
@@ -198,11 +220,17 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
     alignItems: 'center',
   },
+  containerCompact: {
+    paddingTop: 0,
+  },
 
   // 배지 영역
   badgeArea: {
     alignItems: 'center',
     marginBottom: 20,
+  },
+  badgeAreaCompact: {
+    marginBottom: 12,
   },
 
   // 결과 텍스트
@@ -212,8 +240,15 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 10,
   },
+  resultTitleCompact: {
+    ...Typography.pageTitle,
+    marginBottom: 8,
+  },
   reasonCard: {
     marginBottom: 24,
+  },
+  reasonCardCompact: {
+    marginBottom: 16,
   },
   statusText: {
     ...Typography.caption,
@@ -243,6 +278,10 @@ const styles = StyleSheet.create({
     gap: 6,
     marginBottom: 28,
   },
+  cardCompact: {
+    padding: 14,
+    marginBottom: 20,
+  },
   cardLabel: {
     ...Typography.caption,
     color: Colors.brand.textHint,
@@ -257,6 +296,9 @@ const styles = StyleSheet.create({
     width: '100%',
     gap: 12,
   },
+  buttonAreaCompact: {
+    gap: 10,
+  },
   primaryButton: {
     width: '100%',
     height: 56,
@@ -264,6 +306,10 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brand.primary,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  buttonVeryCompact: {
+    height: 52,
+    borderRadius: 26,
   },
   primaryButtonText: {
     ...Typography.section,

--- a/app/(tabs)/(home)/scanning.tsx
+++ b/app/(tabs)/(home)/scanning.tsx
@@ -2,7 +2,8 @@ import { useAuth } from '@clerk/expo';
 import LottieView from 'lottie-react-native';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 
 import { fetchAnalysis, requestAnalysis, type AnalysisResponse, type AnalysisVerdict } from '@/api/analyses';
 import { ApiError } from '@/api/api-client';
@@ -10,14 +11,28 @@ import { Colors, Typography } from '@/constants/theme';
 
 const POLLING_INTERVAL_MS = 2_000;
 const MAX_POLLING_MS = 30_000;
+const SHORT_SCREEN_HEIGHT = 760;
+const VERY_SHORT_SCREEN_HEIGHT = 700;
+const DEFAULT_ANIMATION_SIZE = 280;
+const SHORT_ANIMATION_SIZE = 216;
+const VERY_SHORT_ANIMATION_SIZE = 188;
 
 export default function ScanningScreen() {
   const { getToken, isLoaded, isSignedIn } = useAuth();
   const { url: urlParam } = useLocalSearchParams<{ url?: string | string[] }>();
   const url = getUrlParam(urlParam);
+  const { height: windowHeight } = useWindowDimensions();
+  const tabBarHeight = useBottomTabBarHeight();
   const [errorMessage, setErrorMessage] = useState('');
   const [retryKey, setRetryKey] = useState(0);
   const getTokenRef = useRef(getToken);
+  const isShortScreen = windowHeight <= SHORT_SCREEN_HEIGHT;
+  const isVeryShortScreen = windowHeight <= VERY_SHORT_SCREEN_HEIGHT;
+  const animationSize = isVeryShortScreen
+    ? VERY_SHORT_ANIMATION_SIZE
+    : isShortScreen
+      ? SHORT_ANIMATION_SIZE
+      : DEFAULT_ANIMATION_SIZE;
 
   useEffect(() => {
     getTokenRef.current = getToken;
@@ -102,14 +117,28 @@ export default function ScanningScreen() {
           headerShadowVisible: false,
         }}
       />
-      <View style={styles.container}>
+      <View
+        style={[
+          styles.container,
+          isShortScreen && styles.containerCompact,
+          isVeryShortScreen && styles.containerVeryCompact,
+          { paddingBottom: tabBarHeight + 24 },
+        ]}
+      >
         {/* Lottie 애니메이션 + 가운데 점 */}
-        <View style={styles.animationWrapper}>
+        <View
+          style={[
+            styles.animationWrapper,
+            { width: animationSize, height: animationSize },
+            isShortScreen && styles.animationWrapperCompact,
+            isVeryShortScreen && styles.animationWrapperVeryCompact,
+          ]}
+        >
           <LottieView
             source={require('@/assets/animations/scanning.json')}
             autoPlay={!hasError}
             loop={!hasError}
-            style={styles.animation}
+            style={[styles.animation, { width: animationSize, height: animationSize }]}
           />
           <View style={styles.dotsOverlay}>
             <View style={styles.dot} />
@@ -119,15 +148,15 @@ export default function ScanningScreen() {
         </View>
 
         {/* 텍스트 */}
-        <Text style={styles.title}>
+        <Text style={[styles.title, isShortScreen && styles.titleCompact]}>
           {hasError ? '검사를 완료하지 못했어요' : '보안 검사 중입니다'}
         </Text>
-        <Text style={[styles.subtitle, hasError && styles.errorText]}>
+        <Text style={[styles.subtitle, isShortScreen && styles.subtitleCompact, hasError && styles.errorText]}>
           {hasError ? errorMessage : '약 5-10초 정도 소요돼요'}
         </Text>
 
         {/* 검사 대상 카드 */}
-        <View style={styles.card}>
+        <View style={[styles.card, isShortScreen && styles.cardCompact]}>
           <Text style={styles.cardLabel}>검사 대상</Text>
           <Text style={styles.cardUrl} numberOfLines={1} ellipsizeMode="tail">
             {url}
@@ -135,16 +164,16 @@ export default function ScanningScreen() {
         </View>
 
         {hasError && (
-          <View style={styles.buttonArea}>
+          <View style={[styles.buttonArea, isShortScreen && styles.buttonAreaCompact]}>
             <TouchableOpacity
-              style={styles.primaryButton}
+              style={[styles.primaryButton, isVeryShortScreen && styles.buttonCompact]}
               onPress={() => setRetryKey((key) => key + 1)}
               activeOpacity={0.8}
             >
               <Text style={styles.primaryButtonText}>다시 검사</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={styles.secondaryButton}
+              style={[styles.secondaryButton, isVeryShortScreen && styles.buttonCompact]}
               onPress={() => router.back()}
               activeOpacity={0.8}
             >
@@ -298,12 +327,24 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingTop: 40,
   },
+  containerCompact: {
+    paddingTop: 20,
+  },
+  containerVeryCompact: {
+    paddingTop: 12,
+  },
   animationWrapper: {
     width: 280,
     height: 280,
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: 32,
+  },
+  animationWrapperCompact: {
+    marginBottom: 20,
+  },
+  animationWrapperVeryCompact: {
+    marginBottom: 14,
   },
   animation: {
     width: 280,
@@ -328,11 +369,17 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 8,
   },
+  titleCompact: {
+    ...Typography.pageTitle,
+  },
   subtitle: {
     ...Typography.body,
     color: Colors.brand.textSecondary,
     textAlign: 'center',
     marginBottom: 40,
+  },
+  subtitleCompact: {
+    marginBottom: 24,
   },
   card: {
     width: '100%',
@@ -341,6 +388,10 @@ const styles = StyleSheet.create({
     padding: 16,
     gap: 6,
     marginBottom: 24,
+  },
+  cardCompact: {
+    padding: 14,
+    marginBottom: 18,
   },
   cardLabel: {
     ...Typography.caption,
@@ -358,6 +409,9 @@ const styles = StyleSheet.create({
     width: '100%',
     gap: 12,
   },
+  buttonAreaCompact: {
+    gap: 10,
+  },
   primaryButton: {
     width: '100%',
     height: 56,
@@ -365,6 +419,10 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brand.primary,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  buttonCompact: {
+    height: 52,
+    borderRadius: 26,
   },
   primaryButtonText: {
     ...Typography.section,

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -34,8 +34,8 @@ export function FolderCard({
   const cardWidth = width ?? DEFAULT_CARD_WIDTH;
 
   const handleMorePress = () => {
-    moreRef.current?.measure((_fx, _fy, width, height, px, py) => {
-      onMorePress?.({ x: px, y: py, width, height });
+    moreRef.current?.measure((_fx, _fy, measuredWidth, measuredHeight, px, py) => {
+      onMorePress?.({ x: px, y: py, width: measuredWidth, height: measuredHeight });
     });
   };
 

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -4,6 +4,8 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { Colors, Typography } from '@/constants/theme';
 import { AppIcon } from './app-icon';
 
+const DEFAULT_CARD_WIDTH = 144;
+
 export interface AnchorPosition {
   x: number;
   y: number;
@@ -14,6 +16,7 @@ export interface AnchorPosition {
 export interface FolderCardProps {
   folderName: string;
   urlCount: number;
+  width?: number;
   onPress?: () => void;
   onMorePress?: (anchor: AnchorPosition) => void;
   disabled?: boolean;
@@ -22,11 +25,13 @@ export interface FolderCardProps {
 export function FolderCard({
   folderName,
   urlCount,
+  width,
   onPress,
   onMorePress,
   disabled = false,
 }: FolderCardProps) {
   const moreRef = useRef<View>(null);
+  const cardWidth = width ?? DEFAULT_CARD_WIDTH;
 
   const handleMorePress = () => {
     moreRef.current?.measure((_fx, _fy, width, height, px, py) => {
@@ -36,7 +41,7 @@ export function FolderCard({
 
   return (
     <Pressable
-      style={({ pressed }) => [pressed && !disabled && styles.pressed]}
+      style={({ pressed }) => [styles.root, { width: cardWidth }, pressed && !disabled && styles.pressed]}
       onPress={disabled ? undefined : onPress}
       accessibilityRole="button"
       accessibilityLabel={`${folderName} 폴더, ${urlCount}개`}
@@ -44,7 +49,7 @@ export function FolderCard({
     >
       {disabled ? (
         <View style={[styles.shadow, styles.shadowDisabled]}>
-          <View style={styles.cardDisabled}>
+          <View style={[styles.cardDisabled, { width: cardWidth }]}>
             <View style={styles.header}>
               <Text style={[styles.count, styles.countDisabled]}>{urlCount}개</Text>
               <View ref={moreRef} collapsable={false}>
@@ -67,7 +72,7 @@ export function FolderCard({
             colors={[Colors.brand.folderGradientStart, Colors.brand.folderGradientEnd]}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 1 }}
-            style={styles.card}
+            style={[styles.card, { width: cardWidth }]}
           >
             <View style={styles.header}>
               <Text style={styles.count}>{urlCount}개</Text>
@@ -90,6 +95,9 @@ export function FolderCard({
 }
 
 const styles = StyleSheet.create({
+  root: {
+    flexShrink: 0,
+  },
   shadow: {
     borderRadius: 16,
     shadowColor: Colors.brand.shadow,

--- a/components/ui/result-status-icon.tsx
+++ b/components/ui/result-status-icon.tsx
@@ -10,6 +10,7 @@ interface ResultStatusIconProps {
   icon?: boolean;
   disabled?: boolean;
   size?: 'default' | 'large';
+  compact?: boolean;
 }
 
 const VARIANT_CONFIG = {
@@ -49,23 +50,53 @@ export function ResultStatusIcon({
   icon = true,
   disabled = false,
   size = 'default',
+  compact = false,
 }: ResultStatusIconProps) {
   const config = VARIANT_CONFIG[variant];
   const isLarge = size === 'large';
+  const isCompactLarge = isLarge && compact;
 
   return (
-    <View style={[styles.container, isLarge && styles.containerLarge, disabled && styles.disabled]}>
+    <View
+      style={[
+        styles.container,
+        isLarge && styles.containerLarge,
+        isCompactLarge && styles.containerLargeCompact,
+        disabled && styles.disabled,
+      ]}
+    >
       {/* 외부 글로우 레이어 */}
-      <View style={[styles.glowOuter, isLarge && styles.glowOuterLarge, { backgroundColor: config.glowColor, opacity: disabled ? 0.3 : 0.15 }]} />
+      <View
+        style={[
+          styles.glowOuter,
+          isLarge && styles.glowOuterLarge,
+          isCompactLarge && styles.glowOuterLargeCompact,
+          { backgroundColor: config.glowColor, opacity: disabled ? 0.3 : 0.15 },
+        ]}
+      />
       {/* 내부 글로우 레이어 */}
-      <View style={[styles.glowInner, isLarge && styles.glowInnerLarge, { backgroundColor: config.glowColor, opacity: disabled ? 0.3 : 0.3 }]} />
+      <View
+        style={[
+          styles.glowInner,
+          isLarge && styles.glowInnerLarge,
+          isCompactLarge && styles.glowInnerLargeCompact,
+          { backgroundColor: config.glowColor, opacity: disabled ? 0.3 : 0.3 },
+        ]}
+      />
 
       {/* 방패 아이콘 뱃지 */}
-      <View style={[styles.badge, isLarge && styles.badgeLarge, { borderColor: config.iconColor, opacity: disabled ? 0.4 : 1 }]}>
+      <View
+        style={[
+          styles.badge,
+          isLarge && styles.badgeLarge,
+          isCompactLarge && styles.badgeLargeCompact,
+          { borderColor: config.iconColor, opacity: disabled ? 0.4 : 1 },
+        ]}
+      >
         {icon && (
           <MaterialCommunityIcons
             name={config.iconName}
-            size={isLarge ? 68 : 32}
+            size={isCompactLarge ? 52 : isLarge ? 68 : 32}
             color={config.iconColor}
           />
         )}
@@ -73,8 +104,24 @@ export function ResultStatusIcon({
 
       {/* 하단 상태 칩 */}
       {label && (
-        <View style={[styles.chip, isLarge && styles.chipLarge, { backgroundColor: config.chipBackground, opacity: disabled ? 0.4 : 1 }]}>
-          <Text style={[styles.chipLabel, isLarge && styles.chipLabelLarge, { color: config.chipTextColor }]}>{label}</Text>
+        <View
+          style={[
+            styles.chip,
+            isLarge && styles.chipLarge,
+            isCompactLarge && styles.chipLargeCompact,
+            { backgroundColor: config.chipBackground, opacity: disabled ? 0.4 : 1 },
+          ]}
+        >
+          <Text
+            style={[
+              styles.chipLabel,
+              isLarge && styles.chipLabelLarge,
+              isCompactLarge && styles.chipLabelLargeCompact,
+              { color: config.chipTextColor },
+            ]}
+          >
+            {label}
+          </Text>
         </View>
       )}
     </View>
@@ -87,6 +134,8 @@ const GLOW_OUTER_SIZE = CONTAINER_SIZE;
 const GLOW_INNER_SIZE = 80;
 const LARGE_CONTAINER_SIZE = 216;
 const LARGE_BADGE_SIZE = 136;
+const COMPACT_LARGE_CONTAINER_SIZE = 168;
+const COMPACT_LARGE_BADGE_SIZE = 104;
 
 const styles = StyleSheet.create({
   container: {
@@ -98,6 +147,10 @@ const styles = StyleSheet.create({
   containerLarge: {
     width: LARGE_CONTAINER_SIZE,
     height: LARGE_CONTAINER_SIZE,
+  },
+  containerLargeCompact: {
+    width: COMPACT_LARGE_CONTAINER_SIZE,
+    height: COMPACT_LARGE_CONTAINER_SIZE,
   },
   disabled: {
     opacity: 0.5,
@@ -113,6 +166,11 @@ const styles = StyleSheet.create({
     height: LARGE_CONTAINER_SIZE,
     borderRadius: LARGE_CONTAINER_SIZE / 2,
   },
+  glowOuterLargeCompact: {
+    width: COMPACT_LARGE_CONTAINER_SIZE,
+    height: COMPACT_LARGE_CONTAINER_SIZE,
+    borderRadius: COMPACT_LARGE_CONTAINER_SIZE / 2,
+  },
   glowInner: {
     position: 'absolute',
     width: GLOW_INNER_SIZE,
@@ -123,6 +181,11 @@ const styles = StyleSheet.create({
     width: LARGE_BADGE_SIZE,
     height: LARGE_BADGE_SIZE,
     borderRadius: LARGE_BADGE_SIZE / 2,
+  },
+  glowInnerLargeCompact: {
+    width: COMPACT_LARGE_BADGE_SIZE,
+    height: COMPACT_LARGE_BADGE_SIZE,
+    borderRadius: COMPACT_LARGE_BADGE_SIZE / 2,
   },
   badge: {
     width: BADGE_SIZE,
@@ -138,6 +201,11 @@ const styles = StyleSheet.create({
     height: LARGE_BADGE_SIZE,
     borderRadius: LARGE_BADGE_SIZE / 2,
   },
+  badgeLargeCompact: {
+    width: COMPACT_LARGE_BADGE_SIZE,
+    height: COMPACT_LARGE_BADGE_SIZE,
+    borderRadius: COMPACT_LARGE_BADGE_SIZE / 2,
+  },
   chip: {
     position: 'absolute',
     bottom: 0,
@@ -149,11 +217,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 6,
   },
+  chipLargeCompact: {
+    paddingHorizontal: 16,
+    paddingVertical: 5,
+  },
   chipLabel: {
     ...Typography.caption,
   },
   chipLabelLarge: {
     ...Typography.summary,
     fontWeight: '700',
+  },
+  chipLabelLargeCompact: {
+    ...Typography.bold12,
   },
 });

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -4,15 +4,22 @@ import { Colors, Typography } from '@/constants/theme';
 
 interface SectionHeaderProps {
   label: string;
+  compact?: boolean;
   onViewAll?: () => void;
   viewAllLabel?: string;
   rightSlot?: ReactNode;
 }
 
-export function SectionHeader({ label, onViewAll, viewAllLabel = '전체보기', rightSlot }: SectionHeaderProps) {
+export function SectionHeader({
+  label,
+  compact = false,
+  onViewAll,
+  viewAllLabel = '전체보기',
+  rightSlot,
+}: SectionHeaderProps) {
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>{label}</Text>
+      <Text style={[styles.label, compact && styles.labelCompact]}>{label}</Text>
       {rightSlot ?? (onViewAll && (
         <TouchableOpacity onPress={onViewAll} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
           <Text style={styles.viewAll}>{viewAllLabel}</Text>
@@ -31,6 +38,9 @@ const styles = StyleSheet.create({
   label: {
     ...Typography.sectionTitle,
     color: Colors.brand.text,
+  },
+  labelCompact: {
+    ...Typography.section,
   },
   viewAll: {
     ...Typography.caption,

--- a/eas.json
+++ b/eas.json
@@ -16,9 +16,7 @@
     },
     "preview-device": {
       "distribution": "internal",
-      "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "http://192.168.0.12:8080"
-      }
+      "environment": "preview"
     },
     "production": {
       "autoIncrement": true

--- a/eas.json
+++ b/eas.json
@@ -9,7 +9,16 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_BASE_URL": "http://10.0.2.2:8080"
+      }
+    },
+    "preview-device": {
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_BASE_URL": "http://192.168.0.12:8080"
+      }
     },
     "production": {
       "autoIncrement": true


### PR DESCRIPTION
Closes #40

## 개요
작은 화면 또는 세로 공간이 짧은 Android 환경에서 홈, 링크 추가, 검사 중, 검사 결과, 폴더 화면의 UI 요소가 과하게 크게 보이거나 하단 탭 바와 가까워지는 문제를 개선했습니다.

이번 작업에서는 `useWindowDimensions()`로 현재 화면의 폭과 높이를 확인한 뒤, 일정 기준보다 좁거나 짧은 화면에서는 compact 스타일을 적용하도록 구성했습니다. compact 상태에서는 타이틀 typography, 컴포넌트 간격, 카드 padding, 버튼 높이, 검사 결과 아이콘 크기 등을 줄여 주요 정보와 액션 버튼이 한 화면 안에서 더 안정적으로 보이도록 조정했습니다.

또한 `useBottomTabBarHeight()`로 하단 탭 바 높이를 가져와 ScrollView와 검사 화면의 하단 padding에 반영했습니다. 이를 통해 작은 화면에서도 마지막 카드나 버튼이 탭 바에 가려지지 않고 충분한 여백을 확보하도록 처리했습니다.

폴더 화면은 고정 카드 폭만 사용하지 않고, 실제 그리드 영역의 너비를 `onLayout`으로 측정한 뒤 사용 가능한 폭에 맞춰 폴더 카드 너비를 계산하도록 변경했습니다. 기본 2열 배치를 유지하되, 폭이 부족한 경우 카드 폭을 줄이고, 2열 유지가 어려운 화면에서는 카드가 화면 밖으로 넘치지 않도록 가용 너비를 사용하게 했습니다.

공용 컴포넌트인 `ResultStatusIcon`, `SectionHeader`, `FolderCard`에는 compact 또는 width 옵션을 추가해 각 화면에서 작은 화면 대응을 일관되게 재사용할 수 있도록 보완했습니다.

## 주요 구현 내용
- 홈 화면의 작은 폭 대응 스타일 추가
- 링크 추가 화면의 작은 폭/짧은 높이 대응 스타일 추가
- 검사 중 화면의 짧은 높이 대응 및 Lottie 애니메이션 크기 조정
- 안전/주의/차단 검사 결과 화면의 compact 레이아웃 적용
- 하단 탭 바 높이를 반영해 ScrollView 하단 여백 보정
- 검사 결과 상태 아이콘의 compact large 사이즈 추가
- 폴더 화면에서 그리드 너비를 측정해 폴더 카드 폭을 동적으로 계산
- `FolderCard`에 외부 width prop을 추가해 좁은 화면에서도 카드가 넘치지 않도록 처리
- `SectionHeader`에 compact 옵션 추가
- EAS preview 빌드 환경 변수 및 실기기 preview 프로필 추가

## 파일별 역할
- `app/(tabs)/(home)/index.tsx`: 홈 화면 compact 폭 대응, 섹션/통계 영역 간격 축소, 하단 탭 여백 보정
- `app/(tabs)/(home)/add-link.tsx`: 링크 입력 화면의 타이틀, 입력창, 안내 박스 compact 스타일 적용
- `app/(tabs)/(home)/scanning.tsx`: 검사 중 화면의 애니메이션 크기, 상단 여백, 버튼 높이 조정
- `app/(tabs)/(home)/scan-result.tsx`: 안전 결과 화면 compact 레이아웃 적용
- `app/(tabs)/(home)/scan-result-caution.tsx`: 주의 결과 화면 compact 레이아웃 적용
- `app/(tabs)/(home)/scan-result-block.tsx`: 차단 결과 화면 compact 레이아웃 적용
- `app/(tabs)/(folder)/index.tsx`: 폴더 카드 그리드 너비 측정 및 하단 탭 여백 보정
- `components/ui/folder-card.tsx`: 폴더 카드 width prop 추가
- `components/ui/result-status-icon.tsx`: 큰 상태 아이콘의 compact 표시 옵션 추가
- `components/ui/section-header.tsx`: 작은 화면용 label typography 옵션 추가
- `eas.json`: preview 환경 API 주소와 실기기 preview 빌드 프로필 추가

## 해결한 이슈 목록
- [x] 작은 폭 화면에서 홈 화면 브랜드/섹션 UI가 과하게 커지는 문제 개선
- [x] 링크 추가 화면에서 타이틀, 입력창, 안내 박스가 좁은 화면에 맞게 줄어들도록 처리
- [x] 검사 중 화면에서 애니메이션과 버튼 영역이 세로 공간을 과도하게 차지하지 않도록 조정
- [x] 검사 결과 3종 화면에서 상태 아이콘, 결과 문구, 사유 카드, 버튼 간격을 compact하게 조정
- [x] 하단 탭 바가 있는 화면에서 콘텐츠 하단이 가려지지 않도록 padding 보정
- [x] 폴더 카드가 좁은 화면에서 화면 밖으로 넘치지 않도록 카드 폭 계산 로직 추가
- [x] 공용 `ResultStatusIcon`, `SectionHeader`, `FolderCard` 컴포넌트에 작은 화면 대응 옵션 추가
- [x] 기존 링크 검사, 저장, 폴더 CRUD 흐름은 유지

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 기능/API 호출 흐름이 변경되지 않도록 UI 레이아웃 중심으로 수정
- [x] `npm run lint` 통과
- [x] Android 작은 화면/짧은 화면에서 직접 UI 확인
- [x] Screenshots or Video 첨부

## 참고사항
변경 전 사진은 issue에 있는 캡쳐를 참고 바랍니다!
https://github.com/403-Forb2dden/LinClean-FE/issues/40

## Screenshots or Video
- 메인 화면
<img width="449" height="800" alt="image" src="https://github.com/user-attachments/assets/5ceff97c-e0e9-4eac-8c68-6598e9cf2fba" />

- 폴더 화면
<img width="446" height="793" alt="image" src="https://github.com/user-attachments/assets/b86efd70-407a-490a-b21d-1c025ea2ce23" />

- 링크 추가 화면
<img width="448" height="796" alt="image" src="https://github.com/user-attachments/assets/b37c625a-df27-48b9-a297-a54d2dfe1833" />

- 링크 검사 화면
<img width="447" height="800" alt="image" src="https://github.com/user-attachments/assets/e8e0f6b6-757e-4b0f-904e-5754d4727d55" />

- 검사 결과 화면
<img width="450" height="799" alt="image" src="https://github.com/user-attachments/assets/3e179a76-42d5-4edf-a8e0-194731f976f1" />