### PR TITLE
[FIX] 검사 결과 화면 렌더링 시 한글 깨짐 현상 수정

### DIFF
--- a/app/(tabs)/(home)/scan-result-block.tsx
+++ b/app/(tabs)/(home)/scan-result-block.tsx
@@ -47,7 +47,7 @@ export default function ScanResultBlockScreen() {
         <Stack.Screen
           options={{
             headerShown: true,
-            title: '寃??寃곌낵',
+            title: '검사 결과',
             headerBackTitle: '',
             headerStyle: { backgroundColor: Colors.brand.background },
             headerTitleStyle: { ...Typography.title, color: Colors.brand.text },
@@ -56,7 +56,7 @@ export default function ScanResultBlockScreen() {
           }}
         />
         <View style={styles.loadingContainer}>
-          <Text style={styles.statusText}>遺꾩꽍 寃곌낵瑜?遺덈윭?ㅻ뒗 以묒엯?덈떎.</Text>
+          <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>
         </View>
       </>
     );

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -100,7 +100,7 @@ export default function ScanResultCautionScreen() {
         <Stack.Screen
           options={{
             headerShown: true,
-            title: '寃??寃곌낵',
+            title: '검사 결과',
             headerBackTitle: '',
             headerStyle: { backgroundColor: Colors.brand.background },
             headerTitleStyle: { ...Typography.title, color: Colors.brand.text },
@@ -109,7 +109,7 @@ export default function ScanResultCautionScreen() {
           }}
         />
         <View style={styles.loadingContainer}>
-          <Text style={styles.statusText}>遺꾩꽍 寃곌낵瑜?遺덈윭?ㅻ뒗 以묒엯?덈떎.</Text>
+          <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>
         </View>
       </>
     );

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -100,7 +100,7 @@ export default function ScanResultScreen() {
         <Stack.Screen
           options={{
             headerShown: true,
-            title: '寃??寃곌낵',
+            title: '검사 결과',
             headerBackTitle: '',
             headerStyle: { backgroundColor: Colors.brand.background },
             headerTitleStyle: { ...Typography.title, color: Colors.brand.text },
@@ -109,7 +109,7 @@ export default function ScanResultScreen() {
           }}
         />
         <View style={styles.loadingContainer}>
-          <Text style={styles.statusText}>遺꾩꽍 寃곌낵瑜?遺덈윭?ㅻ뒗 以묒엯?덈떎.</Text>
+          <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>
         </View>
       </>
     );


### PR DESCRIPTION
Closes #62

## 개요
검사 결과 화면 진입 직후 약 0.5초 동안 한글 텍스트가 깨져 보이는 문제를 수정했습니다.

기존에는 검사 완료 후 `scanning.tsx`에서 결과 화면으로 `router.replace()` 된 뒤, 결과 화면이 `analysisId`를 기준으로 상세 분석 결과를 다시 불러오는 동안 임시 로딩 화면이 먼저 렌더링되었습니다. 이 로딩 분기에 들어있는 헤더 제목과 안내 문구가 이미 깨진 문자열로 작성되어 있어, API 응답이 도착하기 전까지 잠깐 깨진 한글이 화면에 표시되었습니다.

이번 작업에서는 검사 결과 화면 3종의 초기 로딩 분기에 들어있던 깨진 문자열을 정상 한글 문구로 교체했습니다. 결과 데이터 로딩, verdict 재확인, 결과 화면 전환, 저장/접속 버튼 동작 흐름은 변경하지 않았습니다.

## 주요 구현 내용
- 안전 결과 화면 초기 로딩 문구 한글 깨짐 수정
- 주의 결과 화면 초기 로딩 문구 한글 깨짐 수정
- 위험 결과 화면 초기 로딩 문구 한글 깨짐 수정
- 결과 화면 로딩 상태의 헤더 제목을 `검사 결과`로 교체
- 결과 화면 로딩 안내 문구를 `분석 결과를 불러오는 중입니다.`로 교체
- 기존 `useAnalysisResult` 데이터 로딩 흐름 유지
- 기존 `router.replace()` 결과 화면 이동 흐름 유지

## 파일별 역할
- `app/(tabs)/(home)/scan-result.tsx`: 안전 결과 화면의 초기 로딩 헤더/문구 한글 깨짐 수정
- `app/(tabs)/(home)/scan-result-caution.tsx`: 주의 결과 화면의 초기 로딩 헤더/문구 한글 깨짐 수정
- `app/(tabs)/(home)/scan-result-block.tsx`: 위험 결과 화면의 초기 로딩 헤더/문구 한글 깨짐 수정

## 해결한 이슈 목록
- [x] 한글이 깨지는 화면이 검사 결과 화면인지 확인
- [x] 검사 로직 실행 이후 결과 화면 렌더링 시점에 문제가 발생하는지 확인
- [x] 안전 결과 화면 `scan-result.tsx`의 초기 로딩 분기 확인
- [x] 주의 결과 화면 `scan-result-caution.tsx`의 초기 로딩 분기 확인
- [x] 위험 결과 화면 `scan-result-block.tsx`의 초기 로딩 분기 확인
- [x] `scanning.tsx`에서 검사 완료 후 결과 화면으로 이동하는 `router.replace()` 흐름 확인
- [x] 결과 화면 진입 직후 `useAnalysisResult` 로딩 중 임시 화면이 렌더링되는 흐름 확인
- [x] 깨진 한글이 폰트 렌더링 문제가 아니라 로딩 분기 문자열 자체 문제임을 확인
- [x] 결과 화면 로딩 헤더 제목을 정상 한글로 교체
- [x] 결과 화면 로딩 안내 문구를 정상 한글로 교체
- [x] 결과 화면의 기존 상세 분석 조회 흐름 유지
- [x] 결과 화면의 기존 저장/접속/확인 버튼 흐름 유지
- [x] Android 에뮬레이터에서 검사 결과 화면 한글 깨짐이 재현되지 않는지 확인
- [ ] 실제 휴대폰 preview 빌드에서 검사 결과 화면 한글 깨짐이 재현되지 않는지 확인

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 검사 결과 화면 3종 모두 동일하게 수정
- [x] 기존 API 호출 및 분석 결과 조회 흐름 변경 없음
- [x] 기존 결과 화면 라우팅 정책 변경 없음

## 참고사항
- 문제의 원인은 결과 화면 첫 렌더링 시 표시되는 로딩 분기에 깨진 문자열이 남아 있던 것입니다.
- API 응답 후 정상 결과 UI가 렌더링되면서 깨진 문구가 사라졌기 때문에, 사용자에게는 약 0.5초 정도만 한글이 깨지는 것처럼 보였습니다.
- 이번 PR에서는 원인이 확인된 로딩 분기의 깨진 문자열만 수정했습니다.
- 폰트 로딩, Typography, 네비게이션 중복 push 방지 로직은 변경하지 않았습니다.

## Screenshots or Video
- 수정 전 화면
<img width="477" height="766" alt="검사결과 화면뜰 때 한글 깨짐" src="https://github.com/user-attachments/assets/45217f48-dc4f-4677-becb-5f665d0368c7" />

-수정 후 화면
<img width="501" height="1015" alt="한글깨지는 화면 수정 " src="https://github.com/user-attachments/assets/2ab4263e-2948-4125-8bca-43888b2bdebb" />

