### PR TITLE
[FIX] 링크 저장 모달 키보드 대응 및 링크 추가 입력 동작 개선

### DIFF
--- a/app/(tabs)/(home)/add-link.tsx
+++ b/app/(tabs)/(home)/add-link.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 import {
+  Keyboard,
   KeyboardAvoidingView,
   Platform,
   StyleSheet,
@@ -37,13 +38,32 @@ export default function AddLinkScreen() {
   const isCompact = windowWidth < COMPACT_WIDTH || windowHeight <= SHORT_SCREEN_HEIGHT;
   const [isNavigating, setIsNavigating] = useState(false);
   const isNavigatingRef = useRef(false);
+  const urlInputRef = useRef<TextInput>(null);
+  const urlFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearUrlFocusTimer = useCallback(() => {
+    if (urlFocusTimerRef.current) {
+      clearTimeout(urlFocusTimerRef.current);
+      urlFocusTimerRef.current = null;
+    }
+  }, []);
 
   useFocusEffect(
     useCallback(() => {
       isNavigatingRef.current = false;
       setIsNavigating(false);
-    }, []),
+
+      clearUrlFocusTimer();
+      urlFocusTimerRef.current = setTimeout(() => {
+        urlInputRef.current?.focus();
+        urlFocusTimerRef.current = null;
+      }, 100);
+
+      return clearUrlFocusTimer;
+    }, [clearUrlFocusTimer]),
   );
