### PR TITLE
[FIX] 북마크 토글 API 중복 호출 방지

### DIFF
--- a/app/(tabs)/(folder)/[id].tsx
+++ b/app/(tabs)/(folder)/[id].tsx
@@ -12,7 +12,7 @@ import { Colors, Typography } from '@/constants/theme';
 import { getSavedLinkErrorMessage, useSavedLinks, type SavedLink } from '@/context/saved-links-context';
 import { useFolders } from '@/context/folders-context';
 import type { AnchorPosition } from '@/components/ui/folder-card';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { showAlert } from '@/utils/guarded-alert';
 
 type MoreMenuState = {
@@ -26,7 +26,7 @@ export default function FolderDetailScreen() {
   const router = useRouter();
   const folderId = Number(id);
 
-  const { links, toggleBookmark, assignCategory, updateTitle } = useSavedLinks();
+  const { links, bookmarkingLinkIds, toggleBookmark, assignCategory, updateTitle } = useSavedLinks();
   const { folders, refreshFolders } = useFolders();
   const folderLinks = links.filter((l) => l.categoryId === folderId);
   const folderName = folders.find((f) => f.id === folderId)?.name ?? '폴더';
@@ -45,6 +45,20 @@ export default function FolderDetailScreen() {
   const handleMore = (linkId: number, anchor: AnchorPosition) => {
     setMenuState({ visible: true, anchor, linkId });
   };
+
+  const handleBookmark = useCallback(
+    async (linkId: number) => {
+      try {
+        await toggleBookmark(linkId);
+      } catch (error) {
+        showAlert(
+          '북마크 변경 실패',
+          getSavedLinkErrorMessage(error, '북마크 상태를 변경하지 못했습니다. 잠시 후 다시 시도해주세요.'),
+        );
+      }
+    },
+    [toggleBookmark],
+  );
 
   const handleDelete = async (linkId: number) => {
     if (deletingFromFolderIdsRef.current.has(linkId)) {
@@ -150,7 +164,8 @@ export default function FolderDetailScreen() {
                 originalUrl={link.originalUrl}
                 finalUrl={link.finalUrl}
                 bookmarked={link.isBookmarked}
-                onBookmark={() => toggleBookmark(link.id)}
+                bookmarkDisabled={bookmarkingLinkIds.has(link.id)}
+                onBookmark={() => handleBookmark(link.id)}
                 onMore={(anchor: AnchorPosition) => handleMore(link.id, anchor)}
               />
             ))}

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -60,7 +60,7 @@ export default function HomeScreen() {
   }>();
   const { width: windowWidth } = useWindowDimensions();
   const tabBarHeight = useBottomTabBarHeight();
-  const { links, toggleBookmark, deleteLink, updateTitle } = useSavedLinks();
+  const { links, bookmarkingLinkIds, toggleBookmark, deleteLink, updateTitle } = useSavedLinks();
   const { refreshFolders } = useFolders();
   const [menuState, setMenuState] = useState<{ visible: boolean; anchor?: AnchorPosition; linkId?: number }>({ visible: false });
   const [editingLink, setEditingLink] = useState<SavedLink | null>(null);
@@ -284,9 +284,8 @@ export default function HomeScreen() {
                 originalUrl={link.originalUrl}
                 finalUrl={link.finalUrl}
                 bookmarked={link.isBookmarked}
-                onBookmark={() => {
-                  void handleBookmark(link.id);
-                }}
+                bookmarkDisabled={bookmarkingLinkIds.has(link.id)}
+                onBookmark={() => handleBookmark(link.id)}
                 onMore={(anchor) => handleMore(link.id, anchor)}
               />
             ))}

--- a/app/(tabs)/(home)/saved-links.tsx
+++ b/app/(tabs)/(home)/saved-links.tsx
@@ -33,6 +33,7 @@ export default function SavedLinksScreen() {
     hasNext,
     refreshLinks,
     loadMoreLinks,
+    bookmarkingLinkIds,
     toggleBookmark,
     deleteLink,
     updateTitle,
@@ -227,9 +228,8 @@ export default function SavedLinksScreen() {
             originalUrl={item.originalUrl}
             finalUrl={item.finalUrl}
             bookmarked={item.isBookmarked}
-            onBookmark={() => {
-              void handleBookmark(item.id);
-            }}
+            bookmarkDisabled={bookmarkingLinkIds.has(item.id)}
+            onBookmark={() => handleBookmark(item.id)}
             onMore={(anchor) => openMoreMenu(item, anchor)}
           />
         )}

--- a/components/ui/card-link.tsx
+++ b/components/ui/card-link.tsx
@@ -19,7 +19,8 @@ export interface CardLinkProps {
   bookmarked?: boolean;
   icon?: boolean;
   disabled?: boolean;
-  onBookmark?: () => void;
+  bookmarkDisabled?: boolean;
+  onBookmark?: () => void | Promise<void>;
   onMore?: (anchor: AnchorPosition) => void;
   onPress?: () => void;
 }
@@ -46,6 +47,7 @@ export function CardLink({
   bookmarked = false,
   icon = true,
   disabled = false,
+  bookmarkDisabled = false,
   onBookmark,
   onMore,
   onPress,
@@ -57,7 +59,8 @@ export function CardLink({
   const normalizedVerdict = verdict && verdict in VERDICT_LABELS ? verdict : undefined;
   const statusLabel = normalizedVerdict ? VERDICT_LABELS[normalizedVerdict] : (getFirstText(label) ?? '결과 없음');
   const statusColors = normalizedVerdict ? VERDICT_COLORS[normalizedVerdict] : undefined;
-  const guardedBookmark = useGuardedPress(onBookmark, { disabled });
+  const isBookmarkDisabled = disabled || bookmarkDisabled;
+  const guardedBookmark = useGuardedPress(onBookmark, { disabled: isBookmarkDisabled });
   const guardedMore = useGuardedPress(onMore, { disabled });
 
   const handleBookmarkPress = (event: GestureResponderEvent) => {
@@ -124,14 +127,19 @@ export function CardLink({
         {icon && (
           <View style={styles.iconRow}>
             <Pressable
-              onPress={disabled ? undefined : handleBookmarkPress}
+              onPress={isBookmarkDisabled ? undefined : handleBookmarkPress}
               hitSlop={8}
-              style={({ pressed }) => pressed && !disabled && styles.pressed}
+              style={({ pressed }) => [
+                pressed && !isBookmarkDisabled && styles.pressed,
+                bookmarkDisabled && styles.bookmarkDisabled,
+              ]}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: isBookmarkDisabled }}
             >
               <IconSymbol
                 name={bookmarked ? 'bookmark.fill' : 'bookmark'}
                 size={18}
-                color={bookmarked ? Colors.brand.primary : disabled ? Colors.brand.textHint : Colors.brand.textSecondary}
+                color={bookmarked ? Colors.brand.primary : isBookmarkDisabled ? Colors.brand.textHint : Colors.brand.textSecondary}
               />
             </Pressable>
             <Pressable
@@ -237,5 +245,8 @@ const styles = StyleSheet.create({
   },
   pressed: {
     opacity: 0.6,
+  },
+  bookmarkDisabled: {
+    opacity: 0.45,
   },
 });

--- a/context/saved-links-context.tsx
+++ b/context/saved-links-context.tsx
@@ -17,6 +17,8 @@ import { getSiteName } from '@/utils/analysis-result-display';
 const DEFAULT_PAGE_SIZE = 50;
 const LOGIN_REQUIRED_MESSAGE =
   '로그인 상태를 확인할 수 없습니다. 다시 로그인한 뒤 시도해주세요.';
+const NETWORK_REQUEST_FAILED_MESSAGE =
+  '네트워크 연결 상태를 확인한 뒤 다시 시도해주세요.';
 
 export interface SavedLink extends SavedLinkResponse {
   description: string;
@@ -28,6 +30,7 @@ interface SavedLinksContextValue {
   isLoading: boolean;
   isLoadingMore: boolean;
   errorMessage: string;
+  bookmarkingLinkIds: ReadonlySet<number>;
   hasNext: boolean;
   nextCursor: string | null;
   refreshLinks: (query?: SavedLinkListQuery) => Promise<void>;
@@ -47,10 +50,14 @@ export function SavedLinksProvider({ children }: { children: React.ReactNode }) 
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [bookmarkingLinkIds, setBookmarkingLinkIds] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
   const [hasNext, setHasNext] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const lastQueryRef = useRef<SavedLinkListQuery>({ size: DEFAULT_PAGE_SIZE });
   const getTokenRef = useRef(getToken);
+  const bookmarkingLinkIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
     getTokenRef.current = getToken;
@@ -138,7 +145,14 @@ export function SavedLinksProvider({ children }: { children: React.ReactNode }) 
   }, []);
 
   const toggleBookmark = useCallback(async (id: number) => {
-    const previousLinks = links;
+    if (bookmarkingLinkIdsRef.current.has(id)) {
+      return;
+    }
+
+    bookmarkingLinkIdsRef.current.add(id);
+    setBookmarkingLinkIds(new Set(bookmarkingLinkIdsRef.current));
+
+    const previousIsBookmarked = links.find((link) => link.id === id)?.isBookmarked;
     setLinks((prev) =>
       prev.map((link) =>
         link.id === id ? { ...link, isBookmarked: !link.isBookmarked } : link,
@@ -153,8 +167,18 @@ export function SavedLinksProvider({ children }: { children: React.ReactNode }) 
         ),
       );
     } catch (error) {
-      setLinks(previousLinks);
+      if (previousIsBookmarked != null) {
+        setLinks((prev) =>
+          prev.map((link) =>
+            link.id === id ? { ...link, isBookmarked: previousIsBookmarked } : link,
+          ),
+        );
+      }
+
       throw error;
+    } finally {
+      bookmarkingLinkIdsRef.current.delete(id);
+      setBookmarkingLinkIds(new Set(bookmarkingLinkIdsRef.current));
     }
   }, [links]);
 
@@ -223,6 +247,7 @@ export function SavedLinksProvider({ children }: { children: React.ReactNode }) 
         isLoading,
         isLoadingMore,
         errorMessage,
+        bookmarkingLinkIds,
         hasNext,
         nextCursor,
         refreshLinks,
@@ -249,6 +274,10 @@ export function getSavedLinkErrorMessage(error: unknown, fallbackMessage: string
   if (error instanceof Error) {
     if (error.message === 'Missing Clerk session token') {
       return LOGIN_REQUIRED_MESSAGE;
+    }
+
+    if (error.message === 'Network request failed') {
+      return NETWORK_REQUEST_FAILED_MESSAGE;
     }
 
     if (error.message) {


### PR DESCRIPTION
Closes #57

## 개요
링크 카드의 북마크 버튼을 빠르게 여러 번 누를 때 같은 링크에 대한 `PATCH /api/v1/saved-links/{id}/bookmark` 요청이 중복 호출되지 않도록 수정했습니다.

기존에는 `CardLink`의 `useGuardedPress`를 통해 짧은 시간 안의 연타는 일부 방지할 수 있었지만, 홈 화면과 저장 링크 전체보기에서는 `void handleBookmark(id)` 형태로 Promise가 전달되지 않아 API 요청이 700ms보다 오래 걸리는 경우 같은 링크에 대해 추가 토글 요청이 다시 발생할 수 있었습니다.

또한 화면별로 북마크 호출 방식이 달라 홈 화면, 저장 링크 전체보기, 폴더 상세 화면의 동작이 완전히 일관되지 않았습니다.

따라서 이번 작업에서는 버튼 단위의 짧은 입력 방지가 아니라 `toggleBookmark` context 레벨에서 링크 id별 요청 진행 상태를 관리하도록 변경했습니다. 같은 링크의 북마크 요청이 진행 중이면 추가 요청을 무시하고, 요청이 완료된 뒤 다시 누른 경우에만 새로운 토글 요청이 발생하도록 처리했습니다.

## 주요 구현 내용
- `SavedLinksContext`에 `bookmarkingLinkIds` 상태 추가
- `toggleBookmark(id)` 내부에 링크 id별 in-flight guard 추가
- 같은 링크의 북마크 요청이 진행 중이면 추가 `PATCH /bookmark` 요청이 나가지 않도록 처리
- 북마크 요청 시작 시 해당 링크 id를 `bookmarkingLinkIds`에 추가
- 북마크 요청 성공/실패 후 `finally`에서 해당 링크 id 제거
- 요청 중인 링크의 북마크 버튼만 비활성화하도록 `CardLink`에 `bookmarkDisabled` prop 추가
- 홈 화면, 저장 링크 전체보기, 폴더 상세 화면 모두 `bookmarkingLinkIds.has(link.id)` 기준으로 북마크 버튼 비활성화
- 홈 화면과 저장 링크 전체보기의 `void handleBookmark(id)` 호출을 Promise 반환 흐름으로 정리
- 폴더 상세 화면에도 북마크 변경 실패 alert 처리 추가
- optimistic update 실패 시 전체 링크 목록을 되돌리지 않고 해당 링크의 이전 `isBookmarked` 값만 rollback
- `Network request failed` 에러 메시지를 한글 안내 문구로 변환

## 파일별 역할
- `context/saved-links-context.tsx`: 북마크 요청 중인 링크 id 상태 관리, id별 중복 요청 방지, 실패 시 해당 링크만 rollback, 네트워크 실패 메시지 한글화
- `components/ui/card-link.tsx`: 북마크 버튼 전용 비활성화 prop 추가 및 요청 중인 북마크 아이콘 터치 차단
- `app/(tabs)/(home)/index.tsx`: 홈 화면 최근 저장 링크 북마크 버튼에 요청 중 상태 반영
- `app/(tabs)/(home)/saved-links.tsx`: 저장 링크 전체보기 북마크 버튼에 요청 중 상태 반영
- `app/(tabs)/(folder)/[id].tsx`: 폴더 상세 화면 북마크 버튼에 요청 중 상태 반영 및 실패 안내 처리

## 해결한 이슈 목록
- [x] 링크 카드 북마크 버튼을 누를 때마다 API 요청이 발생하는 흐름 확인
- [x] `context/saved-links-context.tsx`의 `toggleBookmark` 호출 흐름 확인
- [x] `PATCH /api/v1/saved-links/{id}/bookmark` 요청이 연속 터치 시 여러 번 발생할 수 있는 구조 확인
- [x] 같은 링크에 대해 북마크 요청이 진행 중일 때 추가 요청이 발생하지 않도록 처리
- [x] 요청 중인 링크의 북마크 버튼을 비활성화하도록 처리
- [x] optimistic update 실패 상황에서 기존 상태로 rollback 되도록 처리
- [x] rollback 범위를 전체 링크 목록이 아닌 해당 링크의 북마크 상태로 제한
- [x] 홈 화면의 최근 저장 링크 북마크 동작에 동일한 guard 적용
- [x] 저장 링크 전체보기 화면의 북마크 동작에 동일한 guard 적용
- [x] 폴더 상세 화면의 북마크 동작에 동일한 guard 적용
- [x] 북마크 요청 실패 시 사용자에게 안내가 표시되도록 처리
- [x] 네트워크 실패 시 영어 메시지 대신 한글 안내 문구가 표시되도록 처리
- [x] Android 에뮬레이터에서 빠른 연속 터치 시 중복 API 요청이 발생하지 않는지 확인
- [ ] 실제 휴대폰 preview 빌드에서 빠른 연속 터치 시 중복 API 요청이 발생하지 않는지 확인

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 홈/저장 링크 전체보기/폴더 상세 북마크 흐름 유지
- [x] 같은 링크 요청 중 재요청 방지 방식으로 toggle API 특성 반영
- [x] 다른 링크의 북마크 버튼은 독립적으로 동작하도록 유지

## 참고사항
- 단순 debounce나 버튼 guard만으로는 API 요청 시간이 700ms보다 길어질 때 중복 요청을 완전히 막기 어렵다고 판단했습니다.
- 이번 수정은 UI 버튼 단위가 아니라 `toggleBookmark` context 레벨에서 같은 링크 id의 중복 요청을 막는 방식입니다.
- 첫 번째 북마크 요청이 완료되기 전까지는 같은 링크의 북마크 버튼이 비활성화됩니다.
- 첫 번째 요청이 완료된 뒤 다시 누르는 것은 사용자의 새로운 의도로 보고 정상적으로 다음 토글 요청을 보냅니다.
- `Network request failed`는 `네트워크 연결 상태를 확인한 뒤 다시 시도해주세요.`로 표시되도록 변경했습니다.

## Screenshots or Video
- 별도 화면 구조 변경 없음
- 요청 중인 북마크 아이콘만 일시적으로 비활성화됩니다.

-테스트를 위해 spring 서버를 일부러 껐습니다. 북마크가 일시적으로 비활성화 된 화면입니다.
<img width="496" height="1016" alt="image" src="https://github.com/user-attachments/assets/cf0cd3b3-9852-4011-b687-ec64d0b6ab54" />

- 다음과 같이 에러메시지를 띄웁니다.
<img width="485" height="1018" alt="image" src="https://github.com/user-attachments/assets/69b9c5d1-2923-418c-b39b-8ca27a4b6dbc" />
