### PR TITLE
[FIX] 링크 검사 polling 20초 초과 시 강제 중단 처리

### DIFF
--- a/app/(tabs)/(home)/scanning.tsx
+++ b/app/(tabs)/(home)/scanning.tsx
@@ -31,6 +31,7 @@ export default function ScanningScreen() {
   const [retryKey, setRetryKey] = useState(0);
   const getTokenRef = useRef(getToken);
   const currentAbortControllerRef = useRef<AbortController | null>(null);
+  const hasNavigatedRef = useRef(false);
   const isShortScreen = windowHeight <= SHORT_SCREEN_HEIGHT;
   const isVeryShortScreen = windowHeight <= VERY_SHORT_SCREEN_HEIGHT;
   const animationSize = isVeryShortScreen
@@ -68,6 +69,7 @@ export default function ScanningScreen() {
     };
 
     currentAbortControllerRef.current = abortController;
+    hasNavigatedRef.current = false;
 
     if (!isLoaded) {
       return () => {
@@ -111,6 +113,7 @@ export default function ScanningScreen() {
       canNavigate: () => isActive && !didTimeout && !hasNavigated,
       onNavigate: () => {
         hasNavigated = true;
+        hasNavigatedRef.current = true;
         clearScreenTimeout();
       },
     })
@@ -151,6 +154,10 @@ export default function ScanningScreen() {
     }
 
     const animationTimeoutId = setTimeout(() => {
+      if (hasNavigatedRef.current) {
+        return;
+      }
+
       currentAbortControllerRef.current?.abort();
       setErrorMessage(getAnalysisErrorMessage(new Error('TIMEOUT')));
     }, SCAN_SCREEN_TIMEOUT_MS);

--- a/app/(tabs)/(home)/scanning.tsx
+++ b/app/(tabs)/(home)/scanning.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@clerk/expo';
 import LottieView from 'lottie-react-native';
+import { useIsFocused } from '@react-navigation/native';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -9,15 +10,17 @@ import { ApiError } from '@/api/api-client';
 import { Colors, Typography } from '@/constants/theme';
 
 const POLLING_INTERVAL_MS = 2_000;
-const MAX_POLLING_MS = 30_000;
+const SCAN_SCREEN_TIMEOUT_MS = 20_000;
 
 export default function ScanningScreen() {
   const { getToken, isLoaded, isSignedIn } = useAuth();
+  const isFocused = useIsFocused();
   const { url: urlParam } = useLocalSearchParams<{ url?: string | string[] }>();
   const url = getUrlParam(urlParam);
   const [errorMessage, setErrorMessage] = useState('');
   const [retryKey, setRetryKey] = useState(0);
   const getTokenRef = useRef(getToken);
+  const currentAbortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     getTokenRef.current = getToken;
@@ -25,44 +28,77 @@ export default function ScanningScreen() {
 
   useEffect(() => {
     const abortController = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let timedOut = false;
+    let screenTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    let isActive = true;
+    let didTimeout = false;
+    let hasNavigated = false;
+
+    const clearScreenTimeout = () => {
+      if (screenTimeoutId) {
+        clearTimeout(screenTimeoutId);
+        screenTimeoutId = null;
+      }
+    };
+
+    const handleScreenTimeout = () => {
+      if (!isActive || didTimeout || hasNavigated) {
+        return;
+      }
+
+      didTimeout = true;
+      abortController.abort();
+      setErrorMessage(getAnalysisErrorMessage(new Error('TIMEOUT')));
+    };
+
+    currentAbortControllerRef.current = abortController;
 
     if (!isLoaded) {
-      return () => abortController.abort();
+      return () => {
+        isActive = false;
+        if (currentAbortControllerRef.current === abortController) {
+          currentAbortControllerRef.current = null;
+        }
+        abortController.abort();
+      };
     }
 
     if (!isSignedIn) {
       setErrorMessage('로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.');
-      return () => abortController.abort();
+      return () => {
+        isActive = false;
+        if (currentAbortControllerRef.current === abortController) {
+          currentAbortControllerRef.current = null;
+        }
+        abortController.abort();
+      };
     }
 
     if (!url) {
       setErrorMessage('검사할 URL을 찾을 수 없습니다. 링크를 다시 입력해주세요.');
-      return () => abortController.abort();
+      return () => {
+        isActive = false;
+        if (currentAbortControllerRef.current === abortController) {
+          currentAbortControllerRef.current = null;
+        }
+        abortController.abort();
+      };
     }
 
     setErrorMessage('');
+    screenTimeoutId = setTimeout(handleScreenTimeout, SCAN_SCREEN_TIMEOUT_MS);
 
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => {
-        timedOut = true;
-        abortController.abort();
-        reject(new Error('TIMEOUT'));
-      }, MAX_POLLING_MS);
-    });
-
-    Promise.race([
-      runAnalysisPolling({
-        getToken: () => getTokenRef.current(),
-        url,
-        signal: abortController.signal,
-      }),
-      timeoutPromise,
-    ])
+    runAnalysisPolling({
+      getToken: () => getTokenRef.current(),
+      url,
+      signal: abortController.signal,
+      canNavigate: () => isActive && !didTimeout && !hasNavigated,
+      onNavigate: () => {
+        hasNavigated = true;
+        clearScreenTimeout();
+      },
+    })
       .catch((error) => {
-        if (timedOut) {
-          setErrorMessage(getAnalysisErrorMessage(new Error('TIMEOUT')));
+        if (!isActive || hasNavigated || didTimeout) {
           return;
         }
 
@@ -73,21 +109,34 @@ export default function ScanningScreen() {
         setErrorMessage(getAnalysisErrorMessage(error));
       })
       .finally(() => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
+        clearScreenTimeout();
       });
 
     return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
+      isActive = false;
+      clearScreenTimeout();
+      if (currentAbortControllerRef.current === abortController) {
+        currentAbortControllerRef.current = null;
       }
-
       abortController.abort();
     };
   }, [isLoaded, isSignedIn, retryKey, url]);
 
   const hasError = errorMessage.length > 0;
+  const isScanningAnimationVisible = isFocused && !hasError;
+
+  useEffect(() => {
+    if (!isScanningAnimationVisible) {
+      return undefined;
+    }
+
+    const animationTimeoutId = setTimeout(() => {
+      currentAbortControllerRef.current?.abort();
+      setErrorMessage(getAnalysisErrorMessage(new Error('TIMEOUT')));
+    }, SCAN_SCREEN_TIMEOUT_MS);
+
+    return () => clearTimeout(animationTimeoutId);
+  }, [isScanningAnimationVisible, retryKey, url]);
 
   return (
     <>
@@ -107,8 +156,8 @@ export default function ScanningScreen() {
         <View style={styles.animationWrapper}>
           <LottieView
             source={require('@/assets/animations/scanning.json')}
-            autoPlay={!hasError}
-            loop={!hasError}
+            autoPlay={isScanningAnimationVisible}
+            loop={isScanningAnimationVisible}
             style={styles.animation}
           />
           <View style={styles.dotsOverlay}>
@@ -161,16 +210,20 @@ async function runAnalysisPolling({
   getToken,
   url,
   signal,
+  canNavigate,
+  onNavigate,
 }: {
   getToken: () => Promise<string | null>;
   url: string;
   signal: AbortSignal;
+  canNavigate: () => boolean;
+  onNavigate: () => void;
 }) {
-  const deadline = Date.now() + MAX_POLLING_MS;
+  const deadline = Date.now() + SCAN_SCREEN_TIMEOUT_MS;
   let analysis = await requestAnalysis(getToken, url, { signal });
 
   while (!signal.aborted) {
-    const handled = handleAnalysisResult(analysis, url, signal);
+    const handled = handleAnalysisResult(analysis, url, signal, canNavigate, onNavigate);
 
     if (handled) {
       return;
@@ -187,7 +240,13 @@ async function runAnalysisPolling({
   }
 }
 
-function handleAnalysisResult(analysis: AnalysisResponse, fallbackUrl: string, signal: AbortSignal) {
+function handleAnalysisResult(
+  analysis: AnalysisResponse,
+  fallbackUrl: string,
+  signal: AbortSignal,
+  canNavigate: () => boolean,
+  onNavigate: () => void,
+) {
   if (analysis.status === 'queued') {
     return false;
   }
@@ -200,7 +259,8 @@ function handleAnalysisResult(analysis: AnalysisResponse, fallbackUrl: string, s
     throw new Error('MISSING_VERDICT');
   }
 
-  if (!signal.aborted) {
+  if (!signal.aborted && canNavigate()) {
+    onNavigate();
     router.replace({
       pathname: getResultPath(analysis.verdict),
       params: {


### PR DESCRIPTION
Closes #67

## 개요
링크 검사 중 화면의 최대 대기 시간을 20초로 조정하고, 20초를 초과하면 재검사 가능한 상태로 전환되도록 timeout 처리를 강화했습니다.

기존 `app/(tabs)/(home)/scanning.tsx`에는 `MAX_POLLING_MS = 30_000` 기준의 polling 제한이 있었지만, 실제 휴대폰 테스트 중 검사 결과 화면을 여러 번 거치고 뒤로가기를 반복하는 상황에서 `보안 검사 중입니다` 애니메이션이 무한히 도는 문제가 발생했습니다.

이 문제는 단순히 polling 요청 시작 시점 기준 timeout만으로는 충분히 막기 어려웠습니다. 중복 검사나 뒤로가기 흐름으로 오래된 `scanning` 화면이 다시 보이는 경우, 사용자 입장에서는 애니메이션이 계속 도는 화면을 보고 있지만 기존 polling timeout 관리 흐름은 이미 정리되었거나 기대한 run과 분리될 수 있기 때문입니다.

따라서 이번 작업에서는 기준을 이중화했습니다.

1. polling/request 기준 20초 timeout  
   분석 요청과 polling loop 자체가 20초를 넘지 않도록 제한합니다.

2. 화면/애니메이션 기준 20초 watchdog  
   화면이 focus되어 있고 Lottie 애니메이션이 도는 상태가 되면, polling 상태와 관계없이 20초 후 반드시 timeout 상태로 전환합니다.

이를 통해 API 요청, polling, 네비게이션 상태가 꼬이더라도 사용자가 검사 중 애니메이션 화면에서 20초 이상 무한 대기하지 않도록 보완했습니다.

## 주요 구현 내용
- 기존 `MAX_POLLING_MS = 30_000` 제거
- 검사 화면 timeout 정책 상수 `SCAN_SCREEN_TIMEOUT_MS = 20_000` 추가
- polling 내부 deadline을 20초 기준으로 변경
- 검사 화면 단위 20초 timeout 추가
- 화면 focus 여부를 기준으로 애니메이션 표시 상태 감지
- Lottie 애니메이션이 보이는 상태 기준 20초 watchdog 추가
- timeout 발생 시 현재 진행 중인 요청을 `AbortController.abort()`로 정리
- timeout 발생 시 error 상태로 전환해 Lottie 애니메이션 중단
- timeout 후 `검사를 완료하지 못했어요`, `다시 검사`, `돌아가기` 표시
- timeout 이후 늦게 도착한 polling 결과가 결과 화면으로 이동시키지 않도록 guard 추가
- 정상 결과 화면 이동 시 timeout이 뒤늦게 error 상태를 만들지 않도록 guard 추가
- retry/unmount 시 기존 timeout과 abort controller 정리

## 파일별 역할
- `app/(tabs)/(home)/scanning.tsx`: polling timeout, 화면 단위 timeout, 애니메이션 visible watchdog, abort/cleanup, 늦은 결과 이동 방어 처리

## 해결한 이슈 목록
- [x] `app/(tabs)/(home)/scanning.tsx`의 현재 polling 흐름 확인
- [x] 기존 `MAX_POLLING_MS = 30_000` 기준 제거
- [x] polling 최대 대기 시간과 검사 중 화면 체류 시간을 `20_000ms` 기준으로 통일
- [x] 20초 제한 값을 `SCAN_SCREEN_TIMEOUT_MS` 상수로 분리
- [x] 분석 요청 `POST /api/v1/analyses`가 지연되는 경우에도 20초 후 timeout 처리
- [x] 분석 조회 `GET /api/v1/analyses/{analysisId}` polling이 지연되는 경우에도 20초 후 timeout 처리
- [x] polling 내부 deadline뿐 아니라 화면 단위 timeout 추가
- [x] 애니메이션이 도는 화면 기준의 20초 watchdog 추가
- [x] timeout 발생 시 `AbortController.abort()`로 진행 중인 요청 정리
- [x] timeout 발생 후 Lottie 애니메이션이 계속 재생되지 않도록 error 상태 전환
- [x] timeout 발생 후 `검사를 완료하지 못했어요` 문구와 `다시 검사` 버튼 표시
- [x] timeout 발생 후 뒤늦게 도착한 API 응답이 결과 화면으로 이동시키지 않도록 방어
- [x] 결과 화면으로 이미 정상 이동한 경우 timeout 에러 상태가 뒤늦게 반영되지 않도록 방어
- [x] `다시 검사` 버튼을 누르면 기존 URL로 새 검사가 재시작되도록 기존 retry 흐름 유지
- [x] 재검사 시 이전 timeout, 이전 abort controller, 이전 polling 요청이 남아 상태를 바꾸지 않도록 cleanup 처리
- [x] 컴포넌트 unmount 시 timeout과 polling timer 정리
- [x] Android 에뮬레이터에서 정상 결과 이동 및 20초 timeout 동작 확인
- [ ] Android 실제 휴대폰에서 검사 중 화면이 20초 이상 무한 반복되지 않는지 확인


## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 정상 결과 화면 이동 흐름 유지
- [x] 기존 timeout/error 문구 및 재검사 UI 흐름 유지
- [x] polling 기준 timeout과 애니메이션 기준 watchdog을 함께 적용
- [x] timeout 이후 늦은 응답으로 인한 결과 화면 이동 방지

## 참고사항
- 기준을 이중화한 이유는 polling timeout만으로는 오래된 `scanning` 화면이 다시 보이는 상황을 완전히 방어하기 어렵기 때문입니다.
- 사용자가 실제로 보고 있는 것은 polling 상태가 아니라 애니메이션 화면이므로, 화면 focus 및 Lottie 재생 상태를 기준으로 한 watchdog을 추가했습니다.
- 검사 여러 번 시작으로 인한 중복 입력 문제는 별도 브랜치에서 처리되었고, 이번 PR은 이미 꼬인 상태에서도 검사 중 화면이 20초 이상 지속되지 않도록 하는 안전장치에 집중했습니다.
- Android 실제 기기 및 에뮬레이터에서의 최종 수동 확인은 추가 확인이 필요합니다.

## Screenshots or Video
- 같은 버그를 재현후, 확인해보니 캡쳐본과 같이 잘 적용되는것을 확인하였습니다.
<img width="496" height="1021" alt="image" src="https://github.com/user-attachments/assets/b4312689-2df5-41db-b285-8fd7a844a2f2" />