+
+  useEffect(() => clearUrlFocusTimer, [clearUrlFocusTimer]);
 
   useEffect(() => {
     const nextSharedUrl = getSharedUrlParam(sharedUrl);
@@ -132,6 +152,7 @@ export default function AddLinkScreen() {
             <View style={[styles.inputRow, isCompact && styles.inputRowCompact]}>
               <View style={[styles.inputWrapper, isCompact && styles.inputWrapperCompact, hasError && styles.inputError]}>
                 <TextInput
+                  ref={urlInputRef}
                   style={styles.input}
                   placeholder="https://example.com"
                   placeholderTextColor={Colors.brand.textHint}
@@ -140,8 +161,8 @@ export default function AddLinkScreen() {
                   autoCapitalize="none"
                   autoCorrect={false}
                   keyboardType="url"
-                  returnKeyType="search"
-                  onSubmitEditing={handleScan}
+                  returnKeyType="done"
+                  onSubmitEditing={Keyboard.dismiss}
                 />
                 {url.length > 0 && (
                   <TouchableOpacity

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Keyboard,
   LayoutAnimation,
@@ -61,13 +61,28 @@ export function LinkSaveModal({
   const insets = useSafeAreaInsets();
   const [title, setTitle] = useState(initialTitle);
   const [keyboardInset, setKeyboardInset] = useState(0);
+  const titleInputRef = useRef<TextInput>(null);
+  const titleFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const trimmedTitle = title.trim();
   const saveDisabled = loading || trimmedTitle.length === 0;
 
+  const clearTitleFocusTimer = useCallback(() => {
+    if (titleFocusTimerRef.current) {
+      clearTimeout(titleFocusTimerRef.current);
+      titleFocusTimerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     setTitle(initialTitle);
-  }, [initialTitle, visible]);
+
+    if (!visible) {
+      clearTitleFocusTimer();
+    }
+  }, [clearTitleFocusTimer, initialTitle, visible]);
+
+  useEffect(() => clearTitleFocusTimer, [clearTitleFocusTimer]);
 
   useEffect(() => {
     if (!visible) {
@@ -90,11 +105,30 @@ export function LinkSaveModal({
     };
   }, [visible]);
 
+  const handleCancel = useCallback(() => {
+    if (loading) {
+      return;
+    }
+
+    clearTitleFocusTimer();
+    onCancel();
+  }, [clearTitleFocusTimer, loading, onCancel]);
+
+  const handleModalShow = useCallback(() => {
+    clearTitleFocusTimer();
+
+    titleFocusTimerRef.current = setTimeout(() => {
+      titleInputRef.current?.focus();
+      titleFocusTimerRef.current = null;
+    }, 100);
+  }, [clearTitleFocusTimer]);
+
   const handleSave = () => {
     if (saveDisabled) return;
+    clearTitleFocusTimer();
     onSave(trimmedTitle);
   };
-  const guardedCancel = useGuardedPress(onCancel, { disabled: loading, lockMs: 250 });
+  const guardedCancel = useGuardedPress(handleCancel, { disabled: loading, lockMs: 250 });
   const guardedSave = useGuardedPress(handleSave, { disabled: saveDisabled });
   const guardedClearTitle = useGuardedPress(() => setTitle(''), {
     disabled: loading,
@@ -111,6 +145,7 @@ export function LinkSaveModal({
       transparent
       animationType="slide"
       onRequestClose={guardedCancel}
+      onShow={handleModalShow}
     >
       <View style={[styles.overlay, { paddingBottom: modalBottomInset }]}>
         <Pressable style={styles.backdrop} onPress={guardedCancel} />
@@ -132,6 +167,7 @@ export function LinkSaveModal({
               <Text style={styles.label}>URL 제목</Text>
               <View style={styles.inputRow}>
                 <TextInput
+                  ref={titleInputRef}
                   style={styles.input}
                   value={title}
                   onChangeText={setTitle}
@@ -141,7 +177,6 @@ export function LinkSaveModal({
                   onSubmitEditing={Keyboard.dismiss}
                   maxLength={500}
                   editable={!loading}
-                  autoFocus
                 />
                 {title.length > 0 && !loading && (
                   <TouchableOpacity

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -1,19 +1,44 @@
 import { useEffect, useState } from 'react';
 import {
   Keyboard,
-  KeyboardAvoidingView,
+  LayoutAnimation,
   Modal,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
+  type KeyboardEvent,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors, Typography } from '@/constants/theme';
 import { useGuardedPress } from '@/utils/press-guard';
+
+const MODAL_BOTTOM_GAP = 16;
+const KEYBOARD_TOP_GAP = 16;
+
+const showKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+const hideKeyboardEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+const syncKeyboardLayoutAnimation = (event: KeyboardEvent) => {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+
+  const duration = event.duration > 10 ? event.duration : 10;
+
+  LayoutAnimation.configureNext({
+    duration,
+    update: {
+      duration,
+      type: LayoutAnimation.Types[event.easing] || LayoutAnimation.Types.keyboard,
+    },
+  });
+};
 
 interface LinkSaveModalProps {
   visible: boolean;
@@ -33,7 +58,9 @@ export function LinkSaveModal({
   onCancel,
   onSave,
 }: LinkSaveModalProps) {
+  const insets = useSafeAreaInsets();
   const [title, setTitle] = useState(initialTitle);
+  const [keyboardInset, setKeyboardInset] = useState(0);
 
   const trimmedTitle = title.trim();
   const saveDisabled = loading || trimmedTitle.length === 0;
@@ -42,12 +69,37 @@ export function LinkSaveModal({
     setTitle(initialTitle);
   }, [initialTitle, visible]);
 
+  useEffect(() => {
+    if (!visible) {
+      setKeyboardInset(0);
+      return;
+    }
+
+    const showSubscription = Keyboard.addListener(showKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
+      setKeyboardInset(event.endCoordinates.height);
+    });
+    const hideSubscription = Keyboard.addListener(hideKeyboardEvent, (event) => {
+      syncKeyboardLayoutAnimation(event);
+      setKeyboardInset(0);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, [visible]);
+
   const handleSave = () => {
     if (saveDisabled) return;
     onSave(trimmedTitle);
   };
   const guardedCancel = useGuardedPress(onCancel, { disabled: loading, lockMs: 250 });
   const guardedSave = useGuardedPress(handleSave, { disabled: saveDisabled });
+  const restingBottomInset = Math.max(insets.bottom, MODAL_BOTTOM_GAP);
+  const modalBottomInset = keyboardInset > 0
+    ? keyboardInset + KEYBOARD_TOP_GAP
+    : restingBottomInset;
 
   return (
     <Modal
@@ -56,68 +108,71 @@ export function LinkSaveModal({
       animationType="slide"
       onRequestClose={guardedCancel}
     >
-      <KeyboardAvoidingView
-        style={styles.overlay}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      >
+      <View style={[styles.overlay, { paddingBottom: modalBottomInset }]}>
         <Pressable style={styles.backdrop} onPress={guardedCancel} />
 
         <View style={styles.sheet}>
-          <View style={styles.handle} />
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.sheetContent}
+          >
+            <View style={styles.handle} />
 
-          <View style={styles.header}>
-            <Text style={styles.title}>링크 저장</Text>
-            <Text style={styles.description}>저장할 URL 제목을 입력해 주세요.</Text>
-          </View>
-
-          <View style={styles.fieldGroup}>
-            <Text style={styles.label}>URL 제목</Text>
-            <TextInput
-              style={styles.input}
-              value={title}
-              onChangeText={setTitle}
-              placeholder="예: 네이버 블로그"
-              placeholderTextColor={Colors.brand.textHint}
-              returnKeyType="done"
-              onSubmitEditing={Keyboard.dismiss}
-              maxLength={500}
-              editable={!loading}
-              autoFocus
-            />
-          </View>
-
-          <View style={styles.fieldGroup}>
-            <Text style={styles.label}>검사 대상 URL</Text>
-            <View style={styles.urlBox}>
-              <Text style={styles.urlText} numberOfLines={1} ellipsizeMode="tail">
-                {url}
-              </Text>
+            <View style={styles.header}>
+              <Text style={styles.title}>링크 저장</Text>
+              <Text style={styles.description}>저장할 URL 제목을 입력해 주세요.</Text>
             </View>
-          </View>
 
-          <View style={styles.actions}>
-            <TouchableOpacity
-              style={styles.cancelButton}
-              onPress={guardedCancel}
-              activeOpacity={0.8}
-              disabled={loading}
-            >
-              <Text style={styles.cancelButtonText}>취소</Text>
-            </TouchableOpacity>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>URL 제목</Text>
+              <TextInput
+                style={styles.input}
+                value={title}
+                onChangeText={setTitle}
+                placeholder="예: 네이버 블로그"
+                placeholderTextColor={Colors.brand.textHint}
+                returnKeyType="done"
+                onSubmitEditing={Keyboard.dismiss}
+                maxLength={500}
+                editable={!loading}
+                autoFocus
+              />
+            </View>
 
-            <TouchableOpacity
-              style={[styles.saveButton, saveDisabled && styles.saveButtonDisabled]}
-              onPress={guardedSave}
-              activeOpacity={0.8}
-              disabled={saveDisabled}
-            >
-              <Text style={[styles.saveButtonText, saveDisabled && styles.saveButtonTextDisabled]}>
-                {loading ? '저장 중...' : '저장'}
-              </Text>
-            </TouchableOpacity>
-          </View>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>검사 대상 URL</Text>
+              <View style={styles.urlBox}>
+                <Text style={styles.urlText} numberOfLines={1} ellipsizeMode="tail">
+                  {url}
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={styles.cancelButton}
+                onPress={guardedCancel}
+                activeOpacity={0.8}
+                disabled={loading}
+              >
+                <Text style={styles.cancelButtonText}>취소</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[styles.saveButton, saveDisabled && styles.saveButtonDisabled]}
+                onPress={guardedSave}
+                activeOpacity={0.8}
+                disabled={saveDisabled}
+              >
+                <Text style={[styles.saveButtonText, saveDisabled && styles.saveButtonTextDisabled]}>
+                  {loading ? '저장 중...' : '저장'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </ScrollView>
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 }
@@ -133,12 +188,16 @@ const styles = StyleSheet.create({
   },
   sheet: {
     width: '100%',
+    maxHeight: '80%',
     backgroundColor: Colors.light.background,
     borderTopLeftRadius: 28,
     borderTopRightRadius: 28,
-    paddingTop: 14,
+    overflow: 'hidden',
+  },
+  sheetContent: {
+    paddingTop: 12,
     paddingHorizontal: 24,
-    paddingBottom: 32,
+    paddingBottom: 24,
   },
   handle: {
     alignSelf: 'center',
@@ -146,11 +205,11 @@ const styles = StyleSheet.create({
     height: 6,
     borderRadius: 3,
     backgroundColor: Colors.brand.line,
-    marginBottom: 30,
+    marginBottom: 22,
   },
   header: {
-    gap: 14,
-    marginBottom: 34,
+    gap: 8,
+    marginBottom: 24,
   },
   title: {
     ...Typography.title,
@@ -161,16 +220,16 @@ const styles = StyleSheet.create({
     color: Colors.brand.textSecondary,
   },
   fieldGroup: {
-    gap: 12,
-    marginBottom: 28,
+    gap: 10,
+    marginBottom: 20,
   },
   label: {
     ...Typography.caption,
     color: Colors.brand.text,
   },
   input: {
-    height: 56,
-    borderRadius: 20,
+    height: 52,
+    borderRadius: 18,
     borderWidth: 1,
     borderColor: Colors.brand.line,
     paddingHorizontal: 18,
@@ -179,8 +238,8 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.light.background,
   },
   urlBox: {
-    height: 56,
-    borderRadius: 20,
+    height: 52,
+    borderRadius: 18,
     backgroundColor: Colors.brand.background,
     justifyContent: 'center',
     paddingHorizontal: 18,
@@ -193,12 +252,12 @@ const styles = StyleSheet.create({
   actions: {
     flexDirection: 'row',
     gap: 14,
-    marginTop: 4,
+    marginTop: 0,
   },
   cancelButton: {
     flex: 1,
-    height: 56,
-    borderRadius: 28,
+    height: 52,
+    borderRadius: 26,
     borderWidth: 1.5,
     borderColor: Colors.brand.primary,
     alignItems: 'center',
@@ -211,8 +270,8 @@ const styles = StyleSheet.create({
   },
   saveButton: {
     flex: 1,
-    height: 56,
-    borderRadius: 28,
+    height: 52,
+    borderRadius: 26,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: Colors.brand.primary,

--- a/components/ui/link-save-modal.tsx
+++ b/components/ui/link-save-modal.tsx
@@ -96,6 +96,10 @@ export function LinkSaveModal({
   };
   const guardedCancel = useGuardedPress(onCancel, { disabled: loading, lockMs: 250 });
   const guardedSave = useGuardedPress(handleSave, { disabled: saveDisabled });
+  const guardedClearTitle = useGuardedPress(() => setTitle(''), {
+    disabled: loading,
+    lockMs: 250,
+  });
   const restingBottomInset = Math.max(insets.bottom, MODAL_BOTTOM_GAP);
   const modalBottomInset = keyboardInset > 0
     ? keyboardInset + KEYBOARD_TOP_GAP
@@ -126,18 +130,29 @@ export function LinkSaveModal({
 
             <View style={styles.fieldGroup}>
               <Text style={styles.label}>URL 제목</Text>
-              <TextInput
-                style={styles.input}
-                value={title}
-                onChangeText={setTitle}
-                placeholder="예: 네이버 블로그"
-                placeholderTextColor={Colors.brand.textHint}
-                returnKeyType="done"
-                onSubmitEditing={Keyboard.dismiss}
-                maxLength={500}
-                editable={!loading}
-                autoFocus
-              />
+              <View style={styles.inputRow}>
+                <TextInput
+                  style={styles.input}
+                  value={title}
+                  onChangeText={setTitle}
+                  placeholder="예: 네이버 블로그"
+                  placeholderTextColor={Colors.brand.textHint}
+                  returnKeyType="done"
+                  onSubmitEditing={Keyboard.dismiss}
+                  maxLength={500}
+                  editable={!loading}
+                  autoFocus
+                />
+                {title.length > 0 && !loading && (
+                  <TouchableOpacity
+                    onPress={guardedClearTitle}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    style={styles.clearButton}
+                  >
+                    <Text style={styles.clearButtonText}>−</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
             </View>
 
             <View style={styles.fieldGroup}>
@@ -227,15 +242,35 @@ const styles = StyleSheet.create({
     ...Typography.caption,
     color: Colors.brand.text,
   },
-  input: {
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     height: 52,
     borderRadius: 18,
     borderWidth: 1,
     borderColor: Colors.brand.line,
     paddingHorizontal: 18,
+    backgroundColor: Colors.light.background,
+  },
+  input: {
+    flex: 1,
     ...Typography.body,
     color: Colors.brand.text,
-    backgroundColor: Colors.light.background,
+    padding: 0,
+  },
+  clearButton: {
+    marginLeft: 8,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: Colors.brand.softMint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clearButtonText: {
+    ...Typography.caption,
+    color: Colors.brand.primary,
+    lineHeight: 16,
   },
   urlBox: {
     height: 52,


### PR DESCRIPTION
Closes #78

## 개요
링크 저장 시 표시되는 URL 제목 저장 모달에도 키보드 노출 대응을 적용하고, 링크 추가 화면의 URL 입력 키보드 동작을 입력 모달들과 동일한 방향으로 개선했습니다.

기존 #54 / PR #63에서는 링크 제목 수정 모달과 폴더명 수정 모달에 키보드 show/hide 이벤트 기반 하단 여백 보정, 완료/done 키 저장 동작 제거, Modal onShow 이후 수동 focus 처리를 적용했습니다.

이번 작업에서는 누락되어 있던 링크 저장 모달에도 동일한 키보드 대응 방식을 적용했습니다. 키보드가 올라온 상태에서도 입력창과 취소/저장 버튼을 확인할 수 있도록 하단 inset을 조정하고, 작은 화면에서도 버튼이 키보드에 가려지지 않도록 모달 내부 여백과 높이를 함께 보완했습니다.

또한 링크 추가 화면의 URL 입력칸은 화면 진입 시 자동으로 키보드가 올라오도록 focus 처리를 추가하고, 키보드 우측 버튼을 검색 동작이 아닌 완료/done 동작으로 변경했습니다. 이제 키보드의 체크 표시를 눌러도 검사가 시작되지 않고 키보드만 닫히며, 실제 검사는 화면의 검사 버튼을 눌렀을 때만 실행됩니다.

## 주요 구현 내용
- 링크 저장 모달의 키보드 show/hide 이벤트 기반 하단 inset 처리 추가
- 키보드 노출 시 링크 저장 모달이 키보드 위로 올라오도록 위치 보정
- Android 하단 시스템 내비게이션 바와 겹치지 않도록 기본 하단 여백 적용
- 링크 저장 모달 내부를 `ScrollView`로 감싸 작은 화면 대응 보완
- 키보드 활성화 상태에서 취소/저장 버튼이 가려지지 않도록 모달 내부 여백 및 버튼 높이 조정
- 링크 저장 모달의 URL 제목 입력칸에 전체 지우기 버튼 추가
- 링크 저장 모달의 `autoFocus` 제거
- 링크 저장 모달을 `Modal.onShow` 이후 100ms 뒤 수동 focus 방식으로 변경
- 저장/취소/닫힘/언마운트 시 예약된 focus timer cleanup 처리
- 링크 추가 화면 진입 시 URL 입력칸 자동 focus 처리
- 링크 추가 화면 URL 입력칸의 키보드 return key를 `search`에서 `done`으로 변경
- 링크 추가 화면에서 키보드 완료/done 키 입력 시 검사 실행 대신 `Keyboard.dismiss`만 실행하도록 변경
- 검사 버튼을 통한 기존 검사 시작 흐름 유지

## 파일별 역할
- `components/ui/link-save-modal.tsx`: 링크 저장 모달의 키보드 대응, 하단 위치 보정, 모달 크기 조정, 입력 focus 안정화, 제목 입력 초기화 버튼 추가
- `app/(tabs)/(home)/add-link.tsx`: 링크 추가 화면 URL 입력칸 자동 focus 처리, 키보드 완료 키 동작 변경

## 해결한 이슈 목록
- [x] 링크 저장 모달에 키보드 show/hide 이벤트 기반 하단 inset 처리를 적용
- [x] 키보드가 올라왔을 때 링크 저장 모달 입력창과 버튼이 화면 안에 보이도록 수정
- [x] 키보드 활성화 상태에서 취소/저장 버튼이 가려지지 않도록 모달 내부 여백 조정
- [x] 키보드가 닫힌 뒤 모달이 보정된 기본 하단 위치로 복귀하도록 처리
- [x] Android 하단 시스템 내비게이션 바와 모달 버튼 영역이 겹치지 않도록 처리
- [x] 링크 저장 모달의 URL 제목 입력칸에 전체 지우기 버튼 추가
- [x] 링크 저장 모달의 `autoFocus`를 제거하고 `Modal.onShow` 기반 수동 focus로 변경
- [x] 예약된 focus timer가 저장/취소/닫힘/언마운트 이후 실행되지 않도록 cleanup 처리
- [x] 링크 추가 화면 진입 시 URL 입력칸에 자동 focus가 적용되도록 처리
- [x] 링크 추가 화면 URL 입력칸의 키보드 버튼을 검색 아이콘이 아닌 완료/done 형태로 변경
- [x] 키보드 완료/done 키 입력 시 검사 시작 대신 키보드만 닫히도록 수정
- [x] 실제 검사는 화면의 검사 버튼을 눌렀을 때만 실행되도록 유지
- [x] 기존 저장 버튼 및 검사 버튼의 비활성화 조건 유지
- [x] 기존 저장 API 및 검사 화면 이동 흐름 유지

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 저장 버튼을 통한 기존 저장 API 호출 흐름 유지
- [x] 검사 버튼을 통한 기존 검사 시작 흐름 유지
- [x] 키보드 완료 키 입력 시 저장/검사 핸들러가 호출되지 않도록 처리

## Screenshots or Video
- 링크 저장 모달 키보드 화면
<img width="492" height="1024" alt="image" src="https://github.com/user-attachments/assets/915d04f4-067e-4645-acbd-d41c7cb17bb7" />
