### PR TITLE
[FIX] 홈 통계 카드 포커스 재조회 제거

### DIFF
--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -7,7 +7,6 @@ import {
   View,
 } from 'react-native';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
-import { useFocusEffect } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { AppIcon } from '@/components/ui/app-icon';
@@ -96,38 +95,36 @@ export default function HomeScreen() {
     setSaveToastVisible(true);
   }, [savedLinkToast]);
 
-  useFocusEffect(
-    useCallback(() => {
-      const abortController = new AbortController();
+  useEffect(() => {
+    const abortController = new AbortController();
 
-      async function loadStatistics() {
-        setIsStatisticsLoading(true);
-        setHasStatisticsError(false);
+    async function loadStatistics() {
+      setIsStatisticsLoading(true);
+      setHasStatisticsError(false);
 
-        try {
-          const response = await fetchVerdictStatistics({ signal: abortController.signal });
-          setStatistics(response);
-        } catch {
-          if (abortController.signal.aborted) {
-            return;
-          }
+      try {
+        const response = await fetchVerdictStatistics({ signal: abortController.signal });
+        setStatistics(response);
+      } catch {
+        if (abortController.signal.aborted) {
+          return;
+        }
 
-          setStatistics(EMPTY_STATISTICS);
-          setHasStatisticsError(true);
-        } finally {
-          if (!abortController.signal.aborted) {
-            setIsStatisticsLoading(false);
-          }
+        setStatistics(EMPTY_STATISTICS);
+        setHasStatisticsError(true);
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsStatisticsLoading(false);
         }
       }
+    }
 
-      void loadStatistics();
+    void loadStatistics();
 
-      return () => {
-        abortController.abort();
-      };
-    }, []),
-  );
+    return () => {
+      abortController.abort();
+    };
+  }, []);
 
   const handleMore = (id: number, anchor: AnchorPosition) => {
     setMenuState({ visible: true, anchor, linkId: id });


### PR DESCRIPTION
Closes #76

## 개요
PR #69의 `1981967` 커밋에서 홈 화면 통계 카드가 최신 데이터를 반영하도록 `useEffect` 기반 최초 조회 로직을 `useFocusEffect` 기반 포커스 재조회 로직으로 변경했습니다.

하지만 홈 탭 재진입, 검사 결과 저장 후 홈 복귀, 탭 이동 등으로 홈 화면에 다시 포커스될 때마다 `fetchVerdictStatistics`가 호출될 수 있습니다.

홈 통계 데이터는 약 50분 주기로 갱신되어도 충분하므로, 포커스마다 통계 API를 재호출하는 방식은 백엔드 서버에 불필요한 요청 부하를 줄 수 있다고 판단했습니다.

따라서 이번 작업에서는 `1981967` 커밋의 포커스 재조회 변경 사항을 되돌리고, 기존처럼 홈 화면 최초 mount 시점에만 통계 데이터를 조회하도록 복구했습니다.

## 주요 구현 내용
- 홈 화면 통계 조회 로직에서 `useFocusEffect` 제거
- `useEffect` 기반 최초 mount 시점 통계 조회 방식으로 복구
- `useFocusEffect` import 제거
- 기존 `AbortController` 기반 요청 정리 흐름 유지
- 기존 통계 카드의 로딩, 에러, 빈 상태 처리 유지

## 파일별 역할
- `app/(tabs)/(home)/index.tsx`: 홈 통계 카드 API 조회 시점을 포커스 재조회에서 최초 mount 조회 방식으로 복구

## 해결한 이슈 목록
- [x] PR #69 및 `1981967` 커밋 변경 범위 확인
- [x] `useFocusEffect` 기반 통계 재조회 로직 제거
- [x] `useEffect` 기반 최초 mount 조회 방식 복구
- [x] 홈 화면 포커스 진입만으로 `fetchVerdictStatistics`가 반복 호출되지 않도록 수정
- [x] 기존 통계 카드의 로딩/에러/빈 상태 처리 유지
- [x] 앱 실행 후 홈 화면 최초 진입 및 탭 재진입 동작 수동 확인

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 변경 범위가 홈 화면 통계 조회 로직으로 한정됨
- [x] `git diff --check origin/dev...HEAD` 통과

## 참고사항
- 관련 PR: #69
- 되돌린 커밋: `1981967` - `fix: 홈 통계 카드 포커스 재조회 처리`
- 이번 커밋: `1fdbb9f` - `fix: 홈 통계 카드 포커스 재조회 제거`
- 별도 worktree에는 `node_modules`가 없어 `npm run lint`, `npx tsc --noEmit`은 실행하지 못했습니다.

## Screenshots or Video
- UI 변경 없음