### PR TITLE
[FIX] 검사 중 뒤로가기 및 하단 탭 이동 방지

### DIFF
--- a/app/(tabs)/(home)/scanning.tsx
+++ b/app/(tabs)/(home)/scanning.tsx
@@ -2,11 +2,12 @@ import { useAuth } from '@clerk/expo';
 import LottieView from 'lottie-react-native';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { BackHandler, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { fetchAnalysis, requestAnalysis, type AnalysisResponse, type AnalysisVerdict } from '@/api/analyses';
 import { ApiError } from '@/api/api-client';
 import { Colors, Typography } from '@/constants/theme';
+import { AppIcon } from '@/components/ui/app-icon';
 
 const POLLING_INTERVAL_MS = 2_000;
 const MAX_POLLING_MS = 30_000;
@@ -88,6 +89,19 @@ export default function ScanningScreen() {
   }, [isLoaded, isSignedIn, retryKey, url]);
 
   const hasError = errorMessage.length > 0;
+  const isScanning = !hasError;
+
+  useEffect(() => {
+    if (!isScanning) {
+      return undefined;
+    }
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => true);
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isScanning]);
 
   return (
     <>
@@ -100,6 +114,17 @@ export default function ScanningScreen() {
           headerTitleStyle: { ...Typography.title, color: Colors.brand.text },
           headerTintColor: Colors.brand.text,
           headerShadowVisible: false,
+          headerBackVisible: !isScanning,
+          gestureEnabled: !isScanning,
+          headerLeft: isScanning
+            ? () => (
+                <AppIcon
+                  name="back"
+                  disabled
+                  style={styles.headerBackButton}
+                />
+              )
+            : undefined,
         }}
       />
       <View style={styles.container}>
@@ -297,6 +322,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 24,
     paddingTop: 40,
