### PR TITLE
[FEATURE] 저장된 URL 중복 체크 API 연동

### DIFF
--- a/api/saved-links.ts
+++ b/api/saved-links.ts
@@ -54,6 +54,10 @@ export type SavedLinkTitleUpdateResponse = {
   title: string;
 };
 
+export type SavedLinkUrlCheckResponse = {
+  exists: boolean;
+};
+
 type SavedLinkRequestOptions = Pick<ApiRequestOptions, 'signal'>;
 
 export function createSavedLink(
@@ -76,6 +80,18 @@ export function fetchSavedLinks(
   return authenticatedApiRequest<SavedLinkListResponse>(
     getToken,
     `/api/v1/saved-links${buildSavedLinkQuery(query)}`,
+    options,
+  );
+}
+
+export function checkSavedLinkUrl(
+  getToken: ClerkTokenGetter,
+  url: string,
+  options: SavedLinkRequestOptions = {},
+) {
+  return authenticatedApiRequest<SavedLinkUrlCheckResponse>(
+    getToken,
+    `/api/v1/saved-links/check?url=${encodeURIComponent(url)}`,
     options,
   );
 }

--- a/app/(tabs)/(home)/add-link.tsx
+++ b/app/(tabs)/(home)/add-link.tsx
@@ -41,6 +41,7 @@ export default function AddLinkScreen() {
   const isCompact = windowWidth < COMPACT_WIDTH || windowHeight <= SHORT_SCREEN_HEIGHT;
   const [isNavigating, setIsNavigating] = useState(false);
   const isNavigatingRef = useRef(false);
+  const urlRef = useRef(initialSharedUrl);
   const getTokenRef = useRef(getToken);
 
   useEffect(() => {
@@ -61,6 +62,7 @@ export default function AddLinkScreen() {
       return;
     }
 
+    urlRef.current = nextSharedUrl;
     setUrl(nextSharedUrl);
     setError('');
   }, [sharedUrl]);
@@ -101,6 +103,13 @@ export default function AddLinkScreen() {
 
     try {
       const response = await checkSavedLinkUrl(() => getTokenRef.current(), normalizedUrl);
+      const currentNormalizedUrl = normalizeHttpUrlInput(urlRef.current.trim());
+
+      if (currentNormalizedUrl !== normalizedUrl) {
+        isNavigatingRef.current = false;
+        setIsNavigating(false);
+        return;
+      }
 
       if (response.exists) {
         setError('이미 저장된 링크입니다.');
@@ -118,6 +127,7 @@ export default function AddLinkScreen() {
   };
 
   const handleChangeUrl = (value: string) => {
+    urlRef.current = value;
     setUrl(value);
     if (error) setError('');
   };
@@ -125,6 +135,7 @@ export default function AddLinkScreen() {
   const hasError = error.length > 0;
   const scanDisabled = !url.trim() || isNavigating || !isLoaded;
   const guardedClearUrl = useGuardedPress(() => {
+    urlRef.current = '';
     setUrl('');
     setError('');
   }, { lockMs: 250 });

--- a/app/(tabs)/(home)/add-link.tsx
+++ b/app/(tabs)/(home)/add-link.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@clerk/expo';
 import { useFocusEffect } from '@react-navigation/native';
 import {
   KeyboardAvoidingView,
@@ -12,6 +13,8 @@ import {
 } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 
+import { ApiError } from '@/api/api-client';
+import { checkSavedLinkUrl } from '@/api/saved-links';
 import { ScanButton } from '@/components/ui/scan-button';
 import { Colors, Typography } from '@/constants/theme';
 import { useGuardedPress } from '@/utils/press-guard';
@@ -29,6 +32,7 @@ function getSharedUrlParam(value: string | string[] | undefined): string {
 }
 
 export default function AddLinkScreen() {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
   const { sharedUrl } = useLocalSearchParams<{ sharedUrl?: string }>();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const initialSharedUrl = getSharedUrlParam(sharedUrl);
@@ -37,6 +41,11 @@ export default function AddLinkScreen() {
   const isCompact = windowWidth < COMPACT_WIDTH || windowHeight <= SHORT_SCREEN_HEIGHT;
   const [isNavigating, setIsNavigating] = useState(false);
   const isNavigatingRef = useRef(false);
+  const getTokenRef = useRef(getToken);
+
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
 
   useFocusEffect(
     useCallback(() => {
@@ -56,7 +65,7 @@ export default function AddLinkScreen() {
     setError('');
   }, [sharedUrl]);
 
-  const handleScan = () => {
+  const handleScan = async () => {
     if (isNavigatingRef.current) {
       return;
     }
@@ -76,10 +85,36 @@ export default function AddLinkScreen() {
       return;
     }
 
+    if (!isLoaded) {
+      setError('로그인 상태를 확인하고 있습니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+
+    if (!isSignedIn) {
+      setError('로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.');
+      return;
+    }
+
     setError('');
     isNavigatingRef.current = true;
     setIsNavigating(true);
-    router.push({ pathname: '/(tabs)/(home)/scanning', params: { url: normalizedUrl } });
+
+    try {
+      const response = await checkSavedLinkUrl(() => getTokenRef.current(), normalizedUrl);
+
+      if (response.exists) {
+        setError('이미 저장된 링크입니다.');
+        isNavigatingRef.current = false;
+        setIsNavigating(false);
+        return;
+      }
+
+      router.push({ pathname: '/(tabs)/(home)/scanning', params: { url: normalizedUrl } });
+    } catch (error) {
+      setError(getSavedLinkUrlCheckErrorMessage(error));
+      isNavigatingRef.current = false;
+      setIsNavigating(false);
+    }
   };
 
   const handleChangeUrl = (value: string) => {
@@ -88,7 +123,7 @@ export default function AddLinkScreen() {
   };
 
   const hasError = error.length > 0;
-  const scanDisabled = !url.trim() || isNavigating;
+  const scanDisabled = !url.trim() || isNavigating || !isLoaded;
   const guardedClearUrl = useGuardedPress(() => {
     setUrl('');
     setError('');
@@ -141,7 +176,9 @@ export default function AddLinkScreen() {
                   autoCorrect={false}
                   keyboardType="url"
                   returnKeyType="search"
-                  onSubmitEditing={handleScan}
+                  onSubmitEditing={() => {
+                    void handleScan();
+                  }}
                 />
                 {url.length > 0 && (
                   <TouchableOpacity
@@ -153,7 +190,12 @@ export default function AddLinkScreen() {
                   </TouchableOpacity>
                 )}
               </View>
-              <ScanButton onPress={handleScan} disabled={scanDisabled} />
+              <ScanButton
+                onPress={() => {
+                  void handleScan();
+                }}
+                disabled={scanDisabled}
+              />
             </View>
 
             {/* 에러 메시지 */}
@@ -171,6 +213,24 @@ export default function AddLinkScreen() {
       </View>
     </>
   );
+}
+
+function getSavedLinkUrlCheckErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+    }
+
+    return error.message || '저장된 링크 확인에 실패했습니다. 잠시 후 다시 시도해주세요.';
+  }
+
+  if (error instanceof Error) {
+    if (error.message === 'Missing Clerk session token') {
+      return '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+    }
+  }
+
+  return '저장된 링크 확인에 실패했습니다. 잠시 후 다시 시도해주세요.';
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Closes #74

## 개요

링크 검사 시작 전, 사용자가 입력한 URL이 이미 저장된 링크에 존재하는지 확인하는 API를 연동했습니다.

기존에는 URL 입력 후 검사 시작 버튼을 누르면 바로 검사 중 화면으로 이동하고, `POST /api/v1/analyses` 분석 요청 및 polling 흐름이 시작되었습니다. 이번 작업에서는 검사 화면으로 이동하기 전에 저장 링크 URL 중복 체크 API를 먼저 호출하도록 변경했습니다.

중복 체크 결과 `exists: true`이면 분석 요청을 시작하지 않고, 검사 중 화면으로 이동하지 않으며, 사용자에게 이미 저장된 링크임을 안내합니다. `exists: false`이면 기존 링크 검사 흐름이 그대로 진행됩니다.

## 주요 구현 내용

- 저장 링크 URL 중복 체크 API 타입 추가
- 저장 링크 URL 중복 체크 API 호출 함수 추가
- `GET /api/v1/saved-links/check?url={url}` 연동
- 보호 API 호출에 `authenticatedApiRequest` 사용
- Clerk 인증 토큰을 포함해 중복 체크 API 호출
- URL query parameter 전달 시 `encodeURIComponent`로 인코딩 처리
- 링크 추가 화면에서 검사 시작 전 중복 체크 API 선호출
- 이미 저장된 URL인 경우 검사 중 화면 이동 차단
- 이미 저장된 URL인 경우 `이미 저장된 링크입니다.` 안내 표시
- 저장되지 않은 URL인 경우 기존 검사 중 화면 이동 및 분석 요청 흐름 유지
- 중복 체크 API 실패 시 사용자 안내 메시지 표시
- 중복 체크 요청 중 검사 버튼 중복 입력 방지
- URL 수정 시 기존 안내 메시지가 초기화되어 다시 검사할 수 있도록 기존 흐름 유지

## 파일별 역할

- `api/saved-links.ts`: 저장 링크 URL 중복 체크 응답 타입과 `checkSavedLinkUrl` API 호출 함수 추가
- `app/(tabs)/(home)/add-link.tsx`: 검사 시작 버튼 클릭 시 URL 검증 후 중복 체크 API를 먼저 호출하고, 결과에 따라 검사 진행 여부 분기 처리

## 해결한 이슈 목록

- [x] URL 추가 화면의 현재 검사 시작 흐름 확인
- [x] `app/(tabs)/(home)/add-link.tsx`에서 검사 버튼 클릭 흐름 확인
- [x] 저장 링크 URL 중복 체크 API 타입과 호출 함수를 `api/saved-links.ts`에 추가
- [x] `GET /api/v1/saved-links/check?url={url}` 요청에 Clerk 인증 토큰 포함
- [x] API 호출에 `authenticatedApiRequest` 사용
- [x] 입력 URL을 query parameter로 전달할 때 안전하게 인코딩
- [x] 사용자가 검사 시작 버튼을 누르면 분석 요청 전에 중복 체크 API를 먼저 호출
- [x] `exists: true` 응답이면 분석 요청을 시작하지 않고 사용자에게 이미 저장된 링크임을 안내
- [x] `exists: false` 응답이면 기존 링크 검사 흐름 유지
- [x] 중복 체크 API 실패 시 사용자에게 안내 표시
- [x] 중복 체크 요청 중 검사 버튼 중복 입력 방지
- [x] 기존 `POST /api/v1/analyses` 요청 및 polling 흐름 유지
- [x] 이미 저장된 URL 안내 후 사용자가 URL을 수정하면 다시 검사 가능
- [x] Android 에뮬레이터에서 중복 URL과 신규 URL 흐름 각각 확인
- [ ] 실제 휴대폰 preview 빌드에서 중복 URL 안내와 정상 검사 흐름 확인

## 체크 사항

- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 분석 요청 및 polling 흐름이 깨지지 않도록 검사 시작 전 단계에서만 중복 체크 처리
- [x] 보호 API 호출 전 `/auth/me`를 수동 호출하지 않음

## 참고사항

- 백엔드 API는 `LinClean-BE-spring` PR #43에서 `dev` 브랜치에 머지된 내용을 사용했습니다.
- API endpoint: `GET /api/v1/saved-links/check?url={url}`
- 실제 백엔드 응답은 `{ data: { exists: boolean } }` 형태이며, 프론트 공통 API 클라이언트가 `data`를 unwrap합니다.
- 중복 기준은 현재 로그인한 멤버의 저장 링크 중 `Analysis.original_url` exact match입니다.
- 검사만 완료하고 저장하지 않은 URL은 중복 대상으로 판단되지 않습니다.

## Screenshots or Video
- api 연동 전 저장해놓았던 url을 입력해도 잘 체크해주는 모습입니다.
<img width="446" height="795" alt="image" src="https://github.com/user-attachments/assets/ab325f6b-38aa-4850-8475-b8fbbdfcb919" />
