### PR TITLE
[FEATURE] 보안 등급별 링크 현황 카드 API 연동

### DIFF
--- a/api/analyses.ts
+++ b/api/analyses.ts
@@ -1,5 +1,6 @@
 import {
   authenticatedApiRequest,
+  publicApiRequest,
   type ApiRequestOptions,
   type ClerkTokenGetter,
 } from '@/api/api-client';
@@ -30,6 +31,8 @@ export type AnalysisResponse = {
   errorMessage?: string;
 };
 
+export type VerdictStatisticsResponse = Record<AnalysisVerdict, number>;
+
 type AnalysisRequestOptions = Pick<ApiRequestOptions, 'signal'>;
 
 export function requestAnalysis(
@@ -52,6 +55,13 @@ export function fetchAnalysis(
   return authenticatedApiRequest<AnalysisResponse>(
     getToken,
     `/api/v1/analyses/${encodeURIComponent(analysisId)}`,
+    options,
+  );
+}
+
+export function fetchVerdictStatistics(options: AnalysisRequestOptions = {}) {
+  return publicApiRequest<VerdictStatisticsResponse>(
+    '/api/v1/analyses/statistics',
     options,
   );
 }

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -7,6 +7,7 @@ import {
   View,
 } from 'react-native';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { useFocusEffect } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { AppIcon } from '@/components/ui/app-icon';
@@ -95,36 +96,38 @@ export default function HomeScreen() {
     setSaveToastVisible(true);
   }, [savedLinkToast]);
 