+  },
+  headerBackButton: {
+    width: 44,
+    height: 44,
   },
   animationWrapper: {
     width: 280,

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -20,12 +20,36 @@ const TAB_TO_HREF: Partial<Record<TabVariant, string>> = {
   folder: '/(tabs)/(folder)',
 };
 
+type NestedRoute = {
+  name?: string;
+  state?: {
+    index?: number;
+    routes?: NestedRoute[];
+  };
+};
+
+function getActiveNestedRouteName(route?: NestedRoute): string | undefined {
+  const nestedState = route?.state;
+
+  if (!nestedState?.routes?.length) {
+    return route?.name;
+  }
+
+  const nestedIndex = nestedState.index ?? 0;
+  return getActiveNestedRouteName(nestedState.routes[nestedIndex]);
+}
+
 function CustomTabBar({ state }: BottomTabBarProps) {
   const activeRoute = state.routes[state.index];
   const activeRouteName = activeRoute?.name ?? '(home)';
   const activeTab = ROUTE_TO_TAB[activeRouteName] ?? 'home';
+  const isScanningRoute = getActiveNestedRouteName(activeRoute as NestedRoute) === 'scanning';
 
   function handleTabPress(tab: TabVariant) {
+    if (isScanningRoute) {
+      return;
+    }
+
     const href = TAB_TO_HREF[tab];
     if (href) {
       router.navigate(href as any);
@@ -36,6 +60,9 @@ function CustomTabBar({ state }: BottomTabBarProps) {
     <BottomTabBar
       activeTab={activeTab}
       onTabPress={handleTabPress}
+      home={{ disabled: isScanningRoute }}
+      addLink={{ disabled: isScanningRoute }}
+      folder={{ disabled: isScanningRoute }}
     />
   );
 }


### PR DESCRIPTION
Closes #68

## 개요
링크 검사 중 화면에서 사용자가 상단 뒤로가기, Android 시스템 뒤로가기, 하단 탭바 이동으로 검사 화면을 벗어나지 못하도록 처리했습니다.

기존 `app/(tabs)/(home)/scanning.tsx`는 하단 탭 구조 안의 홈 스택 화면으로 열리기 때문에, 검사 polling이 진행 중이어도 헤더 뒤로가기나 Android 시스템 뒤로가기, 하단 탭바 버튼을 통해 다른 화면으로 이동할 수 있었습니다.

이번 작업에서는 검사 애니메이션이 표시되는 진행 중 상태를 `!hasError` 기준으로 정리하고, 해당 상태에서는 화면 이탈 경로를 모두 차단했습니다. 상단 뒤로가기 버튼은 숨기지 않고 기존 `AppIcon`의 disabled 상태를 사용해 비활성 아이콘으로 표시되도록 했습니다.

애뮬레이터에서 확인해본 결과 시스템 뒤로가기, 헤더 뒤로가기, 하단 탭바 모두 비활성화 되어 뒤로가지 않는 것을 확인하였습니다.

## 주요 구현 내용
- 검사 진행 중 상태를 `!hasError` 기준으로 정리
- 검사 중 상단 헤더 뒤로가기 버튼을 disabled 상태로 표시
- 검사 중 iOS swipe back 제스처 비활성화
- 검사 중 Android 시스템 뒤로가기 버튼 차단
- 현재 nested route가 `scanning`인지 판별하는 helper 추가
- 검사 중 하단 탭 press 무시 처리
- `BottomTabBar`의 기존 `disabled` prop으로 `홈`, `링크 추가`, `폴더` 탭 비활성화
- 검사 실패 또는 timeout 이후 `다시 검사`, `돌아가기` 버튼 흐름 유지

## 파일별 역할
- `app/(tabs)/(home)/scanning.tsx`: 검사 진행 중 헤더 뒤로가기 disabled 표시, iOS gesture 차단, Android BackHandler 차단 처리
- `app/(tabs)/_layout.tsx`: nested route state를 확인해 `scanning` 화면 여부를 판단하고 하단 탭 이동 및 입력 비활성화 처리

## 해결한 이슈 목록
- [x] `app/(tabs)/(home)/scanning.tsx`의 현재 Stack header 뒤로가기 동작 확인
- [x] 검사 중 상태에서 상단 헤더의 뒤로가기 버튼이 눌리지 않도록 처리
- [x] 상단 뒤로가기 버튼을 숨기지 않고 disabled 상태로 표시
- [x] Android 물리/시스템 뒤로가기 버튼을 검사 중에는 차단
- [x] iOS swipe back 제스처를 검사 중에는 차단
- [x] 검사 중 화면에서 하단 탭바 버튼을 눌러도 다른 탭으로 이동하지 않도록 처리
- [x] 하단 탭바의 `홈`, `링크 추가`, `폴더` 버튼을 검사 중에는 비활성화
- [x] 현재 nested route가 `scanning`인지 확인할 수 있도록 처리
- [x] `BottomTabBar`와 `BottomTabItem`의 기존 `disabled` prop을 활용해 탭 이동 차단
- [x] 검사 중이 아닐 때는 기존 하단 탭바 이동 정책 유지
- [x] 검사 timeout 또는 에러 상태에서 `다시 검사`, `돌아가기` 버튼 동작 정책 유지
- [x] 검사 결과 화면으로 이동한 뒤에는 기존 뒤로가기/탭 이동 정책 유지
- [x] Android 에뮬레이터에서 하단 탭바 이동 차단 확인
- [ ] Android 실제 휴대폰에서 시스템 뒤로가기 버튼 차단 확인


## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 polling, timeout, error 상태 전환 로직은 유지
- [x] 결과 화면 이동은 기존 `router.replace()` 흐름 유지

## 참고사항
- 검사 진행 중 상태는 현재 화면의 error 여부를 기준으로 판단합니다.
- timeout 또는 에러 발생 후에는 화면 내부 버튼으로 재검사 또는 돌아가기를 선택할 수 있습니다.
- 하단 탭바는 nested route가 `scanning`일 때만 비활성화되며, 결과 화면에서는 기존 탭 이동 정책을 유지합니다.

## Screenshots or Video
- 검사로직이 돌아갈 때 화면입니다
<img width="504" height="1025" alt="image" src="https://github.com/user-attachments/assets/133e2495-42bc-4525-96d5-e3d6eda6c6dd" />
