### PR TITLE
[FIX] 버튼 중복 입력 및 알림창 터치 관통 방지

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -5,13 +5,14 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useShareIntentContext } from 'expo-share-intent';
 import * as WebBrowser from 'expo-web-browser';
 import { useEffect, useRef, useState } from 'react';
-import { Alert, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ApiError } from '@/api/api-client';
 import { SocialLoginButton } from '@/components/ui/social-login-button';
 import { Colors, Typography } from '@/constants/theme';
 import { syncAuthenticatedMember } from '@/services/auth-api';
+import { showAlert } from '@/utils/guarded-alert';
 import { getSharedUrlFromIntent } from '@/utils/shared-url';
 
 const IMG_WORDMARK = require('@/assets/images/login_wordmark.png');
@@ -62,7 +63,7 @@ export default function LoginScreen() {
     }
 
     shownNoticeRef.current = notice;
-    Alert.alert(alert.title, alert.message);
+    showAlert(alert.title, alert.message);
   }, [notice]);
 
   const handleGoogleLogin = async () => {
@@ -98,7 +99,7 @@ export default function LoginScreen() {
         }
       }
 
-      Alert.alert(
+      showAlert(
         '로그인 실패',
         '계정 연결 중 서버와 통신하지 못했습니다. 잠시 후 다시 시도해주세요.'
       );

--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -1,4 +1,4 @@
-import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
@@ -12,7 +12,8 @@ import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import { useFolders } from '@/context/folders-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { showAlert } from '@/utils/guarded-alert';
 
 type MoreMenuState = {
   visible: boolean;
@@ -35,6 +36,7 @@ export default function FolderDetailScreen() {
   const [toastVisible, setToastVisible] = useState(false);
   const [addToastVisible, setAddToastVisible] = useState(false);
   const [titleToastVisible, setTitleToastVisible] = useState(false);
+  const deletingFromFolderIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     if (urlAdded === '1') setAddToastVisible(true);
@@ -45,20 +47,32 @@ export default function FolderDetailScreen() {
   };
 
   const handleDelete = async (linkId: number) => {
+    if (deletingFromFolderIdsRef.current.has(linkId)) {
+      return;
+    }
+
+    deletingFromFolderIdsRef.current.add(linkId);
+
     try {
       await assignCategory([linkId], null);
       await refreshFolders();
       setToastVisible(true);
     } catch (error) {
-      Alert.alert(
+      showAlert(
         '폴더에서 삭제 실패',
         getSavedLinkErrorMessage(error, '링크를 폴더에서 제외하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
+    } finally {
+      deletingFromFolderIdsRef.current.delete(linkId);
     }
   };
 
   const confirmDeleteFromFolder = (linkId: number) => {
-    Alert.alert(
+    if (deletingFromFolderIdsRef.current.has(linkId)) {
+      return;
+    }
+
+    showAlert(
       '폴더에서 삭제할까요?',
       '링크는 삭제되지 않아요.\n현재 폴더에서만 제외돼요.',
       [

--- a/app/(tabs)/(folder)/folder-add-url.tsx
+++ b/app/(tabs)/(folder)/folder-add-url.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
-  Alert,
   FlatList,
   StyleSheet,
   Text,
@@ -14,6 +13,7 @@ import { SelectionCircle } from '@/components/ui/selection-circle';
 import { Colors, Typography } from '@/constants/theme';
 import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
 import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
+import { showAlert } from '@/utils/guarded-alert';
 
 // ─── Selectable card row ──────────────────────────────────────────────────────
 
@@ -60,6 +60,7 @@ export default function FolderAddUrlScreen() {
 
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [isAdding, setIsAdding] = useState(false);
+  const isAddingRef = useRef(false);
 
   const toggleSelect = useCallback((id: number) => {
     setSelectedIds((prev) => {
@@ -74,7 +75,8 @@ export default function FolderAddUrlScreen() {
   }, []);
 
   const handleAdd = async () => {
-    if (isAdding || selectedIds.size === 0) return;
+    if (isAddingRef.current || selectedIds.size === 0) return;
+    isAddingRef.current = true;
     setIsAdding(true);
     try {
       await assignCategory([...selectedIds], Number(folderId));
@@ -84,11 +86,12 @@ export default function FolderAddUrlScreen() {
         params: { id: folderId, urlAdded: '1' },
       });
     } catch (error) {
-      Alert.alert(
+      showAlert(
         'URL 추가 실패',
         getFolderErrorMessage(error, '선택한 URL을 폴더에 추가하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
     } finally {
+      isAddingRef.current = false;
       setIsAdding(false);
     }
   };

--- a/app/(tabs)/(folder)/folder-name.tsx
+++ b/app/(tabs)/(folder)/folder-name.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -13,16 +14,30 @@ import { router, Stack } from 'expo-router';
 import { Button } from '@/components/ui/button';
 import { Colors, Typography } from '@/constants/theme';
 import { useFolders } from '@/context/folders-context';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export default function FolderNameScreen() {
   const [folderName, setFolderName] = useState('');
   const [isFocused, setIsFocused] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isNavigatingRef = useRef(false);
   const { folders } = useFolders();
 
-  const canProceed = folderName.trim().length > 0;
+  useFocusEffect(
+    useCallback(() => {
+      isNavigatingRef.current = false;
+      setIsNavigating(false);
+    }, []),
+  );
+
+  const canProceed = folderName.trim().length > 0 && !isNavigating;
 
   const handleNext = () => {
+    if (isNavigatingRef.current) {
+      return;
+    }
+
     const trimmedName = folderName.trim();
     const hasDuplicateName = folders.some(
       (folder) => normalizeFolderName(folder.name) === normalizeFolderName(trimmedName),
@@ -34,11 +49,14 @@ export default function FolderNameScreen() {
     }
 
     setErrorMessage('');
+    isNavigatingRef.current = true;
+    setIsNavigating(true);
     router.push({
       pathname: '/(tabs)/(folder)/folder-url-select',
       params: { folderName: trimmedName },
     });
   };
+  const guardedClearFolderName = useGuardedPress(() => setFolderName(''), { lockMs: 250 });
 
   return (
     <>
@@ -87,7 +105,7 @@ export default function FolderNameScreen() {
                 />
                 {folderName.length > 0 && (
                   <TouchableOpacity
-                    onPress={() => setFolderName('')}
+                    onPress={guardedClearFolderName}
                     hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                     style={styles.clearButton}
                   >

--- a/app/(tabs)/(folder)/folder-url-select.tsx
+++ b/app/(tabs)/(folder)/folder-url-select.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
-  Alert,
   FlatList,
   StyleSheet,
   Text,
@@ -14,6 +13,7 @@ import { SelectionCircle } from '@/components/ui/selection-circle';
 import { Colors, Typography } from '@/constants/theme';
 import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
 import { useSavedLinks, type SavedLink } from '@/context/saved-links-context';
+import { showAlert } from '@/utils/guarded-alert';
 
 // ─── Selectable card row ──────────────────────────────────────────────────────
 
@@ -56,6 +56,7 @@ export default function FolderUrlSelectScreen() {
   const { links: allLinks, refreshLinks } = useSavedLinks();
   const links = allLinks.filter((l) => l.categoryId === null);
   const name = (folderName ?? '새 폴더').trim();
+  const isCreatingRef = useRef(false);
 
   const toggleSelect = useCallback((id: number) => {
     setSelectedIds((prev) => {
@@ -70,15 +71,17 @@ export default function FolderUrlSelectScreen() {
   }, []);
 
   const handleCreate = async () => {
-    if (isCreating) return;
+    if (isCreatingRef.current) return;
+    isCreatingRef.current = true;
     setIsCreating(true);
     try {
       await addFolder(name, [...selectedIds]);
     } catch (error) {
-      Alert.alert(
+      showAlert(
         '폴더 생성 실패',
         getFolderErrorMessage(error, '폴더를 생성하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
+      isCreatingRef.current = false;
       setIsCreating(false);
       return;
     }
@@ -87,8 +90,6 @@ export default function FolderUrlSelectScreen() {
       await refreshLinks();
     } catch {
       // Link refresh is best-effort after the folder has already been created.
-    } finally {
-      setIsCreating(false);
     }
 
     router.dismissAll();
@@ -96,6 +97,8 @@ export default function FolderUrlSelectScreen() {
       pathname: '/(tabs)/(folder)',
       params: { folderCreated: String(Date.now()) },
     });
+    isCreatingRef.current = false;
+    setIsCreating(false);
   };
 
   const selectedCount = selectedIds.size;

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -24,6 +23,8 @@ import { Colors, Typography } from '@/constants/theme';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { useSavedLinks } from '@/context/saved-links-context';
 import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
+import { showAlert } from '@/utils/guarded-alert';
+import { useGuardedPress } from '@/utils/press-guard';
 
 type MenuState = {
   visible: boolean;
@@ -60,6 +61,7 @@ export default function FolderScreen() {
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [renameToastVisible, setRenameToastVisible] = useState(false);
   const lastCreatedToastRef = useRef<string | undefined>(undefined);
+  const isMutatingRef = useRef(false);
   const renameInputRef = useRef<TextInput>(null);
   const folderCreated = typeof folderCreatedParam === 'string' ? folderCreatedParam : undefined;
 
@@ -91,23 +93,29 @@ export default function FolderScreen() {
   const handleRenameConfirm = async () => {
     const trimmed = renameState.value.trim();
     const currentName = renameState.currentName.trim();
-    if (renameState.folderId == null || !trimmed || trimmed === currentName || isMutating) return;
+    if (renameState.folderId == null || !trimmed || trimmed === currentName || isMutatingRef.current) return;
+    isMutatingRef.current = true;
     setIsMutating(true);
     try {
       await renameFolder(renameState.folderId, trimmed);
       setRenameState({ visible: false, value: '', currentName: '' });
       setRenameToastVisible(true);
     } catch (error) {
-      Alert.alert(
+      showAlert(
         '폴더명 수정 실패',
         getFolderErrorMessage(error, '폴더 이름을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
     } finally {
+      isMutatingRef.current = false;
       setIsMutating(false);
     }
   };
 
   const handleRenameCancel = () => {
+    if (isMutatingRef.current) {
+      return;
+    }
+
     setRenameState({ visible: false, value: '', currentName: '' });
   };
 
@@ -115,24 +123,26 @@ export default function FolderScreen() {
     if (menuState.folderId == null) return;
     const folderId = menuState.folderId;
 
-    Alert.alert('폴더 삭제', '폴더를 삭제할까요? 폴더 안의 링크는 미분류 상태로 이동합니다.', [
+    showAlert('폴더 삭제', '폴더를 삭제할까요? 폴더 안의 링크는 미분류 상태로 이동합니다.', [
       { text: '취소', style: 'cancel' },
       {
         text: '삭제',
         style: 'destructive',
         onPress: async () => {
-          if (isMutating) return;
+          if (isMutatingRef.current) return;
+          isMutatingRef.current = true;
           setIsMutating(true);
           try {
             await deleteFolder(folderId);
             await refreshLinks();
             setDeleteToastVisible(true);
           } catch (error) {
-            Alert.alert(
+            showAlert(
               '폴더 삭제 실패',
               getFolderErrorMessage(error, '폴더를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.'),
             );
           } finally {
+            isMutatingRef.current = false;
             setIsMutating(false);
           }
         },
@@ -149,6 +159,12 @@ export default function FolderScreen() {
     trimmedRenameValue.length === 0 ||
     trimmedRenameValue === renameState.currentName.trim() ||
     isMutating;
+  const guardedRenameCancel = useGuardedPress(handleRenameCancel, { disabled: isMutating, lockMs: 250 });
+  const guardedRenameConfirm = useGuardedPress(handleRenameConfirm, { disabled: renameSubmitDisabled });
+  const guardedClearRename = useGuardedPress(
+    () => setRenameState((s) => ({ ...s, value: '' })),
+    { disabled: isMutating, lockMs: 250 },
+  );
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -238,13 +254,13 @@ export default function FolderScreen() {
         visible={renameState.visible}
         transparent
         animationType="fade"
-        onRequestClose={handleRenameCancel}
+        onRequestClose={guardedRenameCancel}
       >
         <KeyboardAvoidingView
           style={renameStyles.overlay}
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
-          <Pressable style={renameStyles.backdrop} onPress={handleRenameCancel} />
+          <Pressable style={renameStyles.backdrop} onPress={guardedRenameCancel} />
           <View style={renameStyles.sheet}>
             <Text style={renameStyles.sheetTitle}>폴더명 수정</Text>
             <View style={renameStyles.inputRow}>
@@ -256,13 +272,13 @@ export default function FolderScreen() {
                 placeholder="폴더 이름 입력"
                 placeholderTextColor={Colors.brand.textHint}
                 returnKeyType="done"
-                onSubmitEditing={handleRenameConfirm}
+                onSubmitEditing={guardedRenameConfirm}
                 maxLength={50}
                 autoFocus
               />
               {renameState.value.length > 0 && (
                 <TouchableOpacity
-                  onPress={() => setRenameState((s) => ({ ...s, value: '' }))}
+                  onPress={guardedClearRename}
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                   style={renameStyles.clearButton}
                 >
@@ -271,12 +287,12 @@ export default function FolderScreen() {
               )}
             </View>
             <View style={renameStyles.actions}>
-              <TouchableOpacity style={renameStyles.cancelBtn} onPress={handleRenameCancel}>
+              <TouchableOpacity style={renameStyles.cancelBtn} onPress={guardedRenameCancel}>
                 <Text style={renameStyles.cancelText}>취소</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={[renameStyles.confirmBtn, renameSubmitDisabled && renameStyles.confirmBtnDisabled]}
-                onPress={handleRenameConfirm}
+                onPress={guardedRenameConfirm}
                 disabled={renameSubmitDisabled}
               >
                 <Text style={[renameStyles.confirmText, renameSubmitDisabled && renameStyles.confirmTextDisabled]}>

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
-=======
-  Alert,
->>>>>>> dev
   Keyboard,
   LayoutAnimation,
   Modal,
@@ -175,21 +171,15 @@ export default function FolderScreen() {
   };
 
   const handleRenameCancel = () => {
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
     if (isMutatingRef.current) {
       return;
     }
 
-=======
->>>>>>> dev
     if (renameFocusTimerRef.current) {
       clearTimeout(renameFocusTimerRef.current);
       renameFocusTimerRef.current = null;
     }
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
 
-=======
->>>>>>> dev
     setRenameState({ visible: false, value: '', currentName: '' });
   };
 
@@ -244,15 +234,12 @@ export default function FolderScreen() {
     trimmedRenameValue.length === 0 ||
     trimmedRenameValue === renameState.currentName.trim() ||
     isMutating;
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
   const guardedRenameCancel = useGuardedPress(handleRenameCancel, { disabled: isMutating, lockMs: 250 });
   const guardedRenameConfirm = useGuardedPress(handleRenameConfirm, { disabled: renameSubmitDisabled });
   const guardedClearRename = useGuardedPress(
     () => setRenameState((s) => ({ ...s, value: '' })),
     { disabled: isMutating, lockMs: 250 },
   );
-=======
->>>>>>> dev
   const renameRestingBottomInset = Math.max(insets.bottom, RENAME_MODAL_BOTTOM_GAP);
   const renameModalBottomInset = renameKeyboardInset > 0
     ? renameKeyboardInset + RENAME_KEYBOARD_TOP_GAP
@@ -346,11 +333,7 @@ export default function FolderScreen() {
         visible={renameState.visible}
         transparent
         animationType="fade"
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
         onRequestClose={guardedRenameCancel}
-=======
-        onRequestClose={handleRenameCancel}
->>>>>>> dev
         onShow={handleRenameModalShow}
       >
         <View
@@ -381,11 +364,7 @@ export default function FolderScreen() {
                 />
                 {renameState.value.length > 0 && (
                   <TouchableOpacity
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
                     onPress={guardedClearRename}
-=======
-                    onPress={() => setRenameState((s) => ({ ...s, value: '' }))}
->>>>>>> dev
                     hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                     style={renameStyles.clearButton}
                   >
@@ -394,7 +373,6 @@ export default function FolderScreen() {
                 )}
               </View>
               <View style={renameStyles.actions}>
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
                 <TouchableOpacity style={renameStyles.cancelBtn} onPress={guardedRenameCancel}>
                   <Text style={renameStyles.cancelText}>취소</Text>
                 </TouchableOpacity>
@@ -407,23 +385,6 @@ export default function FolderScreen() {
                     저장
                   </Text>
                 </TouchableOpacity>
-=======
-                <TouchableOpacity
-                  style={renameStyles.cancelBtn}
-                  onPress={handleRenameCancel}
-                >
-                  <Text style={renameStyles.cancelText}>취소</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[renameStyles.confirmBtn, renameSubmitDisabled && renameStyles.confirmBtnDisabled]}
-                  onPress={handleRenameConfirm}
-                  disabled={renameSubmitDisabled}
-                >
-                  <Text style={[renameStyles.confirmText, renameSubmitDisabled && renameStyles.confirmTextDisabled]}>
-                    저장
-                  </Text>
-                </TouchableOpacity>
->>>>>>> dev
               </View>
             </ScrollView>
           </View>

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-  KeyboardAvoidingView,
+  Keyboard,
+  LayoutAnimation,
   Modal,
   Platform,
   Pressable,
@@ -11,8 +12,9 @@ import {
   TextInput,
   TouchableOpacity,
   View,
+  type KeyboardEvent,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { AddFolderButton } from '@/components/ui/add-folder-button';
 import { FolderCard } from '@/components/ui/folder-card';
@@ -32,7 +34,30 @@ type MenuState = {
   folderId?: number;
 };
 
+const RENAME_MODAL_BOTTOM_GAP = 16;
+const RENAME_KEYBOARD_TOP_GAP = 8;
+
+const showKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+const hideKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+const syncKeyboardLayoutAnimation = (event: KeyboardEvent) => {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+
+  const duration = event.duration > 10 ? event.duration : 10;
+
+  LayoutAnimation.configureNext({
+    duration,
+    update: {
+      duration,
+      type: LayoutAnimation.Types[event.easing] || LayoutAnimation.Types.keyboard,
+    },
+  });
+};
+
 export default function FolderScreen() {
+  const insets = useSafeAreaInsets();
   const router = useRouter();
   const { folderCreated: folderCreatedParam } = useLocalSearchParams<{
     folderCreated?: string | string[];
@@ -57,12 +82,14 @@ export default function FolderScreen() {
     currentName: '',
   });
   const [isMutating, setIsMutating] = useState(false);
+  const [renameKeyboardInset, setRenameKeyboardInset] = useState(0);
   const [createToastVisible, setCreateToastVisible] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [renameToastVisible, setRenameToastVisible] = useState(false);
   const lastCreatedToastRef = useRef<string | undefined>(undefined);
   const isMutatingRef = useRef(false);
   const renameInputRef = useRef<TextInput>(null);
+  const renameFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const folderCreated = typeof folderCreatedParam === 'string' ? folderCreatedParam : undefined;
 
   const folders = useMemo(
@@ -83,11 +110,39 @@ export default function FolderScreen() {
     setCreateToastVisible(true);
   }, [folderCreated]);
 
+  useEffect(() => {
+    return () => {
+      if (renameFocusTimerRef.current) {
+        clearTimeout(renameFocusTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!renameState.visible) {
+      setRenameKeyboardInset(0);
+      return;
+    }
+
+    const showSubscription = Keyboard.addListener(showKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
+      setRenameKeyboardInset(event.endCoordinates.height);
+    });
+    const hideSubscription = Keyboard.addListener(hideKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
+      setRenameKeyboardInset(0);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, [renameState.visible]);
+
   const handleEditName = () => {
     if (menuState.folderId == null) return;
     const current = folders.find((f) => f.id === menuState.folderId)?.name ?? '';
     setRenameState({ visible: true, folderId: menuState.folderId, value: current, currentName: current });
-    setTimeout(() => renameInputRef.current?.focus(), 100);
   };
 
   const handleRenameConfirm = async () => {
@@ -98,6 +153,10 @@ export default function FolderScreen() {
     setIsMutating(true);
     try {
       await renameFolder(renameState.folderId, trimmed);
+      if (renameFocusTimerRef.current) {
+        clearTimeout(renameFocusTimerRef.current);
+        renameFocusTimerRef.current = null;
+      }
       setRenameState({ visible: false, value: '', currentName: '' });
       setRenameToastVisible(true);
     } catch (error) {
@@ -116,7 +175,23 @@ export default function FolderScreen() {
       return;
     }
 
+    if (renameFocusTimerRef.current) {
+      clearTimeout(renameFocusTimerRef.current);
+      renameFocusTimerRef.current = null;
+    }
+
     setRenameState({ visible: false, value: '', currentName: '' });
+  };
+
+  const handleRenameModalShow = () => {
+    if (renameFocusTimerRef.current) {
+      clearTimeout(renameFocusTimerRef.current);
+    }
+
+    renameFocusTimerRef.current = setTimeout(() => {
+      renameInputRef.current?.focus();
+      renameFocusTimerRef.current = null;
+    }, 100);
   };
 
   const handleDelete = () => {
@@ -165,6 +240,10 @@ export default function FolderScreen() {
     () => setRenameState((s) => ({ ...s, value: '' })),
     { disabled: isMutating, lockMs: 250 },
   );
+  const renameRestingBottomInset = Math.max(insets.bottom, RENAME_MODAL_BOTTOM_GAP);
+  const renameModalBottomInset = renameKeyboardInset > 0
+    ? renameKeyboardInset + RENAME_KEYBOARD_TOP_GAP
+    : renameRestingBottomInset;
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
@@ -255,53 +334,61 @@ export default function FolderScreen() {
         transparent
         animationType="fade"
         onRequestClose={guardedRenameCancel}
+        onShow={handleRenameModalShow}
       >
-        <KeyboardAvoidingView
-          style={renameStyles.overlay}
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        <View
+          style={[
+            renameStyles.overlay,
+            { paddingBottom: renameModalBottomInset },
+          ]}
         >
           <Pressable style={renameStyles.backdrop} onPress={guardedRenameCancel} />
           <View style={renameStyles.sheet}>
-            <Text style={renameStyles.sheetTitle}>폴더명 수정</Text>
-            <View style={renameStyles.inputRow}>
-              <TextInput
-                ref={renameInputRef}
-                style={renameStyles.input}
-                value={renameState.value}
-                onChangeText={(v) => setRenameState((s) => ({ ...s, value: v }))}
-                placeholder="폴더 이름 입력"
-                placeholderTextColor={Colors.brand.textHint}
-                returnKeyType="done"
-                onSubmitEditing={guardedRenameConfirm}
-                maxLength={50}
-                autoFocus
-              />
-              {renameState.value.length > 0 && (
-                <TouchableOpacity
-                  onPress={guardedClearRename}
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  style={renameStyles.clearButton}
-                >
-                  <Text style={renameStyles.clearButtonText}>−</Text>
+            <ScrollView
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={renameStyles.sheetContent}
+            >
+              <Text style={renameStyles.sheetTitle}>폴더명 수정</Text>
+              <View style={renameStyles.inputRow}>
+                <TextInput
+                  ref={renameInputRef}
+                  style={renameStyles.input}
+                  value={renameState.value}
+                  onChangeText={(v) => setRenameState((s) => ({ ...s, value: v }))}
+                  placeholder="폴더 이름 입력"
+                  placeholderTextColor={Colors.brand.textHint}
+                  returnKeyType="done"
+                  onSubmitEditing={Keyboard.dismiss}
+                  maxLength={50}
+                />
+                {renameState.value.length > 0 && (
+                  <TouchableOpacity
+                    onPress={guardedClearRename}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    style={renameStyles.clearButton}
+                  >
+                    <Text style={renameStyles.clearButtonText}>−</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+              <View style={renameStyles.actions}>
+                <TouchableOpacity style={renameStyles.cancelBtn} onPress={guardedRenameCancel}>
+                  <Text style={renameStyles.cancelText}>취소</Text>
                 </TouchableOpacity>
-              )}
-            </View>
-            <View style={renameStyles.actions}>
-              <TouchableOpacity style={renameStyles.cancelBtn} onPress={guardedRenameCancel}>
-                <Text style={renameStyles.cancelText}>취소</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[renameStyles.confirmBtn, renameSubmitDisabled && renameStyles.confirmBtnDisabled]}
-                onPress={guardedRenameConfirm}
-                disabled={renameSubmitDisabled}
-              >
-                <Text style={[renameStyles.confirmText, renameSubmitDisabled && renameStyles.confirmTextDisabled]}>
-                  저장
-                </Text>
-              </TouchableOpacity>
-            </View>
+                <TouchableOpacity
+                  style={[renameStyles.confirmBtn, renameSubmitDisabled && renameStyles.confirmBtnDisabled]}
+                  onPress={guardedRenameConfirm}
+                  disabled={renameSubmitDisabled}
+                >
+                  <Text style={[renameStyles.confirmText, renameSubmitDisabled && renameStyles.confirmTextDisabled]}>
+                    저장
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
           </View>
-        </KeyboardAvoidingView>
+        </View>
       </Modal>
     </SafeAreaView>
   );
@@ -389,9 +476,14 @@ const renameStyles = StyleSheet.create({
     backgroundColor: Colors.brand.overlayBackdrop,
   },
   sheet: {
+    width: '100%',
+    maxHeight: '80%',
     backgroundColor: Colors.brand.surface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
+    overflow: 'hidden',
+  },
+  sheetContent: {
     padding: 24,
     paddingBottom: 40,
     gap: 16,

--- a/app/(tabs)/(home)/add-link.tsx
+++ b/app/(tabs)/(home)/add-link.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -12,6 +13,7 @@ import { Stack, router, useLocalSearchParams } from 'expo-router';
 
 import { ScanButton } from '@/components/ui/scan-button';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 import { normalizeHttpUrlInput } from '@/utils/shared-url';
 
 function getSharedUrlParam(value: string | string[] | undefined): string {
@@ -27,6 +29,15 @@ export default function AddLinkScreen() {
   const initialSharedUrl = getSharedUrlParam(sharedUrl);
   const [url, setUrl] = useState(initialSharedUrl);
   const [error, setError] = useState('');
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isNavigatingRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      isNavigatingRef.current = false;
+      setIsNavigating(false);
+    }, []),
+  );
 
   useEffect(() => {
     const nextSharedUrl = getSharedUrlParam(sharedUrl);
@@ -40,6 +51,10 @@ export default function AddLinkScreen() {
   }, [sharedUrl]);
 
   const handleScan = () => {
+    if (isNavigatingRef.current) {
+      return;
+    }
+
     const trimmed = url.trim();
 
     if (!trimmed) {
@@ -56,6 +71,8 @@ export default function AddLinkScreen() {
     }
 
     setError('');
+    isNavigatingRef.current = true;
+    setIsNavigating(true);
     router.push({ pathname: '/(tabs)/(home)/scanning', params: { url: normalizedUrl } });
   };
 
@@ -65,7 +82,11 @@ export default function AddLinkScreen() {
   };
 
   const hasError = error.length > 0;
-  const scanDisabled = !url.trim();
+  const scanDisabled = !url.trim() || isNavigating;
+  const guardedClearUrl = useGuardedPress(() => {
+    setUrl('');
+    setError('');
+  }, { lockMs: 250 });
 
   return (
     <>
@@ -116,7 +137,7 @@ export default function AddLinkScreen() {
                 />
                 {url.length > 0 && (
                   <TouchableOpacity
-                    onPress={() => { setUrl(''); setError(''); }}
+                    onPress={guardedClearUrl}
                     hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                     style={styles.clearButton}
                   >

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  Alert,
   ScrollView,
   StyleSheet,
   Text,
@@ -19,6 +18,7 @@ import { Colors, Typography } from '@/constants/theme';
 import { useFolders } from '@/context/folders-context';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
+import { showAlert } from '@/utils/guarded-alert';
 
 export default function HomeScreen() {
   const { savedLinkToast: savedLinkToastParam } = useLocalSearchParams<{
@@ -32,6 +32,7 @@ export default function HomeScreen() {
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [titleToastVisible, setTitleToastVisible] = useState(false);
   const lastToastParamRef = useRef<string | undefined>(undefined);
+  const deletingLinkIdsRef = useRef<Set<number>>(new Set());
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
 
   // 최근 저장한 링크 — createdAt 내림차순 상위 3개
@@ -57,7 +58,7 @@ export default function HomeScreen() {
       try {
         await toggleBookmark(id);
       } catch (error) {
-        Alert.alert(
+        showAlert(
           '북마크 변경 실패',
           getSavedLinkErrorMessage(error, '북마크 상태를 변경하지 못했습니다. 잠시 후 다시 시도해주세요.'),
         );
@@ -68,21 +69,33 @@ export default function HomeScreen() {
 
   const handleDelete = useCallback(
     (id: number) => {
-      Alert.alert('링크 삭제', '저장한 링크를 삭제할까요?', [
+      if (deletingLinkIdsRef.current.has(id)) {
+        return;
+      }
+
+      showAlert('링크 삭제', '저장한 링크를 삭제할까요?', [
         { text: '취소', style: 'cancel' },
         {
           text: '삭제',
           style: 'destructive',
           onPress: async () => {
+            if (deletingLinkIdsRef.current.has(id)) {
+              return;
+            }
+
+            deletingLinkIdsRef.current.add(id);
+
             try {
               await deleteLink(id);
               await refreshFolders();
               setDeleteToastVisible(true);
             } catch (error) {
-              Alert.alert(
+              showAlert(
                 '삭제 실패',
                 getSavedLinkErrorMessage(error, '링크를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.'),
               );
+            } finally {
+              deletingLinkIdsRef.current.delete(id);
             }
           },
         },

--- a/app/(tabs)/(home)/notices.tsx
+++ b/app/(tabs)/(home)/notices.tsx
@@ -145,12 +145,15 @@ export default function NoticesScreen() {
   const handleRetry = useCallback(() => {
     startLoadNotices();
   }, [startLoadNotices]);
-  const guardedOpenNotice = useGuardedPress((id: number) =>
+
+  const openNotice = useCallback((id: number) => {
     router.push({
       pathname: '/(tabs)/(home)/notice-detail' as any,
       params: { id: String(id) },
-    }),
-  );
+    });
+  }, []);
+
+  const guardedOpenNotice = useGuardedPress(openNotice);
 
   const renderNotice = useCallback(
     ({ item }: { item: NoticeListItemResponse }) => (

--- a/app/(tabs)/(home)/notices.tsx
+++ b/app/(tabs)/(home)/notices.tsx
@@ -16,6 +16,7 @@ import { fetchNotices, type NoticeListItemResponse } from '@/api/notices';
 import { AppIcon } from '@/components/ui/app-icon';
 import { Button } from '@/components/ui/button';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 const NOTICE_PAGE_SIZE = 20;
 
@@ -144,18 +145,19 @@ export default function NoticesScreen() {
   const handleRetry = useCallback(() => {
     startLoadNotices();
   }, [startLoadNotices]);
+  const guardedOpenNotice = useGuardedPress((id: number) =>
+    router.push({
+      pathname: '/(tabs)/(home)/notice-detail' as any,
+      params: { id: String(id) },
+    }),
+  );
 
   const renderNotice = useCallback(
     ({ item }: { item: NoticeListItemResponse }) => (
       <TouchableOpacity
         style={styles.noticeItem}
         activeOpacity={0.7}
-        onPress={() =>
-          router.push({
-            pathname: '/(tabs)/(home)/notice-detail' as any,
-            params: { id: String(item.id) },
-          })
-        }
+        onPress={() => guardedOpenNotice?.(item.id)}
       >
         <View style={styles.noticeTop}>
           {item.isPinned && (
@@ -168,7 +170,7 @@ export default function NoticesScreen() {
         <Text style={styles.noticeDate}>{formatDate(item.createdAt)}</Text>
       </TouchableOpacity>
     ),
-    [],
+    [guardedOpenNotice],
   );
 
   return (

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -1,7 +1,6 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   RefreshControl,
   StyleSheet,
@@ -21,6 +20,7 @@ import type { AnchorPosition } from '@/components/ui/folder-card';
 import { Colors, Typography } from '@/constants/theme';
 import { useFolders } from '@/context/folders-context';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
+import { showAlert } from '@/utils/guarded-alert';
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
@@ -52,6 +52,7 @@ export default function SavedLinksScreen() {
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [titleToastVisible, setTitleToastVisible] = useState(false);
+  const deletingLinkIdsRef = useRef<Set<number>>(new Set());
 
   const folderItems = useMemo<FilterChipItem[]>(
     () => [
@@ -93,7 +94,7 @@ export default function SavedLinksScreen() {
       try {
         await toggleBookmark(id);
       } catch (error) {
-        Alert.alert(
+        showAlert(
           '북마크 변경 실패',
           getSavedLinkErrorMessage(error, '북마크 상태를 변경하지 못했습니다. 잠시 후 다시 시도해주세요.'),
         );
@@ -104,21 +105,33 @@ export default function SavedLinksScreen() {
 
   const handleDelete = useCallback(
     (id: number) => {
-      Alert.alert('링크 삭제', '저장한 링크를 삭제할까요?', [
+      if (deletingLinkIdsRef.current.has(id)) {
+        return;
+      }
+
+      showAlert('링크 삭제', '저장한 링크를 삭제할까요?', [
         { text: '취소', style: 'cancel' },
         {
           text: '삭제',
           style: 'destructive',
           onPress: async () => {
+            if (deletingLinkIdsRef.current.has(id)) {
+              return;
+            }
+
+            deletingLinkIdsRef.current.add(id);
+
             try {
               await deleteLink(id);
               await refreshFolders();
               setDeleteToastVisible(true);
             } catch (error) {
-              Alert.alert(
+              showAlert(
                 '삭제 실패',
                 getSavedLinkErrorMessage(error, '링크를 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.'),
               );
+            } finally {
+              deletingLinkIdsRef.current.delete(id);
             }
           },
         },

--- a/app/(tabs)/(home)/scan-result-block.tsx
+++ b/app/(tabs)/(home)/scan-result-block.tsx
@@ -12,6 +12,7 @@ import {
   getAnalysisResultPath,
   getRouteParam,
 } from '@/utils/analysis-result-display';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export default function ScanResultBlockScreen() {
   const {
@@ -25,6 +26,7 @@ export default function ScanResultBlockScreen() {
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('danger'));
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'danger');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
+  const guardedDismissAll = useGuardedPress(() => router.dismissAll());
 
   useEffect(() => {
     if (!analysis?.verdict || analysis.verdict === 'danger') {
@@ -105,7 +107,7 @@ export default function ScanResultBlockScreen() {
         <View style={styles.buttonArea}>
           <TouchableOpacity
             style={styles.confirmButton}
-            onPress={() => router.dismissAll()}
+            onPress={guardedDismissAll}
             activeOpacity={0.8}
           >
             <Text style={styles.confirmButtonText}>확인</Text>

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
@@ -15,6 +15,8 @@ import {
   getAnalysisResultPath,
   getRouteParam,
 } from '@/utils/analysis-result-display';
+import { showAlert } from '@/utils/guarded-alert';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export default function ScanResultCautionScreen() {
   const {
@@ -30,6 +32,7 @@ export default function ScanResultCautionScreen() {
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('caution'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const isSavingRef = useRef(false);
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'caution');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
   const saveAnalysisId = analysis?.analysisId ?? analysisId;
@@ -56,10 +59,11 @@ export default function ScanResultCautionScreen() {
   }, [analysis, url]);
 
   const handleSave = async (title: string) => {
-    if (!canSave || !saveAnalysisId) {
+    if (!canSave || !saveAnalysisId || isSavingRef.current) {
       return;
     }
 
+    isSavingRef.current = true;
     setIsSaving(true);
 
     try {
@@ -75,11 +79,12 @@ export default function ScanResultCautionScreen() {
         params: { savedLinkToast: String(Date.now()) },
       });
     } catch (error) {
-      Alert.alert(
+      showAlert(
         '저장 실패',
         getSavedLinkErrorMessage(error, '링크를 저장하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
     } finally {
+      isSavingRef.current = false;
       setIsSaving(false);
     }
   };
@@ -93,6 +98,10 @@ export default function ScanResultCautionScreen() {
       }
     }
   };
+  const guardedOpenSaveModal = useGuardedPress(() => setSaveModalVisible(true), {
+    disabled: !canSave || saveModalVisible,
+  });
+  const guardedOpenUrl = useGuardedPress(handleOpenUrl, { disabled: !finalUrl });
 
   if (isVerifyingAnalysis || shouldRedirectToVerdict) {
     return (
@@ -157,15 +166,15 @@ export default function ScanResultCautionScreen() {
         {/* 버튼 영역 */}
         <View style={styles.buttonArea}>
           <TouchableOpacity
-            style={[styles.cautionButton, !canSave && styles.disabledButton]}
-            onPress={() => setSaveModalVisible(true)}
+            style={[styles.cautionButton, (!canSave || saveModalVisible) && styles.disabledButton]}
+            onPress={guardedOpenSaveModal}
             activeOpacity={0.8}
-            disabled={!canSave}
+            disabled={!canSave || saveModalVisible}
           >
             <Text style={styles.cautionButtonText}>주의 후 저장</Text>
           </TouchableOpacity>
 
-          <TouchableOpacity style={styles.secondaryButton} onPress={handleOpenUrl} activeOpacity={0.8}>
+          <TouchableOpacity style={styles.secondaryButton} onPress={guardedOpenUrl} activeOpacity={0.8}>
             <Text style={styles.secondaryButtonText}>즉시 URL 접속</Text>
           </TouchableOpacity>
         </View>

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import { Alert, Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ResultStatusIcon } from '@/components/ui/result-status-icon';
 import { ScanResultReason } from '@/components/ui/scan-result-reason';
 import { getMockScanResultReason } from '@/constants/scan-result-reasons';
@@ -15,6 +15,8 @@ import {
   getAnalysisResultPath,
   getRouteParam,
 } from '@/utils/analysis-result-display';
+import { showAlert } from '@/utils/guarded-alert';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export default function ScanResultScreen() {
   const {
@@ -30,6 +32,7 @@ export default function ScanResultScreen() {
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('safe'));
   const [saveModalVisible, setSaveModalVisible] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const isSavingRef = useRef(false);
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'safe');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
   const saveAnalysisId = analysis?.analysisId ?? analysisId;
@@ -56,10 +59,11 @@ export default function ScanResultScreen() {
   }, [analysis, url]);
 
   const handleSave = async (title: string) => {
-    if (!canSave || !saveAnalysisId) {
+    if (!canSave || !saveAnalysisId || isSavingRef.current) {
       return;
     }
 
+    isSavingRef.current = true;
     setIsSaving(true);
 
     try {
@@ -75,11 +79,12 @@ export default function ScanResultScreen() {
         params: { savedLinkToast: String(Date.now()) },
       });
     } catch (error) {
-      Alert.alert(
+      showAlert(
         '저장 실패',
         getSavedLinkErrorMessage(error, '링크를 저장하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
     } finally {
+      isSavingRef.current = false;
       setIsSaving(false);
     }
   };
@@ -93,6 +98,10 @@ export default function ScanResultScreen() {
       }
     }
   };
+  const guardedOpenSaveModal = useGuardedPress(() => setSaveModalVisible(true), {
+    disabled: !canSave || saveModalVisible,
+  });
+  const guardedOpenUrl = useGuardedPress(handleOpenUrl, { disabled: !finalUrl });
 
   if (isVerifyingAnalysis || shouldRedirectToVerdict) {
     return (
@@ -157,15 +166,15 @@ export default function ScanResultScreen() {
         {/* 버튼 영역 */}
         <View style={styles.buttonArea}>
           <TouchableOpacity
-            style={[styles.primaryButton, !canSave && styles.disabledButton]}
-            onPress={() => setSaveModalVisible(true)}
+            style={[styles.primaryButton, (!canSave || saveModalVisible) && styles.disabledButton]}
+            onPress={guardedOpenSaveModal}
             activeOpacity={0.8}
-            disabled={!canSave}
+            disabled={!canSave || saveModalVisible}
           >
             <Text style={styles.primaryButtonText}>저장</Text>
           </TouchableOpacity>
 
-          <TouchableOpacity style={styles.secondaryButton} onPress={handleOpenUrl} activeOpacity={0.8}>
+          <TouchableOpacity style={styles.secondaryButton} onPress={guardedOpenUrl} activeOpacity={0.8}>
             <Text style={styles.secondaryButtonText}>즉시 URL 접속</Text>
           </TouchableOpacity>
         </View>

--- a/app/(tabs)/(home)/scanning.tsx
+++ b/app/(tabs)/(home)/scanning.tsx
@@ -7,6 +7,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { fetchAnalysis, requestAnalysis, type AnalysisResponse, type AnalysisVerdict } from '@/api/analyses';
 import { ApiError } from '@/api/api-client';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 const POLLING_INTERVAL_MS = 2_000;
 const MAX_POLLING_MS = 30_000;
@@ -88,6 +89,8 @@ export default function ScanningScreen() {
   }, [isLoaded, isSignedIn, retryKey, url]);
 
   const hasError = errorMessage.length > 0;
+  const guardedRetry = useGuardedPress(() => setRetryKey((key) => key + 1));
+  const guardedBack = useGuardedPress(() => router.back());
 
   return (
     <>
@@ -138,14 +141,14 @@ export default function ScanningScreen() {
           <View style={styles.buttonArea}>
             <TouchableOpacity
               style={styles.primaryButton}
-              onPress={() => setRetryKey((key) => key + 1)}
+              onPress={guardedRetry}
               activeOpacity={0.8}
             >
               <Text style={styles.primaryButtonText}>다시 검사</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.secondaryButton}
-              onPress={() => router.back()}
+              onPress={guardedBack}
               activeOpacity={0.8}
             >
               <Text style={styles.secondaryButtonText}>돌아가기</Text>

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -2,7 +2,7 @@ import { useAuth } from '@clerk/expo';
 import Constants from 'expo-constants';
 import { router } from 'expo-router';
 import { useRef, useState } from 'react';
-import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ApiError } from '@/api/api-client';
@@ -10,6 +10,8 @@ import { withdrawMember } from '@/api/members';
 import { AppIcon } from '@/components/ui/app-icon';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
+import { showAlert } from '@/utils/guarded-alert';
+import { useGuardedPress } from '@/utils/press-guard';
 
 const version = Constants.expoConfig?.version ?? '—';
 type LoginNotice = 'withdrawal-complete' | 'session-expired';
@@ -27,10 +29,12 @@ interface SettingRowProps {
 }
 
 function SettingRow({ label, onPress, rightText, destructive = false, showChevron = false }: SettingRowProps) {
+  const guardedOnPress = useGuardedPress(onPress, { disabled: !onPress });
+
   return (
     <TouchableOpacity
       style={styles.row}
-      onPress={onPress}
+      onPress={guardedOnPress}
       activeOpacity={onPress ? 0.7 : 1}
       disabled={!onPress}
     >
@@ -48,17 +52,37 @@ function SettingRow({ label, onPress, rightText, destructive = false, showChevro
 export default function SettingsScreen() {
   const { getToken, signOut } = useAuth();
   const [isWithdrawing, setIsWithdrawing] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
   const isWithdrawingRef = useRef(false);
+  const isLoggingOutRef = useRef(false);
 
   function handleLogout() {
-    Alert.alert('로그아웃', '로그아웃하시겠습니까?', [
+    if (isLoggingOutRef.current) {
+      return;
+    }
+
+    showAlert('로그아웃', '로그아웃하시겠습니까?', [
       { text: '취소', style: 'cancel' },
       {
         text: '로그아웃',
         style: 'destructive',
         onPress: async () => {
-          await signOut();
-          router.replace('/(auth)/login');
+          if (isLoggingOutRef.current) {
+            return;
+          }
+
+          isLoggingOutRef.current = true;
+          setIsLoggingOut(true);
+
+          try {
+            await signOut();
+            router.replace('/(auth)/login');
+          } catch (error) {
+            console.error(error);
+            isLoggingOutRef.current = false;
+            setIsLoggingOut(false);
+            showAlert('로그아웃 실패', '로그아웃 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+          }
         },
       },
     ]);
@@ -69,7 +93,7 @@ export default function SettingsScreen() {
       return;
     }
 
-    Alert.alert(
+    showAlert(
       '회원탈퇴',
       '회원탈퇴하시겠습니까? 탈퇴 후에는 현재 계정으로 서비스를 이용할 수 없습니다.',
       [
@@ -106,7 +130,7 @@ export default function SettingsScreen() {
 
       isWithdrawingRef.current = false;
       setIsWithdrawing(false);
-      Alert.alert(
+      showAlert(
         '회원탈퇴 실패',
         '회원탈퇴 처리 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.',
       );
@@ -181,7 +205,11 @@ export default function SettingsScreen() {
         {/* 계정 */}
         <SectionLabel label="계정" />
         <View style={styles.group}>
-          <SettingRow label="로그아웃" onPress={handleLogout} />
+          <SettingRow
+            label="로그아웃"
+            rightText={isLoggingOut ? '처리 중' : undefined}
+            onPress={isLoggingOut ? undefined : handleLogout}
+          />
           <View style={styles.divider} />
           <SettingRow
             label="회원탈퇴"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,8 +5,10 @@ import { Stack } from 'expo-router';
 import { ShareIntentProvider } from 'expo-share-intent';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import { StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
+import { PressBlocker } from '@/components/ui/press-blocker';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY;
@@ -27,7 +29,7 @@ export default function RootLayout() {
   return (
     <ShareIntentProvider options={{ scheme: 'linclean', resetOnBackground: false }}>
       <ClerkProvider publishableKey={clerkPublishableKey} tokenCache={tokenCache}>
-        <GestureHandlerRootView style={{ flex: 1 }}>
+        <GestureHandlerRootView style={styles.root}>
           <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
             <Stack>
               <Stack.Screen name="index" options={{ headerShown: false }} />
@@ -38,8 +40,15 @@ export default function RootLayout() {
             </Stack>
             <StatusBar style="auto" />
           </ThemeProvider>
+          <PressBlocker />
         </GestureHandlerRootView>
       </ClerkProvider>
     </ShareIntentProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/components/external-link.tsx
+++ b/components/external-link.tsx
@@ -2,22 +2,28 @@ import { Href, Link } from 'expo-router';
 import { openBrowserAsync, WebBrowserPresentationStyle } from 'expo-web-browser';
 import { type ComponentProps } from 'react';
 
+import { useGuardedPress } from '@/utils/press-guard';
+
 type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: Href & string };
 
 export function ExternalLink({ href, ...rest }: Props) {
+  const openExternalLink = useGuardedPress(async () => {
+    await openBrowserAsync(href, {
+      presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
+    });
+  });
+
   return (
     <Link
       target="_blank"
       {...rest}
       href={href}
-      onPress={async (event) => {
+      onPress={(event) => {
         if (process.env.EXPO_OS !== 'web') {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();
           // Open the link in an in-app browser.
-          await openBrowserAsync(href, {
-            presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
-          });
+          openExternalLink?.();
         }
       }}
     />

--- a/components/ui/action-icon-button.tsx
+++ b/components/ui/action-icon-button.tsx
@@ -1,5 +1,6 @@
 import { Pressable, StyleSheet, Text } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 import { IconSymbol } from './icon-symbol';
 
 type Variant = 'delete' | 'erase';
@@ -28,10 +29,11 @@ export function ActionIconButton({
   const labelColor = disabled ? Colors.brand.textHint : Colors.brand.textSecondary;
   const showIcon = icon;
   const showLabel = Boolean(label);
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
 
   return (
     <Pressable
-      onPress={disabled ? undefined : onPress}
+      onPress={guardedOnPress}
       style={({ pressed }) => [
         styles.container,
         pressed && !disabled && styles.pressed,

--- a/components/ui/add-folder-button.tsx
+++ b/components/ui/add-folder-button.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, TouchableOpacity, type TouchableOpacityProps } from 'react-native';
 
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export interface AddFolderButtonProps extends Omit<TouchableOpacityProps, 'style'> {
   label?: string;
@@ -15,10 +16,12 @@ export function AddFolderButton({
   onPress,
   ...rest
 }: AddFolderButtonProps) {
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
+
   return (
     <TouchableOpacity
       style={[styles.base, disabled && styles.disabled]}
-      onPress={onPress}
+      onPress={guardedOnPress}
       disabled={disabled}
       activeOpacity={0.75}
       {...rest}

--- a/components/ui/app-icon.tsx
+++ b/components/ui/app-icon.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-native';
 
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 import { IconSymbol, type IconSymbolName } from './icon-symbol';
 
 export type AppIconName =
@@ -58,10 +59,11 @@ export function AppIcon({
   style,
 }: AppIconProps) {
   const iconColor = disabled ? Colors.brand.textHint : Colors.brand.text;
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
 
   return (
     <TouchableOpacity
-      onPress={onPress}
+      onPress={guardedOnPress}
       disabled={disabled}
       activeOpacity={0.7}
       style={[styles.container, style]}

--- a/components/ui/bookmark-chip.tsx
+++ b/components/ui/bookmark-chip.tsx
@@ -1,6 +1,7 @@
 import { Pressable, StyleSheet, Text } from 'react-native';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export type BookmarkChipVariant = 'active' | 'inactive';
 
@@ -20,6 +21,7 @@ export function BookmarkChip({
   onPress,
 }: BookmarkChipProps) {
   const isActive = variant === 'active';
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
 
   const containerStyle = disabled
     ? styles.chipDisabled
@@ -41,7 +43,7 @@ export function BookmarkChip({
 
   return (
     <Pressable
-      onPress={disabled ? undefined : onPress}
+      onPress={guardedOnPress}
       style={({ pressed }) => [
         styles.chip,
         containerStyle,

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
 export type ButtonSize = 'large' | 'medium' | 'small';
@@ -34,6 +35,7 @@ export function Button({
   ...rest
 }: ButtonProps) {
   const isDisabled = disabled || loading;
+  const guardedOnPress = useGuardedPress(onPress, { disabled: isDisabled });
 
   return (
     <TouchableOpacity
@@ -43,7 +45,7 @@ export function Button({
         styles[`variant_${variant}` as keyof typeof styles],
         isDisabled && styles[`variant_${variant}_disabled` as keyof typeof styles],
       ]}
-      onPress={onPress}
+      onPress={guardedOnPress}
       disabled={isDisabled}
       activeOpacity={0.75}
       {...rest}

--- a/components/ui/card-link.tsx
+++ b/components/ui/card-link.tsx
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
-import { Alert, Linking, Pressable, StyleSheet, Text, View, type GestureResponderEvent } from 'react-native';
+import { Linking, Pressable, StyleSheet, Text, View, type GestureResponderEvent } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
+import { showAlert } from '@/utils/guarded-alert';
+import { useGuardedPress } from '@/utils/press-guard';
 import type { AnchorPosition } from './folder-card';
 import { IconSymbol } from './icon-symbol';
 
@@ -55,16 +57,18 @@ export function CardLink({
   const normalizedVerdict = verdict && verdict in VERDICT_LABELS ? verdict : undefined;
   const statusLabel = normalizedVerdict ? VERDICT_LABELS[normalizedVerdict] : (getFirstText(label) ?? '결과 없음');
   const statusColors = normalizedVerdict ? VERDICT_COLORS[normalizedVerdict] : undefined;
+  const guardedBookmark = useGuardedPress(onBookmark, { disabled });
+  const guardedMore = useGuardedPress(onMore, { disabled });
 
   const handleBookmarkPress = (event: GestureResponderEvent) => {
     event.stopPropagation();
-    onBookmark?.();
+    guardedBookmark?.();
   };
 
   const handleMorePress = (event: GestureResponderEvent) => {
     event.stopPropagation();
     moreRef.current?.measure((_fx, _fy, width, height, px, py) => {
-      onMore?.({ x: px, y: py, width, height });
+      guardedMore?.({ x: px, y: py, width, height });
     });
   };
 
@@ -76,20 +80,21 @@ export function CardLink({
     }
 
     if (!openUrl) {
-      Alert.alert('URL을 열 수 없어요', '저장된 URL 정보가 없습니다.');
+      showAlert('URL을 열 수 없어요', '저장된 URL 정보가 없습니다.');
       return;
     }
 
     try {
       await Linking.openURL(openUrl);
     } catch {
-      Alert.alert('URL을 열 수 없어요', '잠시 후 다시 시도해주세요.');
+      showAlert('URL을 열 수 없어요', '잠시 후 다시 시도해주세요.');
     }
   };
+  const guardedCardPress = useGuardedPress(handleCardPress, { disabled });
 
   return (
     <Pressable
-      onPress={handleCardPress}
+      onPress={guardedCardPress}
       style={({ pressed }) => [
         styles.card,
         disabled && styles.cardDisabled,

--- a/components/ui/check-icon.tsx
+++ b/components/ui/check-icon.tsx
@@ -1,5 +1,6 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 type Variant = 'checked' | 'unchecked';
 
@@ -42,10 +43,11 @@ export function CheckIcon({
 }: CheckIconProps) {
   const isChecked = checked ?? variant === 'checked';
   const labelColor = disabled ? Colors.brand.textHint : Colors.brand.textSecondary;
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
 
   return (
     <Pressable
-      onPress={disabled ? undefined : onPress}
+      onPress={guardedOnPress}
       style={({ pressed }) => [
         styles.container,
         pressed && !disabled && styles.pressed,

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -6,16 +6,18 @@ import { ThemedView } from '@/components/themed-view';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
   const theme = useColorScheme() ?? 'light';
+  const handleToggle = useGuardedPress(() => setIsOpen((value) => !value), { lockMs: 250 });
 
   return (
     <ThemedView>
       <TouchableOpacity
         style={styles.heading}
-        onPress={() => setIsOpen((value) => !value)}
+        onPress={handleToggle}
         activeOpacity={0.8}>
         <IconSymbol
           name="chevron.right"

--- a/components/ui/filter-chip.tsx
+++ b/components/ui/filter-chip.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -32,6 +33,8 @@ interface DropdownProps {
 }
 
 function Dropdown({ items, selectedValue, onSelect }: DropdownProps) {
+  const guardedOnSelect = useGuardedPress(onSelect, { lockMs: 250 });
+
   return (
     <View style={dropdownStyles.container}>
       {items.map((item, index) => {
@@ -41,7 +44,7 @@ function Dropdown({ items, selectedValue, onSelect }: DropdownProps) {
         return (
           <View key={item.value}>
             <Pressable
-              onPress={() => onSelect(item.value)}
+              onPress={() => guardedOnSelect?.(item.value)}
               style={({ pressed }) => [
                 dropdownStyles.item,
                 isSelected && dropdownStyles.itemSelected,
@@ -139,10 +142,12 @@ export function FilterChip({
     onSelect?.(value);
   }
 
+  const guardedHandlePress = useGuardedPress(handlePress, { disabled, lockMs: 250 });
+
   return (
     <View style={chipStyles.wrapper}>
       <Pressable
-        onPress={handlePress}
+        onPress={guardedHandlePress}
         style={({ pressed }) => [
           chipStyles.chip,
           disabled && chipStyles.chipDisabled,

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 import { AppIcon } from './app-icon';
 
 export interface AnchorPosition {
@@ -27,17 +28,19 @@ export function FolderCard({
   disabled = false,
 }: FolderCardProps) {
   const moreRef = useRef<View>(null);
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
+  const guardedOnMorePress = useGuardedPress(onMorePress, { disabled });
 
   const handleMorePress = () => {
     moreRef.current?.measure((_fx, _fy, width, height, px, py) => {
-      onMorePress?.({ x: px, y: py, width, height });
+      guardedOnMorePress?.({ x: px, y: py, width, height });
     });
   };
 
   return (
     <Pressable
       style={({ pressed }) => [pressed && !disabled && styles.pressed]}
-      onPress={disabled ? undefined : onPress}
+      onPress={guardedOnPress}
       accessibilityRole="button"
       accessibilityLabel={`${folderName} 폴더, ${urlCount}개`}
       accessibilityState={{ disabled }}

--- a/components/ui/folder-context-menu.tsx
+++ b/components/ui/folder-context-menu.tsx
@@ -1,5 +1,6 @@
 import { Dimensions, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 import type { AnchorPosition } from './folder-card';
 
 const MENU_WIDTH = 140;
@@ -36,6 +37,11 @@ export function FolderContextMenu({
     { label: '폴더명 수정', onPress: () => onEditName?.() },
     { label: '폴더 삭제', onPress: () => onDelete?.(), destructive: true },
   ];
+  const guardedDismiss = useGuardedPress(onDismiss, { lockMs: 250 });
+  const guardedItemPress = useGuardedPress((item: ContextMenuItem) => {
+    onDismiss?.();
+    item.onPress();
+  });
 
   const menuHeight = MENU_ITEM_HEIGHT * resolvedItems.length + (resolvedItems.length - 1);
 
@@ -56,17 +62,14 @@ export function FolderContextMenu({
       animationType="fade"
       onRequestClose={onDismiss}
     >
-      <Pressable style={styles.backdrop} onPress={onDismiss}>
+      <Pressable style={styles.backdrop} onPress={guardedDismiss}>
         <View style={[styles.menu, { top: menuTop, left: menuLeft }]}>
           {resolvedItems.map((item, index) => (
             <View key={item.label}>
               {index > 0 && <View style={styles.divider} />}
               <Pressable
                 style={({ pressed }) => [styles.menuItem, pressed && styles.menuItemPressed]}
-                onPress={() => {
-                  onDismiss?.();
-                  item.onPress();
-                }}
+                onPress={() => guardedItemPress?.(item)}
                 accessibilityRole="button"
                 accessibilityLabel={item.label}
               >

--- a/components/ui/folder-icon.tsx
+++ b/components/ui/folder-icon.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, TouchableOpacity, type StyleProp, type ViewStyle } from 'react-native';
 
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 import { IconSymbol } from './icon-symbol';
 
 export interface FolderIconProps {
@@ -33,10 +34,11 @@ export function FolderIcon({
     : active
       ? Colors.brand.text
       : Colors.brand.textSecondary;
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
 
   return (
     <TouchableOpacity
-      onPress={onPress}
+      onPress={guardedOnPress}
       disabled={disabled}
       activeOpacity={0.7}
       style={[styles.container, style]}

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 interface LinkSaveModalProps {
   visible: boolean;
@@ -44,19 +45,21 @@ export function LinkSaveModal({
     if (saveDisabled) return;
     onSave(trimmedTitle);
   };
+  const guardedCancel = useGuardedPress(onCancel, { disabled: loading, lockMs: 250 });
+  const guardedSave = useGuardedPress(handleSave, { disabled: saveDisabled });
 
   return (
     <Modal
       visible={visible}
       transparent
       animationType="slide"
-      onRequestClose={onCancel}
+      onRequestClose={guardedCancel}
     >
       <KeyboardAvoidingView
         style={styles.overlay}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <Pressable style={styles.backdrop} onPress={loading ? undefined : onCancel} />
+        <Pressable style={styles.backdrop} onPress={guardedCancel} />
 
         <View style={styles.sheet}>
           <View style={styles.handle} />
@@ -75,7 +78,7 @@ export function LinkSaveModal({
               placeholder="예: 네이버 블로그"
               placeholderTextColor={Colors.brand.textHint}
               returnKeyType="done"
-              onSubmitEditing={handleSave}
+              onSubmitEditing={guardedSave}
               maxLength={500}
               editable={!loading}
               autoFocus
@@ -94,7 +97,7 @@ export function LinkSaveModal({
           <View style={styles.actions}>
             <TouchableOpacity
               style={styles.cancelButton}
-              onPress={onCancel}
+              onPress={guardedCancel}
               activeOpacity={0.8}
               disabled={loading}
             >
@@ -103,7 +106,7 @@ export function LinkSaveModal({
 
             <TouchableOpacity
               style={[styles.saveButton, saveDisabled && styles.saveButtonDisabled]}
-              onPress={handleSave}
+              onPress={guardedSave}
               activeOpacity={0.8}
               disabled={saveDisabled}
             >

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
+  Keyboard,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -78,7 +79,7 @@ export function LinkSaveModal({
               placeholder="예: 네이버 블로그"
               placeholderTextColor={Colors.brand.textHint}
               returnKeyType="done"
-              onSubmitEditing={guardedSave}
+              onSubmitEditing={Keyboard.dismiss}
               maxLength={500}
               editable={!loading}
               autoFocus

--- a/components/ui/press-blocker.tsx
+++ b/components/ui/press-blocker.tsx
@@ -1,0 +1,22 @@
+import { StyleSheet, View } from 'react-native';
+
+import { useBlockingInteractionActive } from '@/utils/press-guard';
+
+export function PressBlocker() {
+  const isBlocking = useBlockingInteractionActive();
+
+  if (!isBlocking) {
+    return null;
+  }
+
+  return <View pointerEvents="auto" style={styles.blocker} />;
+}
+
+const styles = StyleSheet.create({
+  blocker: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'transparent',
+    elevation: 9999,
+    zIndex: 9999,
+  },
+});

--- a/components/ui/scan-button.tsx
+++ b/components/ui/scan-button.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, TouchableOpacity, type StyleProp, type ViewStyle } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 import { IconSymbol } from './icon-symbol';
 
 interface ScanButtonProps {
@@ -10,10 +11,11 @@ interface ScanButtonProps {
 
 export function ScanButton({ onPress, disabled = false, style }: ScanButtonProps) {
   const color = disabled ? Colors.brand.textHint : Colors.brand.primary;
+  const guardedOnPress = useGuardedPress(onPress, { disabled });
 
   return (
     <TouchableOpacity
-      onPress={onPress}
+      onPress={guardedOnPress}
       disabled={disabled}
       activeOpacity={0.7}
       style={[styles.container, disabled && styles.containerDisabled, style]}

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 interface SectionHeaderProps {
   label: string;
@@ -10,11 +11,13 @@ interface SectionHeaderProps {
 }
 
 export function SectionHeader({ label, onViewAll, viewAllLabel = '전체보기', rightSlot }: SectionHeaderProps) {
+  const guardedOnViewAll = useGuardedPress(onViewAll);
+
   return (
     <View style={styles.container}>
       <Text style={styles.label}>{label}</Text>
       {rightSlot ?? (onViewAll && (
-        <TouchableOpacity onPress={onViewAll} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+        <TouchableOpacity onPress={guardedOnViewAll} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
           <Text style={styles.viewAll}>{viewAllLabel}</Text>
         </TouchableOpacity>
       ))}

--- a/components/ui/social-login-button.tsx
+++ b/components/ui/social-login-button.tsx
@@ -3,6 +3,7 @@ import { Image } from 'expo-image';
 import { Pressable, StyleSheet, Text, View, type PressableProps } from 'react-native';
 
 import { Colors, Typography } from '@/constants/theme';
+import { useGuardedPress } from '@/utils/press-guard';
 
 export type SocialLoginProvider = 'google' | 'apple';
 
@@ -13,16 +14,20 @@ interface SocialLoginButtonProps extends Omit<PressableProps, 'children' | 'styl
   label: string;
 }
 
-export function SocialLoginButton({ provider, label, disabled, ...rest }: SocialLoginButtonProps) {
+export function SocialLoginButton({ provider, label, disabled, onPress, ...rest }: SocialLoginButtonProps) {
+  const isDisabled = Boolean(disabled);
+  const guardedOnPress = useGuardedPress(onPress ?? undefined, { disabled: isDisabled });
+
   return (
     <Pressable
       accessibilityRole="button"
-      disabled={disabled}
+      disabled={isDisabled}
+      onPress={guardedOnPress}
       style={({ pressed }) => [
         styles.base,
         styles[provider],
         pressed && styles.pressed,
-        disabled && styles.disabled,
+        isDisabled && styles.disabled,
       ]}
       {...rest}
     >

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  Alert,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -14,6 +13,8 @@ import {
 
 import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, type SavedLink } from '@/context/saved-links-context';
+import { showAlert } from '@/utils/guarded-alert';
+import { useGuardedPress } from '@/utils/press-guard';
 
 interface TitleEditModalProps {
   editingLink: SavedLink | null;
@@ -59,7 +60,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       await onConfirm(editingLink.id, trimmedTitle);
       onClose();
     } catch (error) {
-      Alert.alert(
+      showAlert(
         '제목 수정 실패',
         getSavedLinkErrorMessage(error, '제목을 수정하지 못했습니다. 잠시 후 다시 시도해주세요.'),
       );
@@ -74,19 +75,25 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
     trimmedTitleValue.length > 500 ||
     trimmedTitleValue === editingLink?.title.trim() ||
     isUpdatingTitle;
+  const guardedClose = useGuardedPress(handleClose, { disabled: isUpdatingTitle, lockMs: 250 });
+  const guardedConfirm = useGuardedPress(handleConfirm, { disabled: titleSubmitDisabled });
+  const guardedClearTitle = useGuardedPress(() => setTitleValue(''), {
+    disabled: isUpdatingTitle,
+    lockMs: 250,
+  });
 
   return (
     <Modal
       visible={editingLink !== null}
       transparent
       animationType="fade"
-      onRequestClose={handleClose}
+      onRequestClose={guardedClose}
     >
       <KeyboardAvoidingView
         style={styles.overlay}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <Pressable style={styles.backdrop} onPress={handleClose} />
+        <Pressable style={styles.backdrop} onPress={guardedClose} />
         <View style={styles.sheet}>
           <Text style={styles.sheetTitle}>제목 수정</Text>
           <View style={styles.inputRow}>
@@ -98,14 +105,14 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
               placeholder="URL 제목 입력"
               placeholderTextColor={Colors.brand.textHint}
               returnKeyType="done"
-              onSubmitEditing={handleConfirm}
+              onSubmitEditing={guardedConfirm}
               maxLength={500}
               editable={!isUpdatingTitle}
               autoFocus
             />
             {titleValue.length > 0 && !isUpdatingTitle && (
               <TouchableOpacity
-                onPress={() => setTitleValue('')}
+                onPress={guardedClearTitle}
                 hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                 style={styles.clearButton}
               >
@@ -116,14 +123,14 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
           <View style={styles.actions}>
             <TouchableOpacity
               style={styles.cancelBtn}
-              onPress={handleClose}
+              onPress={guardedClose}
               disabled={isUpdatingTitle}
             >
               <Text style={styles.cancelText}>취소</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.confirmBtn, titleSubmitDisabled && styles.confirmBtnDisabled]}
-              onPress={handleConfirm}
+              onPress={guardedConfirm}
               disabled={titleSubmitDisabled}
             >
               <Text style={[styles.confirmText, titleSubmitDisabled && styles.confirmTextDisabled]}>

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -1,9 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
-=======
-  Alert,
->>>>>>> dev
   Keyboard,
   LayoutAnimation,
   Modal,
@@ -21,12 +17,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, type SavedLink } from '@/context/saved-links-context';
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
 import { showAlert } from '@/utils/guarded-alert';
 import { useGuardedPress } from '@/utils/press-guard';
-=======
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
->>>>>>> dev
 
 const MODAL_BOTTOM_GAP = 16;
 const KEYBOARD_TOP_GAP = 8;
@@ -151,15 +143,12 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
     trimmedTitleValue.length > 500 ||
     trimmedTitleValue === editingLink?.title.trim() ||
     isUpdatingTitle;
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
   const guardedClose = useGuardedPress(handleClose, { disabled: isUpdatingTitle, lockMs: 250 });
   const guardedConfirm = useGuardedPress(handleConfirm, { disabled: titleSubmitDisabled });
   const guardedClearTitle = useGuardedPress(() => setTitleValue(''), {
     disabled: isUpdatingTitle,
     lockMs: 250,
   });
-=======
->>>>>>> dev
   const restingBottomInset = Math.max(insets.bottom, MODAL_BOTTOM_GAP);
   const modalBottomInset = keyboardInset > 0
     ? keyboardInset + KEYBOARD_TOP_GAP
@@ -170,11 +159,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       visible={editingLink !== null}
       transparent
       animationType="fade"
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
       onRequestClose={guardedClose}
-=======
-      onRequestClose={handleClose}
->>>>>>> dev
       onShow={handleModalShow}
     >
       <View
@@ -206,11 +191,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
               />
               {titleValue.length > 0 && !isUpdatingTitle && (
                 <TouchableOpacity
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
                   onPress={guardedClearTitle}
-=======
-                  onPress={() => setTitleValue('')}
->>>>>>> dev
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                   style={styles.clearButton}
                 >
@@ -221,22 +202,14 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
             <View style={styles.actions}>
               <TouchableOpacity
                 style={styles.cancelBtn}
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
                 onPress={guardedClose}
-=======
-                onPress={handleClose}
->>>>>>> dev
                 disabled={isUpdatingTitle}
               >
                 <Text style={styles.cancelText}>취소</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={[styles.confirmBtn, titleSubmitDisabled && styles.confirmBtnDisabled]}
-<<<<<<< fix/#56-prevent-duplicate-taps-alert-touch-through
                 onPress={guardedConfirm}
-=======
-                onPress={handleConfirm}
->>>>>>> dev
                 disabled={titleSubmitDisabled}
               >
                 <Text style={[styles.confirmText, titleSubmitDisabled && styles.confirmTextDisabled]}>

--- a/components/ui/title-edit-modal.tsx
+++ b/components/ui/title-edit-modal.tsx
@@ -1,20 +1,46 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  KeyboardAvoidingView,
+  Keyboard,
+  LayoutAnimation,
   Modal,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
+  type KeyboardEvent,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, type SavedLink } from '@/context/saved-links-context';
 import { showAlert } from '@/utils/guarded-alert';
 import { useGuardedPress } from '@/utils/press-guard';
+
+const MODAL_BOTTOM_GAP = 16;
+const KEYBOARD_TOP_GAP = 8;
+
+const showKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+const hideKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+const syncKeyboardLayoutAnimation = (event: KeyboardEvent) => {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+
+  const duration = event.duration > 10 ? event.duration : 10;
+
+  LayoutAnimation.configureNext({
+    duration,
+    update: {
+      duration,
+      type: LayoutAnimation.Types[event.easing] || LayoutAnimation.Types.keyboard,
+    },
+  });
+};
 
 interface TitleEditModalProps {
   editingLink: SavedLink | null;
@@ -23,20 +49,51 @@ interface TitleEditModalProps {
 }
 
 export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditModalProps) {
+  const insets = useSafeAreaInsets();
   const [titleValue, setTitleValue] = useState('');
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+  const [keyboardInset, setKeyboardInset] = useState(0);
   const titleInputRef = useRef<TextInput>(null);
+  const titleFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTitleFocusTimer = useCallback(() => {
+    if (titleFocusTimerRef.current) {
+      clearTimeout(titleFocusTimerRef.current);
+      titleFocusTimerRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     if (!editingLink) {
       setTitleValue('');
+      setKeyboardInset(0);
+      clearTitleFocusTimer();
       return;
     }
 
     setTitleValue(editingLink.title);
-    const focusTimer = setTimeout(() => titleInputRef.current?.focus(), 100);
+  }, [clearTitleFocusTimer, editingLink]);
 
-    return () => clearTimeout(focusTimer);
+  useEffect(() => clearTitleFocusTimer, [clearTitleFocusTimer]);
+
+  useEffect(() => {
+    if (!editingLink) {
+      return;
+    }
+
+    const showSubscription = Keyboard.addListener(showKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
+      setKeyboardInset(event.endCoordinates.height);
+    });
+    const hideSubscription = Keyboard.addListener(hideKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
+      setKeyboardInset(0);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
   }, [editingLink]);
 
   const handleClose = useCallback(() => {
@@ -44,8 +101,18 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       return;
     }
 
+    clearTitleFocusTimer();
     onClose();
-  }, [isUpdatingTitle, onClose]);
+  }, [clearTitleFocusTimer, isUpdatingTitle, onClose]);
+
+  const handleModalShow = useCallback(() => {
+    clearTitleFocusTimer();
+
+    titleFocusTimerRef.current = setTimeout(() => {
+      titleInputRef.current?.focus();
+      titleFocusTimerRef.current = null;
+    }, 100);
+  }, [clearTitleFocusTimer]);
 
   const handleConfirm = useCallback(async () => {
     const trimmedTitle = titleValue.trim();
@@ -58,6 +125,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
 
     try {
       await onConfirm(editingLink.id, trimmedTitle);
+      clearTitleFocusTimer();
       onClose();
     } catch (error) {
       showAlert(
@@ -67,7 +135,7 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
     } finally {
       setIsUpdatingTitle(false);
     }
-  }, [editingLink, isUpdatingTitle, onClose, onConfirm, titleValue]);
+  }, [clearTitleFocusTimer, editingLink, isUpdatingTitle, onClose, onConfirm, titleValue]);
 
   const trimmedTitleValue = titleValue.trim();
   const titleSubmitDisabled =
@@ -81,6 +149,10 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
     disabled: isUpdatingTitle,
     lockMs: 250,
   });
+  const restingBottomInset = Math.max(insets.bottom, MODAL_BOTTOM_GAP);
+  const modalBottomInset = keyboardInset > 0
+    ? keyboardInset + KEYBOARD_TOP_GAP
+    : restingBottomInset;
 
   return (
     <Modal
@@ -88,58 +160,66 @@ export function TitleEditModal({ editingLink, onConfirm, onClose }: TitleEditMod
       transparent
       animationType="fade"
       onRequestClose={guardedClose}
+      onShow={handleModalShow}
     >
-      <KeyboardAvoidingView
-        style={styles.overlay}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      <View
+        style={[
+          styles.overlay,
+          { paddingBottom: modalBottomInset },
+        ]}
       >
         <Pressable style={styles.backdrop} onPress={guardedClose} />
         <View style={styles.sheet}>
-          <Text style={styles.sheetTitle}>제목 수정</Text>
-          <View style={styles.inputRow}>
-            <TextInput
-              ref={titleInputRef}
-              style={styles.input}
-              value={titleValue}
-              onChangeText={setTitleValue}
-              placeholder="URL 제목 입력"
-              placeholderTextColor={Colors.brand.textHint}
-              returnKeyType="done"
-              onSubmitEditing={guardedConfirm}
-              maxLength={500}
-              editable={!isUpdatingTitle}
-              autoFocus
-            />
-            {titleValue.length > 0 && !isUpdatingTitle && (
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.sheetContent}
+          >
+            <Text style={styles.sheetTitle}>제목 수정</Text>
+            <View style={styles.inputRow}>
+              <TextInput
+                ref={titleInputRef}
+                style={styles.input}
+                value={titleValue}
+                onChangeText={setTitleValue}
+                placeholder="URL 제목 입력"
+                placeholderTextColor={Colors.brand.textHint}
+                returnKeyType="done"
+                onSubmitEditing={Keyboard.dismiss}
+                maxLength={500}
+                editable={!isUpdatingTitle}
+              />
+              {titleValue.length > 0 && !isUpdatingTitle && (
+                <TouchableOpacity
+                  onPress={guardedClearTitle}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  style={styles.clearButton}
+                >
+                  <Text style={styles.clearButtonText}>−</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+            <View style={styles.actions}>
               <TouchableOpacity
-                onPress={guardedClearTitle}
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                style={styles.clearButton}
+                style={styles.cancelBtn}
+                onPress={guardedClose}
+                disabled={isUpdatingTitle}
               >
-                <Text style={styles.clearButtonText}>−</Text>
+                <Text style={styles.cancelText}>취소</Text>
               </TouchableOpacity>
-            )}
-          </View>
-          <View style={styles.actions}>
-            <TouchableOpacity
-              style={styles.cancelBtn}
-              onPress={guardedClose}
-              disabled={isUpdatingTitle}
-            >
-              <Text style={styles.cancelText}>취소</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[styles.confirmBtn, titleSubmitDisabled && styles.confirmBtnDisabled]}
-              onPress={guardedConfirm}
-              disabled={titleSubmitDisabled}
-            >
-              <Text style={[styles.confirmText, titleSubmitDisabled && styles.confirmTextDisabled]}>
-                {isUpdatingTitle ? '저장 중...' : '저장'}
-              </Text>
-            </TouchableOpacity>
-          </View>
+              <TouchableOpacity
+                style={[styles.confirmBtn, titleSubmitDisabled && styles.confirmBtnDisabled]}
+                onPress={guardedConfirm}
+                disabled={titleSubmitDisabled}
+              >
+                <Text style={[styles.confirmText, titleSubmitDisabled && styles.confirmTextDisabled]}>
+                  {isUpdatingTitle ? '저장 중...' : '저장'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </ScrollView>
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 }
@@ -154,9 +234,14 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brand.overlayBackdrop,
   },
   sheet: {
+    width: '100%',
+    maxHeight: '80%',
     backgroundColor: Colors.brand.surface,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
+    overflow: 'hidden',
+  },
+  sheetContent: {
     padding: 24,
     paddingBottom: 40,
     gap: 16,

--- a/utils/guarded-alert.ts
+++ b/utils/guarded-alert.ts
@@ -1,0 +1,43 @@
+import { Alert, type AlertButton, type AlertOptions } from 'react-native';
+
+import { beginBlockingInteraction, isBlockingInteractionActive } from '@/utils/press-guard';
+
+export function showAlert(
+  title: string,
+  message?: string,
+  buttons?: AlertButton[],
+  options?: AlertOptions,
+) {
+  if (isBlockingInteractionActive()) {
+    return;
+  }
+
+  const releaseBlock = beginBlockingInteraction();
+  let didHandleButton = false;
+
+  const release = () => {
+    releaseBlock();
+  };
+
+  const resolvedButtons = buttons && buttons.length > 0 ? buttons : [{ text: '확인' }];
+  const guardedButtons = resolvedButtons.map((button) => ({
+    ...button,
+    onPress: () => {
+      if (didHandleButton) {
+        return;
+      }
+
+      didHandleButton = true;
+      release();
+      button.onPress?.();
+    },
+  }));
+
+  Alert.alert(title, message, guardedButtons, {
+    ...options,
+    onDismiss: () => {
+      release();
+      options?.onDismiss?.();
+    },
+  });
+}

--- a/utils/press-guard.ts
+++ b/utils/press-guard.ts
@@ -1,0 +1,121 @@
+import { useCallback, useRef, useSyncExternalStore } from 'react';
+
+export const DEFAULT_PRESS_GUARD_MS = 700;
+
+type GuardOptions = {
+  disabled?: boolean;
+  lockMs?: number;
+  allowWhileBlocked?: boolean;
+};
+
+let blockingInteractionCount = 0;
+const listeners = new Set<() => void>();
+
+function emitBlockingInteractionChange() {
+  listeners.forEach((listener) => listener());
+}
+
+function subscribeBlockingInteraction(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function isBlockingInteractionActive() {
+  return blockingInteractionCount > 0;
+}
+
+export function beginBlockingInteraction() {
+  let released = false;
+
+  blockingInteractionCount += 1;
+  emitBlockingInteractionChange();
+
+  return () => {
+    if (released) {
+      return;
+    }
+
+    released = true;
+    blockingInteractionCount = Math.max(0, blockingInteractionCount - 1);
+    emitBlockingInteractionChange();
+  };
+}
+
+export function useBlockingInteractionActive() {
+  return useSyncExternalStore(
+    subscribeBlockingInteraction,
+    isBlockingInteractionActive,
+    () => false,
+  );
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}
+
+export function useGuardedPress<TArgs extends unknown[]>(
+  handler: ((...args: TArgs) => unknown) | undefined,
+  {
+    disabled = false,
+    lockMs = DEFAULT_PRESS_GUARD_MS,
+    allowWhileBlocked = false,
+  }: GuardOptions = {},
+) {
+  const inFlightRef = useRef(false);
+  const lastPressAtRef = useRef(0);
+  const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const guardedHandler = useCallback(
+    (...args: TArgs) => {
+      if (!handler || disabled || inFlightRef.current) {
+        return;
+      }
+
+      if (!allowWhileBlocked && isBlockingInteractionActive()) {
+        return;
+      }
+
+      const now = Date.now();
+
+      if (now - lastPressAtRef.current < lockMs) {
+        return;
+      }
+
+      lastPressAtRef.current = now;
+      inFlightRef.current = true;
+
+      if (releaseTimerRef.current) {
+        clearTimeout(releaseTimerRef.current);
+        releaseTimerRef.current = null;
+      }
+
+      const release = () => {
+        inFlightRef.current = false;
+      };
+
+      try {
+        const result = handler(...args);
+
+        if (isPromiseLike(result)) {
+          result.then(release, release);
+          return;
+        }
+
+        releaseTimerRef.current = setTimeout(release, lockMs);
+      } catch (error) {
+        release();
+        throw error;
+      }
+    },
+    [allowWhileBlocked, disabled, handler, lockMs],
+  );
+
+  return handler ? guardedHandler : undefined;
+}


### PR DESCRIPTION
Closes #56

## 개요
앱 전반에서 버튼을 빠르게 여러 번 누를 때 동일한 액션이 중복 실행되는 문제를 방지했습니다.

기존에는 저장, 삭제, 수정, 폴더 생성/수정/삭제, 화면 이동 버튼 등을 빠르게 연속 터치하면 동일한 API 요청이나 네비게이션이 여러 번 실행될 수 있었습니다. 예를 들어 링크 저장 버튼을 연속으로 누르면 저장 요청이 중복으로 발생할 수 있고, 삭제 확인창의 삭제 버튼을 빠르게 누르면 동일 삭제 요청이 반복 실행될 여지가 있었습니다. 화면 이동 버튼 역시 짧은 시간 안에 여러 번 입력되면 같은 화면이 중복으로 push될 수 있는 구조였습니다.

이번 작업에서는 이런 문제를 개별 화면에서만 막는 방식이 아니라, 공통 버튼과 주요 액션 컴포넌트에 재사용 가능한 press guard를 적용하는 방식으로 정리했습니다. 버튼을 한 번 누른 직후 짧은 시간 동안 추가 입력을 무시하고, 비동기 요청을 반환하는 액션은 요청이 끝날 때까지 같은 액션이 다시 실행되지 않도록 했습니다. 여기에 저장, 삭제, 수정, 폴더 생성처럼 실제 API 요청을 발생시키는 흐름에는 별도의 in-flight 상태를 함께 적용해 렌더링 타이밍 사이에 발생할 수 있는 재진입도 방지했습니다.

또한 `Alert.alert` 확인창이 표시된 상태에서 뒤쪽 화면의 버튼이 함께 눌리지 않도록 보완했습니다. Alert 표시 중에는 앱 루트에 투명한 터치 차단 레이어를 올려 뒤 화면으로 터치가 관통하지 않게 하고, 확인창의 확인/삭제/취소 버튼 역시 빠르게 연속으로 눌러도 동일 콜백이 반복 실행되지 않도록 `showAlert` 래퍼를 통해 관리했습니다.

이 과정에서 검사 시작 버튼처럼 화면 이동 직후 잠금 상태가 남을 수 있는 케이스도 함께 확인했습니다. 검사 화면으로 이동한 뒤 뒤로가기로 입력 화면에 돌아왔을 때 버튼이 계속 비활성화되지 않도록, 화면이 다시 포커스될 때 네비게이션 잠금을 해제하도록 수정했습니다.

## 주요 구현 내용
- 공통 중복 입력 방지 유틸 `utils/press-guard.ts` 추가
- 공통 Alert 래퍼 `utils/guarded-alert.ts` 추가
- Alert 표시 중 뒤 화면 터치 차단용 `PressBlocker` 추가
- 루트 layout에 `PressBlocker` 연결
- 공통 버튼 컴포넌트에 `useGuardedPress` 적용
- `Button`, `AppIcon`, `ActionIconButton`, `AddFolderButton`, `ScanButton` 중복 입력 차단
- 카드, 칩, 메뉴, 모달 버튼 등 주요 공통 액션 컴포넌트 중복 입력 차단
- 저장 링크 저장 버튼 연속 입력 방지
- 링크 삭제 확인창 및 삭제 요청 중복 실행 방지
- 링크 제목 수정 저장 버튼 연속 입력 방지
- 폴더 생성, 폴더명 수정, 폴더 삭제 요청 중복 실행 방지
- 폴더 URL 추가/제외 요청 중복 실행 방지
- 화면 이동 버튼 빠른 연속 터치 시 중복 push 방지
- 검사 시작 후 뒤로 돌아왔을 때 버튼 잠금이 유지되는 문제 수정
- `Alert.alert` 직접 호출을 `showAlert` 기반 흐름으로 정리

## 파일별 역할
- `utils/press-guard.ts`: 버튼/Pressable 액션의 짧은 연속 입력 및 in-flight 중복 실행 차단
- `utils/guarded-alert.ts`: Alert 표시 중 전역 터치 차단 상태를 시작/해제하고 Alert 버튼 중복 실행 방지
- `components/ui/press-blocker.tsx`: Alert 표시 중 뒤 화면 터치를 막는 투명 차단 레이어
- `app/_layout.tsx`: 앱 루트에 `PressBlocker` 연결
- `components/ui/button.tsx`: 공통 Button의 `disabled/loading` 상태 및 press guard 적용
- `components/ui/app-icon.tsx`: 공통 아이콘 버튼 press guard 적용
- `components/ui/action-icon-button.tsx`: 삭제/지우기 액션 버튼 press guard 적용
- `components/ui/add-folder-button.tsx`: 폴더 추가 버튼 press guard 적용
- `components/ui/scan-button.tsx`: 검사 시작 버튼 press guard 적용
- `components/ui/card-link.tsx`: 링크 카드, 북마크, 더보기 버튼 중복 입력 차단
- `components/ui/link-save-modal.tsx`: 링크 저장 모달의 저장/취소 버튼 중복 입력 차단
- `components/ui/title-edit-modal.tsx`: 제목 수정 모달의 저장/취소 버튼 중복 입력 차단
- `components/ui/folder-card.tsx`: 폴더 카드 및 더보기 버튼 중복 입력 차단
- `components/ui/folder-context-menu.tsx`: 컨텍스트 메뉴 항목 중복 실행 차단
- `app/(tabs)/(home)/scan-result.tsx`: safe 결과 링크 저장 중복 요청 방지
- `app/(tabs)/(home)/scan-result-caution.tsx`: caution 결과 링크 저장 중복 요청 방지
- `app/(tabs)/(home)/add-link.tsx`: 검사 시작 중복 네비게이션 방지 및 뒤로가기 복귀 시 잠금 해제
- `app/(tabs)/(home)/index.tsx`: 홈 최근 저장 링크 삭제/북마크/제목 수정 중복 실행 방지
- `app/(tabs)/(home)/saved-links.tsx`: 저장 링크 목록 삭제/북마크/제목 수정 중복 실행 방지
- `app/(tabs)/(folder)/index.tsx`: 폴더명 수정/삭제 중복 요청 방지
- `app/(tabs)/(folder)/folder-name.tsx`: 폴더 생성 다음 화면 이동 중복 방지 및 복귀 시 잠금 해제
- `app/(tabs)/(folder)/folder-url-select.tsx`: 폴더 생성 요청 중복 방지
- `app/(tabs)/(folder)/folder-add-url.tsx`: 폴더 URL 추가 요청 중복 방지
- `app/(tabs)/(folder)/[id].tsx`: 폴더에서 링크 제외 요청 중복 방지
- `app/(tabs)/(home)/settings.tsx`: 로그아웃/회원탈퇴 확인창 및 요청 중복 실행 방지

## 해결한 이슈 목록
- [x] 앱 전반의 주요 버튼 중복 입력 발생 가능 지점 확인
- [x] 공통 `Button` 컴포넌트의 `loading` 또는 `disabled` 상태 중복 입력 차단 확인
- [x] `AppIcon`, `ActionIconButton`, `AddFolderButton` 등 공통 액션 버튼 중복 입력 차단 적용
- [x] 저장, 삭제, 수정, 이동 등 API 요청 또는 네비게이션을 발생시키는 버튼 우선 점검
- [x] 요청 처리 중인 버튼은 추가 입력이 발생하지 않도록 `disabled` 또는 in-flight 상태 적용
- [x] 저장 링크 저장 버튼 연속 클릭 시 중복 저장 요청 방지
- [x] 링크 삭제 버튼 연속 클릭 시 삭제 요청 중복 실행 방지
- [x] 링크 제목 수정 버튼 연속 클릭 시 수정 요청 중복 실행 방지
- [x] 폴더 생성, 폴더명 수정, 폴더 삭제 버튼 연속 클릭 시 중복 요청 방지
- [x] 화면 이동 버튼 빠른 연속 클릭 시 동일 화면 중복 push 방지
- [x] `Alert.alert` 확인창 표시 중 뒤쪽 화면 버튼 터치 차단
- [x] 확인창의 확인/삭제/취소 버튼 빠른 연속 클릭 시 동일 액션 중복 실행 방지
- [x] 검사 시작 후 뒤로가기 복귀 시 버튼 잠금이 해제되도록 처리
- [x] Android 에뮬레이터에서 빠른 연속 터치 수동 검증
- [ ] 실제 휴대폰 preview 빌드에서 빠른 연속 터치 수동 검증

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 공통 버튼 컴포넌트에 중복 입력 방지 적용
- [x] 주요 API 요청 버튼에 in-flight 중복 실행 방지 적용
- [x] 주요 네비게이션 버튼에 연속 이동 방지 적용
- [x] Alert 표시 중 뒤 화면 터치 차단 처리
- [x] 기존 하단 탭 및 뒤로가기 동작은 별도 중복 차단 대상에서 제외

## 참고
북마크 버튼의 API 호출 간격 조정 또는 별도 디바운스 정책은 이슈 설명에 따라 이번 PR 범위에서 제외했습니다.

이번 PR에서는 버튼 중복 입력 방지와 Alert 표시 중 터치 관통 방지를 우선 처리했습니다.
