### PR TITLE
[FIX] 긴 폴더명 드롭다운 말줄임 처리

### DIFF
--- a/components/ui/filter-chip.tsx
+++ b/components/ui/filter-chip.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
+
+const EXPANDED_LABEL_THRESHOLD = 6;
+const MAX_VISIBLE_LABEL_CHARS = 15;
+const LABEL_MAX_WIDTH = Typography.caption.fontSize * MAX_VISIBLE_LABEL_CHARS;
+const DROPDOWN_MIN_WIDTH = 120;
+const DROPDOWN_HORIZONTAL_PADDING = 32;
+const DROPDOWN_MAX_CONTENT_WIDTH = LABEL_MAX_WIDTH + DROPDOWN_HORIZONTAL_PADDING;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -29,11 +36,12 @@ interface DropdownProps {
   items: FilterChipItem[];
   selectedValue: string;
   onSelect: (value: string) => void;
+  width: number;
 }
 
-function Dropdown({ items, selectedValue, onSelect }: DropdownProps) {
+function Dropdown({ items, selectedValue, onSelect, width }: DropdownProps) {
   return (
-    <View style={dropdownStyles.container}>
+    <View style={[dropdownStyles.container, { width }]}>
       {items.map((item, index) => {
         const isSelected = item.value === selectedValue;
         const isLast = index === items.length - 1;
@@ -55,6 +63,8 @@ function Dropdown({ items, selectedValue, onSelect }: DropdownProps) {
                   dropdownStyles.itemLabel,
                   { color: isSelected ? Colors.brand.text : Colors.brand.textSecondary },
                 ]}
+                numberOfLines={1}
+                ellipsizeMode="tail"
               >
                 {item.label}
               </Text>
@@ -75,7 +85,7 @@ const dropdownStyles = StyleSheet.create({
     marginTop: 4,
     backgroundColor: Colors.brand.surface,
     borderRadius: 10,
-    minWidth: 120,
+    minWidth: DROPDOWN_MIN_WIDTH,
     zIndex: 100,
     shadowColor: Colors.brand.text,
     shadowOffset: { width: 0, height: 2 },
@@ -117,9 +127,15 @@ export function FilterChip({
   onPress,
 }: FilterChipProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const { width } = useWindowDimensions();
 
   const currentItem = items.find((i) => i.value === selectedValue);
   const displayLabel = label ?? currentItem?.label ?? '';
+  const hasLongDropdownItem = items.some((item) => item.label.length > EXPANDED_LABEL_THRESHOLD);
+  const dropdownWidth = Math.min(
+    hasLongDropdownItem ? DROPDOWN_MAX_CONTENT_WIDTH : DROPDOWN_MIN_WIDTH,
+    Math.max(DROPDOWN_MIN_WIDTH, width - 40),
+  );
 
   const isActive = variant === 'active';
   const labelColor = disabled
@@ -151,7 +167,13 @@ export function FilterChip({
         accessibilityRole="button"
         accessibilityState={{ disabled, expanded: isOpen }}
       >
-        <Text style={[chipStyles.label, { color: labelColor }]}>{displayLabel}</Text>
+        <Text
+          style={[chipStyles.label, { color: labelColor }]}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        >
+          {displayLabel}
+        </Text>
         {icon && (
           <View style={isOpen ? chipStyles.iconRotated : undefined}>
             <IconSymbol
@@ -168,6 +190,7 @@ export function FilterChip({
           items={items}
           selectedValue={selectedValue ?? ''}
           onSelect={handleSelect}
+          width={dropdownWidth}
         />
       )}
     </View>
@@ -178,12 +201,17 @@ const chipStyles = StyleSheet.create({
   wrapper: {
     position: 'relative',
     alignSelf: 'flex-start',
+    flexShrink: 1,
+    minWidth: 0,
+    maxWidth: '100%',
     zIndex: 10,
   },
   chip: {
     flexDirection: 'row',
     alignItems: 'center',
+    flexShrink: 1,
     gap: 4,
+    maxWidth: '100%',
     paddingVertical: 8,
     paddingHorizontal: 12,
     borderRadius: 100,
@@ -200,6 +228,8 @@ const chipStyles = StyleSheet.create({
   },
   label: {
     ...Typography.caption,
+    flexShrink: 1,
+    minWidth: 0,
   },
   iconRotated: {
     transform: [{ rotate: '180deg' }],

--- a/components/ui/filter-chip.tsx
+++ b/components/ui/filter-chip.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import { useRef, useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
 
@@ -9,6 +9,9 @@ const LABEL_MAX_WIDTH = Typography.caption.fontSize * MAX_VISIBLE_LABEL_CHARS;
 const DROPDOWN_MIN_WIDTH = 120;
 const DROPDOWN_HORIZONTAL_PADDING = 32;
 const DROPDOWN_MAX_CONTENT_WIDTH = LABEL_MAX_WIDTH + DROPDOWN_HORIZONTAL_PADDING;
+const DROPDOWN_MAX_HEIGHT_RATIO = 0.6;
+const DROPDOWN_SCREEN_PADDING = 20;
+const DROPDOWN_MIN_HEIGHT = 120;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -37,52 +40,71 @@ interface DropdownProps {
   selectedValue: string;
   onSelect: (value: string) => void;
   width: number;
+  maxHeight: number;
+  left: number;
+  top: number;
+  onDismiss: () => void;
 }
 
-function Dropdown({ items, selectedValue, onSelect, width }: DropdownProps) {
+function Dropdown({ items, selectedValue, onSelect, width, maxHeight, left, top, onDismiss }: DropdownProps) {
   return (
-    <View style={[dropdownStyles.container, { width }]}>
-      {items.map((item, index) => {
-        const isSelected = item.value === selectedValue;
-        const isLast = index === items.length - 1;
+    <Modal transparent visible animationType="none" onRequestClose={onDismiss}>
+      <View style={dropdownStyles.modalRoot}>
+        <Pressable style={dropdownStyles.backdrop} onPress={onDismiss} />
+        <View style={[dropdownStyles.container, { width, maxHeight, left, top }]}>
+          <ScrollView
+            style={dropdownStyles.scroll}
+            nestedScrollEnabled
+            showsVerticalScrollIndicator={items.length > 6}
+            keyboardShouldPersistTaps="handled"
+          >
+            {items.map((item, index) => {
+              const isSelected = item.value === selectedValue;
+              const isLast = index === items.length - 1;
 
-        return (
-          <View key={item.value}>
-            <Pressable
-              onPress={() => onSelect(item.value)}
-              style={({ pressed }) => [
-                dropdownStyles.item,
-                isSelected && dropdownStyles.itemSelected,
-                pressed && dropdownStyles.itemPressed,
-              ]}
-              accessibilityRole="menuitem"
-              accessibilityState={{ selected: isSelected }}
-            >
-              <Text
-                style={[
-                  dropdownStyles.itemLabel,
-                  { color: isSelected ? Colors.brand.text : Colors.brand.textSecondary },
-                ]}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {item.label}
-              </Text>
-            </Pressable>
-            {!isLast && <View style={dropdownStyles.divider} />}
-          </View>
-        );
-      })}
-    </View>
+              return (
+                <View key={item.value}>
+                  <Pressable
+                    onPress={() => onSelect(item.value)}
+                    style={({ pressed }) => [
+                      dropdownStyles.item,
+                      isSelected && dropdownStyles.itemSelected,
+                      pressed && dropdownStyles.itemPressed,
+                    ]}
+                    accessibilityRole="menuitem"
+                    accessibilityState={{ selected: isSelected }}
+                  >
+                    <Text
+                      style={[
+                        dropdownStyles.itemLabel,
+                        { color: isSelected ? Colors.brand.text : Colors.brand.textSecondary },
+                      ]}
+                      numberOfLines={1}
+                      ellipsizeMode="tail"
+                    >
+                      {item.label}
+                    </Text>
+                  </Pressable>
+                  {!isLast && <View style={dropdownStyles.divider} />}
+                </View>
+              );
+            })}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
   );
 }
 
 const dropdownStyles = StyleSheet.create({
+  modalRoot: {
+    flex: 1,
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
   container: {
     position: 'absolute',
-    top: '100%',
-    left: 0,
-    marginTop: 4,
     backgroundColor: Colors.brand.surface,
     borderRadius: 10,
     minWidth: DROPDOWN_MIN_WIDTH,
@@ -93,6 +115,9 @@ const dropdownStyles = StyleSheet.create({
     shadowRadius: 8,
     elevation: 4,
     overflow: 'hidden',
+  },
+  scroll: {
+    flexGrow: 0,
   },
   item: {
     paddingVertical: 12,
@@ -127,7 +152,9 @@ export function FilterChip({
   onPress,
 }: FilterChipProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { width } = useWindowDimensions();
+  const [chipBounds, setChipBounds] = useState({ x: 0, y: 0, width: 0, height: 0 });
+  const wrapperRef = useRef<View>(null);
+  const { width, height } = useWindowDimensions();
 
   const currentItem = items.find((i) => i.value === selectedValue);
   const displayLabel = label ?? currentItem?.label ?? '';
@@ -135,6 +162,15 @@ export function FilterChip({
   const dropdownWidth = Math.min(
     hasLongDropdownItem ? DROPDOWN_MAX_CONTENT_WIDTH : DROPDOWN_MIN_WIDTH,
     Math.max(DROPDOWN_MIN_WIDTH, width - 40),
+  );
+  const dropdownLeft = Math.max(
+    DROPDOWN_SCREEN_PADDING,
+    Math.min(chipBounds.x, width - dropdownWidth - DROPDOWN_SCREEN_PADDING),
+  );
+  const dropdownTop = chipBounds.y + chipBounds.height + 4;
+  const dropdownMaxHeight = Math.max(
+    DROPDOWN_MIN_HEIGHT,
+    Math.min(height * DROPDOWN_MAX_HEIGHT_RATIO, height - dropdownTop - DROPDOWN_SCREEN_PADDING),
   );
 
   const isActive = variant === 'active';
@@ -145,7 +181,14 @@ export function FilterChip({
   function handlePress() {
     if (disabled) return;
     if (isActive && items.length > 0) {
-      setIsOpen((prev) => !prev);
+      if (isOpen) {
+        setIsOpen(false);
+      } else {
+        wrapperRef.current?.measureInWindow((x, y, measuredWidth, measuredHeight) => {
+          setChipBounds({ x, y, width: measuredWidth, height: measuredHeight });
+          setIsOpen(true);
+        });
+      }
     }
     onPress?.();
   }
@@ -156,7 +199,7 @@ export function FilterChip({
   }
 
   return (
-    <View style={chipStyles.wrapper}>
+    <View ref={wrapperRef} style={chipStyles.wrapper}>
       <Pressable
         onPress={handlePress}
         style={({ pressed }) => [
@@ -191,6 +234,10 @@ export function FilterChip({
           selectedValue={selectedValue ?? ''}
           onSelect={handleSelect}
           width={dropdownWidth}
+          maxHeight={dropdownMaxHeight}
+          left={dropdownLeft}
+          top={dropdownTop}
+          onDismiss={() => setIsOpen(false)}
         />
       )}
     </View>

--- a/components/ui/filter-chip.tsx
+++ b/components/ui/filter-chip.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { Modal, Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors, Typography } from '@/constants/theme';
 
@@ -153,7 +154,8 @@ export function FilterChip({
 }: FilterChipProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [chipBounds, setChipBounds] = useState({ x: 0, y: 0, width: 0, height: 0 });
-  const wrapperRef = useRef<View>(null);
+  const chipRef = useRef<View>(null);
+  const insets = useSafeAreaInsets();
   const { width, height } = useWindowDimensions();
 
   const currentItem = items.find((i) => i.value === selectedValue);
@@ -167,7 +169,7 @@ export function FilterChip({
     DROPDOWN_SCREEN_PADDING,
     Math.min(chipBounds.x, width - dropdownWidth - DROPDOWN_SCREEN_PADDING),
   );
-  const dropdownTop = chipBounds.y + chipBounds.height + 4;
+  const dropdownTop = chipBounds.y + chipBounds.height + insets.top + 4;
   const dropdownMaxHeight = Math.max(
     DROPDOWN_MIN_HEIGHT,
     Math.min(height * DROPDOWN_MAX_HEIGHT_RATIO, height - dropdownTop - DROPDOWN_SCREEN_PADDING),
@@ -184,7 +186,7 @@ export function FilterChip({
       if (isOpen) {
         setIsOpen(false);
       } else {
-        wrapperRef.current?.measureInWindow((x, y, measuredWidth, measuredHeight) => {
+        chipRef.current?.measureInWindow((x, y, measuredWidth, measuredHeight) => {
           setChipBounds({ x, y, width: measuredWidth, height: measuredHeight });
           setIsOpen(true);
         });
@@ -199,8 +201,9 @@ export function FilterChip({
   }
 
   return (
-    <View ref={wrapperRef} style={chipStyles.wrapper}>
+    <View style={chipStyles.wrapper}>
       <Pressable
+        ref={chipRef}
         onPress={handlePress}
         style={({ pressed }) => [
           chipStyles.chip,


### PR DESCRIPTION
Closes #59

## 개요
저장 링크 전체보기 화면의 폴더 필터 드롭다운에서 긴 폴더명이 좁은 폭 안에서 과도하게 잘리거나, 선택된 필터칩에서 주변 UI를 밀어낼 수 있는 문제를 개선했습니다.

기존 드롭다운은 `전체` 필터칩의 폭을 기준으로 표시되면서 긴 폴더명이 6글자 내외로만 보일 수 있었습니다. 이 경우 폴더명의 앞부분이 같은 항목들이 있을 때 사용자가 폴더를 구분하기 어려웠습니다.

이번 작업에서는 드롭다운 항목 텍스트에 한 줄 말줄임 처리를 적용하고, 긴 폴더명이 하나라도 있는 경우 드롭다운 폭을 최대 15글자 정도까지 확장하도록 조정했습니다. 동시에 작은 화면에서는 화면 폭을 기준으로 드롭다운 폭을 제한해 화면 밖으로 과도하게 벗어나지 않도록 처리했습니다.

선택된 필터칩 라벨도 한 줄 말줄임 처리와 flex 제약을 적용해, 긴 폴더명을 선택해도 북마크 필터칩이나 주변 UI를 밀어내지 않도록 보완했습니다.

추가로 Android 에뮬레이터에서 확인하던 중 폴더 개수가 많아지면 드롭다운 하단 항목이 화면 밖으로 밀려 보이지 않는 문제가 확인되었습니다. 이 부분은 최초 이슈 범위에는 없었지만, 같은 폴더 드롭다운 사용성 문제라 함께 보완했습니다. 드롭다운을 화면 기준 레이어에 띄우고, 목록이 길어지는 경우 내부 스크롤을 통해 아래 항목까지 확인할 수 있도록 수정했습니다.

또한 `Modal` 기반 드롭다운으로 변경한 뒤 safe area 좌표 차이로 인해 드롭다운이 필터칩을 가리는 문제가 있어, 상단 safe area 값을 반영해 기존처럼 필터칩 아래에 표시되도록 위치를 보정했습니다.

## 주요 구현 내용
- 폴더 필터 드롭다운 항목 텍스트에 `numberOfLines={1}` 적용
- 폴더 필터 드롭다운 항목 텍스트에 `ellipsizeMode="tail"` 적용
- 긴 폴더명이 있는 경우 드롭다운 폭을 최대 15글자 분량까지 확장
- 작은 화면에서는 드롭다운 폭이 화면 영역을 넘지 않도록 제한
- 선택된 필터칩 라벨을 한 줄 말줄임 처리
- 필터칩 wrapper, chip, label에 `flexShrink`, `minWidth: 0`, `maxWidth` 제약 적용
- 긴 폴더명을 선택해도 북마크 필터칩이 밀리지 않도록 처리
- 폴더 개수가 많을 때 드롭다운 목록을 스크롤할 수 있도록 처리
- Android에서 스크롤 제스처가 정상 동작하도록 드롭다운을 `Modal` 레이어 기반으로 렌더링
- `Modal` 기반 드롭다운 위치 계산 시 safe area top inset 반영
- 드롭다운 외부 영역 터치 시 목록이 닫히도록 처리

## 파일별 역할
- `components/ui/filter-chip.tsx`: 필터칩 라벨 및 드롭다운 항목의 말줄임 처리, 긴 폴더명 기준 드롭다운 폭 계산, 긴 목록 스크롤, Modal 기반 드롭다운 렌더링 및 safe area 위치 보정 추가

## 해결한 이슈 목록
- [x] 저장 링크 전체보기 화면의 폴더 필터 드롭다운 구조 확인
- [x] 긴 폴더명이 드롭다운에서 좁게 잘리는 문제 확인
- [x] 드롭다운 항목 텍스트에 `numberOfLines={1}` 적용
- [x] 드롭다운 항목 텍스트에 `ellipsizeMode="tail"` 적용
- [x] 긴 폴더명이 있는 경우 드롭다운 폭을 최대 15글자 분량까지 확장
- [x] 화면 크기에 따라 드롭다운 폭이 과도하게 벗어나지 않도록 제한
- [x] 선택된 폴더명이 표시되는 필터칩 라벨도 한 줄 말줄임 처리
- [x] 긴 폴더명을 선택해도 필터칩과 북마크 버튼 레이아웃이 깨지지 않도록 보완
- [x] 폴더 개수가 많을 때 드롭다운 하단 항목이 보이지 않는 문제 확인
- [x] 폴더 개수가 많은 경우 드롭다운 내부 스크롤로 아래 항목을 확인할 수 있도록 보완
- [x] `Modal` 기반 드롭다운이 필터칩 영역을 가리는 문제 보정
- [x] Android 에뮬레이터에서 긴 폴더명 표시 확인
- [x] Android 에뮬레이터에서 긴 폴더 목록 스크롤 동작 확인
- [ ] 실제 휴대폰 preview 빌드에서 긴 폴더명 표시 확인

## 체크 사항
- [x] 이번 이슈 범위인 긴 폴더명으로 인한 레이아웃 깨짐을 수정
- [x] 폴더명 최대 길이 정책이나 입력 제한은 변경하지 않음
- [x] 폴더 목록이 많아지는 경우에도 드롭다운에서 아래 항목을 확인할 수 있도록 보완

## 참고사항
- 드롭다운 폭은 긴 항목이 있을 때만 확장됩니다.
- 짧은 폴더명만 있는 경우 기존처럼 최소 폭 기준으로 표시됩니다.
- 폴더 개수가 많을 때는 드롭다운 내부 스크롤로 아래 항목을 확인할 수 있습니다.
- 긴 목록 스크롤 보완은 최초 이슈 설명에는 없었지만, Android 에뮬레이터 테스트 중 같은 드롭다운 사용성 문제로 확인되어 함께 처리했습니다.
- `Modal` 기반 드롭다운은 safe area top inset을 반영해 기존처럼 필터칩 아래에 표시되도록 보정했습니다.
- 실제 휴대폰 preview 빌드에서의 최종 화면 확인은 추가 확인이 필요합니다.

## Screenshots or Video
- 전체로 설정되어있고, 토글을 누른 화면입니다. 
- 긴 폴더명이 있어 이렇게 최대 15글자까지 확장된 모습입니다.
<img width="499" height="1018" alt="image" src="https://github.com/user-attachments/assets/fdddc68d-5418-479f-b8d7-1a09aeb53eb2" />

- 긴 폴더명에 들어간 화면입니다
<img width="498" height="1018" alt="image" src="https://github.com/user-attachments/assets/b1a4e35e-abdb-426d-8cc6-ef3a2e50bf6e" />


- 긴 폴더명이 없는 경우 화면입니다
<img width="496" height="1017" alt="image" src="https://github.com/user-attachments/assets/e0e1b1c6-9bc4-4bd4-afa1-aab9937277ca" />

- 폴더가 여러개인 경우 화면입니다. 스크롤이 추가되어, 아래에 있는 폴더도 선택할 수 있습니다.
<img width="507" height="1017" alt="image" src="https://github.com/user-attachments/assets/aee8d512-0141-4071-9111-3a152d920adf" />


- 현재 PR에 수정하진 않았지만, 참고삼아 실제 폴더에서는 어떻게 보이는지 캡쳐 첨부합니다.
<img width="503" height="1015" alt="image" src="https://github.com/user-attachments/assets/fbdb06e1-97cc-4244-93bb-c7f6c881db05" />
<img width="498" height="1021" alt="image" src="https://github.com/user-attachments/assets/69883979-e45d-49d2-b922-b858db304d54" />