-  useEffect(() => {
-    const abortController = new AbortController();
+  useFocusEffect(
+    useCallback(() => {
+      const abortController = new AbortController();
 
-    async function loadStatistics() {
-      setIsStatisticsLoading(true);
-      setHasStatisticsError(false);
+      async function loadStatistics() {
+        setIsStatisticsLoading(true);
+        setHasStatisticsError(false);
 
-      try {
-        const response = await fetchVerdictStatistics({ signal: abortController.signal });
-        setStatistics(response);
-      } catch {
-        if (abortController.signal.aborted) {
-          return;
-        }
+        try {
+          const response = await fetchVerdictStatistics({ signal: abortController.signal });
+          setStatistics(response);
+        } catch {
+          if (abortController.signal.aborted) {
+            return;
+          }
 
-        setStatistics(EMPTY_STATISTICS);
-        setHasStatisticsError(true);
-      } finally {
-        if (!abortController.signal.aborted) {
-          setIsStatisticsLoading(false);
+          setStatistics(EMPTY_STATISTICS);
+          setHasStatisticsError(true);
+        } finally {
+          if (!abortController.signal.aborted) {
+            setIsStatisticsLoading(false);
+          }
         }
       }
-    }
 
-    void loadStatistics();
+      void loadStatistics();
 
-    return () => {
-      abortController.abort();
-    };
-  }, []);
+      return () => {
+        abortController.abort();
+      };
+    }, []),
+  );
 
   const handleMore = (id: number, anchor: AnchorPosition) => {
     setMenuState({ visible: true, anchor, linkId: id });

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -63,12 +63,12 @@ export default function HomeScreen() {
   const [titleToastVisible, setTitleToastVisible] = useState(false);
   const [statistics, setStatistics] = useState<VerdictStatisticsResponse>(EMPTY_STATISTICS);
   const [isStatisticsLoading, setIsStatisticsLoading] = useState(true);
-  const [statisticsErrorMessage, setStatisticsErrorMessage] = useState('');
+  const [hasStatisticsError, setHasStatisticsError] = useState(false);
   const lastToastParamRef = useRef<string | undefined>(undefined);
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
   const statisticsStatus = getStatisticsViewStatus(
     isStatisticsLoading,
-    statisticsErrorMessage,
+    hasStatisticsError,
   );
   const hasNoStatistics = SECURITY_STATUS_ITEMS.every(
     (item) => statistics[item.verdict] === 0,
@@ -92,7 +92,7 @@ export default function HomeScreen() {
 
     async function loadStatistics() {
       setIsStatisticsLoading(true);
-      setStatisticsErrorMessage('');
+      setHasStatisticsError(false);
 
       try {
         const response = await fetchVerdictStatistics({ signal: abortController.signal });
@@ -103,7 +103,7 @@ export default function HomeScreen() {
         }
 
         setStatistics(EMPTY_STATISTICS);
-        setStatisticsErrorMessage('불러오지 못했어요');
+        setHasStatisticsError(true);
       } finally {
         if (!abortController.signal.aborted) {
           setIsStatisticsLoading(false);
@@ -406,13 +406,13 @@ const styles = StyleSheet.create({
 
 function getStatisticsViewStatus(
   isLoading: boolean,
-  errorMessage: string,
+  hasError: boolean,
 ): StatisticsViewStatus {
   if (isLoading) {
     return 'loading';
   }
 
-  if (errorMessage) {
+  if (hasError) {
     return 'error';
   }
 

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -15,10 +15,33 @@ import { IconSymbol } from '@/components/ui/icon-symbol';
 import { SectionHeader } from '@/components/ui/section-header';
 import { TitleEditModal } from '@/components/ui/title-edit-modal';
 import { Toast } from '@/components/ui/toast';
+import {
+  fetchVerdictStatistics,
+  type AnalysisVerdict,
+  type VerdictStatisticsResponse,
+} from '@/api/analyses';
 import { Colors, Typography } from '@/constants/theme';
 import { useFolders } from '@/context/folders-context';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
+
+type SecurityStatusItem = {
+  verdict: AnalysisVerdict;
+  label: string;
+  summary: string;
+};
+
+const SECURITY_STATUS_ITEMS: SecurityStatusItem[] = [
+  { verdict: 'safe', label: '안전', summary: '문제 없음' },
+  { verdict: 'caution', label: '주의', summary: '확인 필요' },
+  { verdict: 'danger', label: '위험', summary: '접근 주의' },
+];
+
+const EMPTY_STATISTICS: VerdictStatisticsResponse = {
+  safe: 0,
+  caution: 0,
+  danger: 0,
+};
 
 export default function HomeScreen() {
   const { savedLinkToast: savedLinkToastParam } = useLocalSearchParams<{
@@ -31,6 +54,9 @@ export default function HomeScreen() {
   const [saveToastVisible, setSaveToastVisible] = useState(false);
   const [deleteToastVisible, setDeleteToastVisible] = useState(false);
   const [titleToastVisible, setTitleToastVisible] = useState(false);
+  const [statistics, setStatistics] = useState<VerdictStatisticsResponse>(EMPTY_STATISTICS);
+  const [isStatisticsLoading, setIsStatisticsLoading] = useState(true);
+  const [statisticsErrorMessage, setStatisticsErrorMessage] = useState('');
   const lastToastParamRef = useRef<string | undefined>(undefined);
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
 
@@ -45,6 +71,37 @@ export default function HomeScreen() {
     lastToastParamRef.current = savedLinkToast;
     setSaveToastVisible(true);
   }, [savedLinkToast]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    async function loadStatistics() {
+      setIsStatisticsLoading(true);
+      setStatisticsErrorMessage('');
+
+      try {
+        const response = await fetchVerdictStatistics({ signal: abortController.signal });
+        setStatistics(response);
+      } catch {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        setStatistics(EMPTY_STATISTICS);
+        setStatisticsErrorMessage('불러오지 못했어요');
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsStatisticsLoading(false);
+        }
+      }
+    }
+
+    void loadStatistics();
+
+    return () => {
+      abortController.abort();
+    };
+  }, []);
 
   const handleMore = (id: number, anchor: AnchorPosition) => {
     setMenuState({ visible: true, anchor, linkId: id });
@@ -125,14 +182,44 @@ export default function HomeScreen() {
 
         {/* 보안 등급별 링크 현황 */}
         <View style={styles.section}>
-          <SectionHeader label="보안 등급별 링크 현황" />
-          <View style={styles.statPlaceholder}>
-            <View style={styles.statGrid}>
-              <View style={styles.statItem} />
-              <View style={styles.statItem} />
-              <View style={styles.statItem} />
-              <View style={styles.statItem} />
-            </View>
+          <SectionHeader
+            label="보안 등급별 링크 현황"
+            rightSlot={
+              statisticsErrorMessage ? (
+                <Text style={styles.sectionStatus}>{statisticsErrorMessage}</Text>
+              ) : undefined
+            }
+          />
+          <View style={styles.statCardGroup}>
+            {SECURITY_STATUS_ITEMS.map((item) => {
+              const colors = Colors.brand.verdict[item.verdict];
+              const countLabel = isStatisticsLoading ? '-' : String(statistics[item.verdict]);
+
+              return (
+                <View
+                  key={item.verdict}
+                  style={[
+                    styles.statCard,
+                    { backgroundColor: colors.background, borderColor: colors.accent },
+                  ]}
+                >
+                  <View style={styles.statCardHeader}>
+                    <View style={[styles.statIndicator, { backgroundColor: colors.accent }]} />
+                    <Text style={[styles.statLabel, { color: colors.text }]}>{item.label}</Text>
+                  </View>
+                  <Text
+                    style={[styles.statCount, { color: colors.text }]}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                  >
+                    {countLabel}
+                  </Text>
+                  <Text style={[styles.statSummary, { color: colors.text }]} numberOfLines={1}>
+                    {item.summary}
+                  </Text>
+                </View>
+              );
+            })}
           </View>
         </View>
 
@@ -249,26 +336,47 @@ const styles = StyleSheet.create({
     gap: 12,
   },
 
-  statPlaceholder: {
+  sectionStatus: {
+    ...Typography.bold12,
+    color: Colors.brand.textHint,
+  },
+
+  statCardGroup: {
     backgroundColor: Colors.brand.surface,
     borderRadius: 16,
     borderWidth: 1,
     borderColor: Colors.brand.line,
     padding: 16,
-  },
-  statGrid: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
     gap: 12,
   },
-  statItem: {
+  statCard: {
     flex: 1,
-    minWidth: '45%',
-    height: 56,
-    borderRadius: 10,
-    borderWidth: 1.5,
-    borderColor: Colors.brand.line,
-    borderStyle: 'dashed',
+    minHeight: 112,
+    borderRadius: 14,
+    borderWidth: 1,
+    padding: 12,
+    justifyContent: 'space-between',
+  },
+  statCardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  statIndicator: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  statLabel: {
+    ...Typography.bold12,
+  },
+  statCount: {
+    ...Typography.title,
+    lineHeight: 30,
+  },
+  statSummary: {
+    ...Typography.regular12,
   },
 
   linkList: {

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -31,11 +31,19 @@ type SecurityStatusItem = {
   summary: string;
 };
 
+type StatisticsViewStatus = 'loading' | 'error' | 'empty' | 'ready';
+
 const SECURITY_STATUS_ITEMS: SecurityStatusItem[] = [
   { verdict: 'safe', label: '안전', summary: '문제 없음' },
   { verdict: 'caution', label: '주의', summary: '확인 필요' },
   { verdict: 'danger', label: '위험', summary: '접근 주의' },
 ];
+
+const STATISTICS_STATUS_LABELS: Record<Exclude<StatisticsViewStatus, 'ready'>, string> = {
+  loading: '조회 중',
+  error: '불러오지 못했어요',
+  empty: '기록 없음',
+};
 
 const EMPTY_STATISTICS: VerdictStatisticsResponse = {
   safe: 0,
@@ -59,6 +67,14 @@ export default function HomeScreen() {
   const [statisticsErrorMessage, setStatisticsErrorMessage] = useState('');
   const lastToastParamRef = useRef<string | undefined>(undefined);
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
+  const statisticsStatus = getStatisticsViewStatus(
+    statistics,
+    isStatisticsLoading,
+    statisticsErrorMessage,
+  );
+  const statisticsStatusLabel = statisticsStatus === 'ready'
+    ? ''
+    : STATISTICS_STATUS_LABELS[statisticsStatus];
 
   // 최근 저장한 링크 — createdAt 내림차순 상위 3개
   const recentLinks = links.slice(0, 3);
@@ -185,15 +201,20 @@ export default function HomeScreen() {
           <SectionHeader
             label="보안 등급별 링크 현황"
             rightSlot={
-              statisticsErrorMessage ? (
-                <Text style={styles.sectionStatus}>{statisticsErrorMessage}</Text>
+              statisticsStatusLabel ? (
+                <Text style={styles.sectionStatus}>{statisticsStatusLabel}</Text>
               ) : undefined
             }
           />
           <View style={styles.statCardGroup}>
             {SECURITY_STATUS_ITEMS.map((item) => {
               const colors = Colors.brand.verdict[item.verdict];
-              const countLabel = isStatisticsLoading ? '-' : String(statistics[item.verdict]);
+              const countLabel = getStatisticsCountLabel(
+                item.verdict,
+                statistics,
+                statisticsStatus,
+              );
+              const summary = getStatisticsSummary(item, statisticsStatus);
 
               return (
                 <View
@@ -215,7 +236,7 @@ export default function HomeScreen() {
                     {countLabel}
                   </Text>
                   <Text style={[styles.statSummary, { color: colors.text }]} numberOfLines={1}>
-                    {item.summary}
+                    {summary}
                   </Text>
                 </View>
               );
@@ -383,3 +404,49 @@ const styles = StyleSheet.create({
     gap: 12,
   },
 });
+
+function getStatisticsViewStatus(
+  statistics: VerdictStatisticsResponse,
+  isLoading: boolean,
+  errorMessage: string,
+): StatisticsViewStatus {
+  if (isLoading) {
+    return 'loading';
+  }
+
+  if (errorMessage) {
+    return 'error';
+  }
+
+  if (SECURITY_STATUS_ITEMS.every((item) => statistics[item.verdict] === 0)) {
+    return 'empty';
+  }
+
+  return 'ready';
+}
+
+function getStatisticsCountLabel(
+  verdict: AnalysisVerdict,
+  statistics: VerdictStatisticsResponse,
+  status: StatisticsViewStatus,
+) {
+  return status === 'loading' || status === 'error'
+    ? '-'
+    : String(statistics[verdict]);
+}
+
+function getStatisticsSummary(item: SecurityStatusItem, status: StatisticsViewStatus) {
+  if (status === 'loading') {
+    return '집계 중';
+  }
+
+  if (status === 'error') {
+    return '확인 불가';
+  }
+
+  if (status === 'empty') {
+    return '기록 없음';
+  }
+
+  return item.summary;
+}

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -213,7 +213,7 @@ export default function HomeScreen() {
                 statistics,
                 statisticsStatus,
               );
-              const summary = getStatisticsSummary(item, statisticsStatus);
+              const summary = getStatisticsSummary(item);
 
               return (
                 <View
@@ -437,14 +437,6 @@ function getStatisticsCountLabel(
     : String(statistics[verdict]);
 }
 
-function getStatisticsSummary(item: SecurityStatusItem, status: StatisticsViewStatus) {
-  if (status === 'loading') {
-    return '집계 중';
-  }
-
-  if (status === 'error') {
-    return '확인 불가';
-  }
-
+function getStatisticsSummary(item: SecurityStatusItem) {
   return item.summary;
 }

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -31,7 +31,7 @@ type SecurityStatusItem = {
   summary: string;
 };
 
-type StatisticsViewStatus = 'loading' | 'error' | 'empty' | 'ready';
+type StatisticsViewStatus = 'loading' | 'error' | 'ready';
 
 const SECURITY_STATUS_ITEMS: SecurityStatusItem[] = [
   { verdict: 'safe', label: '안전', summary: '문제 없음' },
@@ -42,7 +42,6 @@ const SECURITY_STATUS_ITEMS: SecurityStatusItem[] = [
 const STATISTICS_STATUS_LABELS: Record<Exclude<StatisticsViewStatus, 'ready'>, string> = {
   loading: '조회 중',
   error: '불러오지 못했어요',
-  empty: '기록 없음',
 };
 
 const EMPTY_STATISTICS: VerdictStatisticsResponse = {
@@ -68,13 +67,13 @@ export default function HomeScreen() {
   const lastToastParamRef = useRef<string | undefined>(undefined);
   const savedLinkToast = typeof savedLinkToastParam === 'string' ? savedLinkToastParam : undefined;
   const statisticsStatus = getStatisticsViewStatus(
-    statistics,
     isStatisticsLoading,
     statisticsErrorMessage,
   );
-  const statisticsStatusLabel = statisticsStatus === 'ready'
-    ? ''
-    : STATISTICS_STATUS_LABELS[statisticsStatus];
+  const hasNoStatistics = SECURITY_STATUS_ITEMS.every(
+    (item) => statistics[item.verdict] === 0,
+  );
+  const statisticsStatusLabel = getStatisticsStatusLabel(statisticsStatus, hasNoStatistics);
 
   // 최근 저장한 링크 — createdAt 내림차순 상위 3개
   const recentLinks = links.slice(0, 3);
@@ -406,7 +405,6 @@ const styles = StyleSheet.create({
 });
 
 function getStatisticsViewStatus(
-  statistics: VerdictStatisticsResponse,
   isLoading: boolean,
   errorMessage: string,
 ): StatisticsViewStatus {
@@ -418,11 +416,15 @@ function getStatisticsViewStatus(
     return 'error';
   }
 
-  if (SECURITY_STATUS_ITEMS.every((item) => statistics[item.verdict] === 0)) {
-    return 'empty';
+  return 'ready';
+}
+
+function getStatisticsStatusLabel(status: StatisticsViewStatus, hasNoStatistics: boolean) {
+  if (status === 'ready') {
+    return hasNoStatistics ? '기록 없음' : '';
   }
 
-  return 'ready';
+  return STATISTICS_STATUS_LABELS[status];
 }
 
 function getStatisticsCountLabel(
@@ -442,10 +444,6 @@ function getStatisticsSummary(item: SecurityStatusItem, status: StatisticsViewSt
 
   if (status === 'error') {
     return '확인 불가';
-  }
-
-  if (status === 'empty') {
-    return '기록 없음';
   }
 
   return item.summary;


### PR DESCRIPTION
Closes #60

## 개요
홈 화면의 `보안 등급별 링크 현황` placeholder 영역을 실제 통계 API 기반 카드 UI로 교체했습니다.

백엔드 `dev`에 이미 머지된 `GET /api/v1/analyses/statistics` API 계약을 확인한 뒤, 프론트 공통 API 클라이언트 패턴에 맞춰 `publicApiRequest`로 연동했습니다. 응답은 `{ safe, caution, danger }` 구조로 정리하고, 홈 화면 진입 시 등급별 통계를 조회해 안전/주의/위험 카드에 표시하도록 구성했습니다.

카드 UI는 기존 디자인 토큰인 `Colors.brand.verdict.*`, `Colors.brand.surface`, `Colors.brand.line`, `Typography.*`를 사용해 구현했습니다. 화면 파일에는 별도 헥스/rgb 색상 하드코딩을 추가하지 않았고, 기존 홈 화면의 섹션 구조와 `SectionHeader`를 재사용했습니다.

로딩, API 에러, 데이터 없음 상태도 카드 레이아웃을 유지한 채 표시되도록 처리했습니다. 작은 휴대폰에서도 카드 UI가 깨지거나 부자연스럽지 않은 것을 확인했습니다.

## 주요 구현 내용
- 홈 화면의 `보안 등급별 링크 현황` placeholder 제거
- `safe`, `caution`, `danger` 등급별 현황 카드 UI 적용
- `GET /api/v1/analyses/statistics` 통계 API 연동
- 통계 응답 타입 `VerdictStatisticsResponse` 추가
- 로딩 상태에서 카드 숫자를 `-`, 보조 문구를 `집계 중`으로 표시
- API 에러 상태에서 카드 숫자를 `-`, 보조 문구를 `확인 불가`로 표시
- 데이터 없음 상태에서 카드 숫자 `0`, 보조 문구 `기록 없음` 표시
- 기존 디자인 토큰과 공통 API 클라이언트 패턴 준수

## 파일별 역할
- `api/analyses.ts`: verdict 통계 응답 타입 및 `fetchVerdictStatistics` API 함수 추가
- `app/(tabs)/(home)/index.tsx`: 홈 화면 보안 등급별 현황 카드 UI, API 조회, 로딩/에러/빈 상태 처리

## 해결한 이슈 목록
- [x] 홈 화면의 `보안 등급별 링크 현황` placeholder 구조 확인
- [x] 표시 등급 기준을 `safe`, `caution`, `danger`로 정리
- [x] 등급별 현황 카드 UI 적용
- [x] 각 등급별 라벨, 개수, 색상, 시각 요소 정의
- [x] 로딩 상태 처리
- [x] API 에러 및 데이터 없음 상태 처리
- [x] 백엔드 등급별 통계 API 존재 여부 확인
- [x] 기존 API 응답 구조를 프론트 타입으로 정리
- [x] 공통 API 클라이언트 패턴에 맞춰 API 연동
- [x] 홈 화면 진입 시 등급별 현황 데이터 조회
- [x] 작은 휴대폰에서 카드 UI 깨짐 여부 확인

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] `API_ERD_WORKING_NOTES.md` 기준에 따라 프론트 레포 안에서만 코드 수정
- [x] 백엔드 코드는 수정하지 않고 API 계약 확인 용도로만 사용
- [x] API base URL, Authorization, `{ data: ... }` unwrap을 직접 처리하지 않음
- [x] `npx tsc --noEmit` 통과
- [x] `npm run lint` 통과
- [x] 화면 파일에 헥스/rgb/rgba 색상 하드코딩 없음 확인
- [x] 기존 저장 링크 목록/북마크/삭제/제목 수정 흐름은 유지

## 참고사항
- API endpoint: `GET /api/v1/analyses/statistics`
- 실제 백엔드 응답은 `{ data: { safe, caution, danger } }` 형태이며, 프론트 공통 API 클라이언트가 `data`를 unwrap합니다.
- 해당 API는 백엔드 `SecurityConfig` 기준 인증 불필요 API입니다.
- Android 에뮬레이터 및 preview 빌드에서의 실제 API 연동 확인은 PR 이후 추가 확인이 필요합니다.

## Screenshots or Video
- 메인화면 캡쳐본 입니다
<img width="476" height="1005" alt="일반화면 캡쳐" src="https://github.com/user-attachments/assets/5885a4c8-bc2a-441f-a90f-320ed490c71b" />

- 작은화면의 경우 캡쳐본 입니다
<img width="447" height="805" alt="작은화면 캡쳐" src="https://github.com/user-attachments/assets/79e16f90-1397-4f40-8848-6861f4ebf7d4" />

- spring 서버를 끈 상황에 뜨는  화면입니다
<img width="506" height="1017" alt="로딩,에러,데이터 없음 상태 처리" src="https://github.com/user-attachments/assets/b01b2b7f-6a37-4b5b-b82d-6a1e1daa40af" />

