### PR TITLE
[DESIGN] 폴더 화면 UI 개편

### DIFF
--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -38,7 +38,6 @@ type MenuState = {
 const FOLDER_SCREEN = ComponentTokens.folderScreen;
 const FOLDER_CARD = ComponentTokens.folderCard;
 const CONTENT_HORIZONTAL_PADDING = FOLDER_SCREEN.contentHorizontalPadding;
-const CANVAS_PADDING_HORIZONTAL = FOLDER_SCREEN.canvasPaddingHorizontal;
 const CANVAS_PADDING_VERTICAL = FOLDER_SCREEN.canvasPaddingVertical;
 const FOLDER_GRID_GAP = FOLDER_SCREEN.gridGap;
 const DEFAULT_FOLDER_CARD_WIDTH = FOLDER_CARD.defaultWidth;
@@ -313,6 +312,7 @@ export default function FolderScreen() {
                   urlCount={folder.linkCount}
                   width={folderCardWidth}
                   variant="plain"
+                  compactFolderName={isCompactWidth}
                   onPress={() => router.push({ pathname: '/(tabs)/(folder)/[id]' as any, params: { id: folder.id } })}
                   onMorePress={(anchor) => handleMorePress(folder.id, anchor)}
                 />
@@ -444,11 +444,11 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   title: {
-    ...Typography.displayMedium,
+    ...Typography.pageTitle,
     color: Colors.brand.text,
   },
   titleCompact: {
-    ...Typography.pageTitle,
+    ...Typography.title,
   },
   subtitle: {
     flex: 1,
@@ -465,11 +465,6 @@ const styles = StyleSheet.create({
   },
 
   canvas: {
-    backgroundColor: Colors.brand.transparent,
-    borderRadius: FOLDER_SCREEN.canvasRadius,
-    borderWidth: FOLDER_SCREEN.canvasBorderWidth,
-    borderColor: Colors.brand.transparent,
-    paddingHorizontal: CANVAS_PADDING_HORIZONTAL,
     paddingVertical: CANVAS_PADDING_VERTICAL,
     gap: FOLDER_SCREEN.canvasGap,
   },

--- a/app/(tabs)/(folder)/index.tsx
+++ b/app/(tabs)/(folder)/index.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
+  useWindowDimensions,
   View,
   type KeyboardEvent,
 } from 'react-native';
@@ -20,9 +21,8 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { AddFolderButton } from '@/components/ui/add-folder-button';
 import { FolderCard } from '@/components/ui/folder-card';
 import { FolderContextMenu } from '@/components/ui/folder-context-menu';
-import { SectionHeader } from '@/components/ui/section-header';
 import { Toast } from '@/components/ui/toast';
-import { Colors, Typography } from '@/constants/theme';
+import { Colors, ComponentTokens, Typography } from '@/constants/theme';
 import type { AnchorPosition } from '@/components/ui/folder-card';
 import { useSavedLinks } from '@/context/saved-links-context';
 import { getFolderErrorMessage, useFolders } from '@/context/folders-context';
@@ -35,11 +35,14 @@ type MenuState = {
   folderId?: number;
 };
 
-const CONTENT_HORIZONTAL_PADDING = 24;
-const CANVAS_PADDING = 16;
-const FOLDER_GRID_GAP = 12;
-const DEFAULT_FOLDER_CARD_WIDTH = 144;
-const MIN_TWO_COLUMN_CARD_WIDTH = 120;
+const FOLDER_SCREEN = ComponentTokens.folderScreen;
+const FOLDER_CARD = ComponentTokens.folderCard;
+const CONTENT_HORIZONTAL_PADDING = FOLDER_SCREEN.contentHorizontalPadding;
+const CANVAS_PADDING_HORIZONTAL = FOLDER_SCREEN.canvasPaddingHorizontal;
+const CANVAS_PADDING_VERTICAL = FOLDER_SCREEN.canvasPaddingVertical;
+const FOLDER_GRID_GAP = FOLDER_SCREEN.gridGap;
+const DEFAULT_FOLDER_CARD_WIDTH = FOLDER_CARD.defaultWidth;
+const MIN_TWO_COLUMN_CARD_WIDTH = FOLDER_SCREEN.minTwoColumnCardWidth;
 const RENAME_MODAL_BOTTOM_GAP = 16;
 const RENAME_KEYBOARD_TOP_GAP = 8;
 
@@ -65,6 +68,7 @@ const syncKeyboardLayoutAnimation = (event: KeyboardEvent) => {
 export default function FolderScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const { width: windowWidth } = useWindowDimensions();
   const tabBarHeight = useBottomTabBarHeight();
   const { folderCreated: folderCreatedParam } = useLocalSearchParams<{
     folderCreated?: string | string[];
@@ -99,6 +103,7 @@ export default function FolderScreen() {
   const renameInputRef = useRef<TextInput>(null);
   const renameFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const folderCreated = typeof folderCreatedParam === 'string' ? folderCreatedParam : undefined;
+  const isCompactWidth = windowWidth < FOLDER_SCREEN.compactWidth;
 
   const folders = useMemo(
     () => rawFolders.map((folder) => ({ ...folder })),
@@ -111,16 +116,10 @@ export default function FolderScreen() {
       return DEFAULT_FOLDER_CARD_WIDTH;
     }
 
-    const defaultTwoColumnWidth = DEFAULT_FOLDER_CARD_WIDTH * 2 + FOLDER_GRID_GAP;
+    const twoColumnCardWidth = Math.floor((availableWidth - FOLDER_GRID_GAP) / 2);
 
-    if (availableWidth >= defaultTwoColumnWidth) {
-      return DEFAULT_FOLDER_CARD_WIDTH;
-    }
-
-    const compactTwoColumnWidth = Math.floor((availableWidth - FOLDER_GRID_GAP) / 2);
-
-    if (compactTwoColumnWidth >= MIN_TWO_COLUMN_CARD_WIDTH) {
-      return compactTwoColumnWidth;
+    if (twoColumnCardWidth >= MIN_TWO_COLUMN_CARD_WIDTH) {
+      return twoColumnCardWidth;
     }
 
     return availableWidth;
@@ -283,17 +282,15 @@ export default function FolderScreen() {
       >
         {/* 상단 헤더 */}
         <View style={styles.header}>
-          <Text style={styles.title}>폴더</Text>
-          <Text style={styles.subtitle}>저장한 링크를 폴더별로 정리해요</Text>
+          <Text style={[styles.title, isCompactWidth && styles.titleCompact]}>폴더</Text>
+          <View style={styles.subtitleRow}>
+            <Text style={styles.subtitle}>저장한 링크를 폴더별로 정리해요</Text>
+            <AddFolderButton onPress={handleAddFolder} />
+          </View>
         </View>
 
         {/* 폴더 캔버스 */}
         <View style={styles.canvas}>
-          <SectionHeader
-            label="내 폴더"
-            rightSlot={<AddFolderButton onPress={handleAddFolder} />}
-          />
-
           {errorMessage ? (
             <View style={styles.errorBox}>
               <Text style={styles.errorText}>{errorMessage}</Text>
@@ -315,6 +312,7 @@ export default function FolderScreen() {
                   folderName={folder.name}
                   urlCount={folder.linkCount}
                   width={folderCardWidth}
+                  variant="plain"
                   onPress={() => router.push({ pathname: '/(tabs)/(folder)/[id]' as any, params: { id: folder.id } })}
                   onMorePress={(anchor) => handleMorePress(folder.id, anchor)}
                 />
@@ -446,21 +444,34 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   title: {
-    ...Typography.pageTitle,
+    ...Typography.displayMedium,
     color: Colors.brand.text,
   },
+  titleCompact: {
+    ...Typography.pageTitle,
+  },
   subtitle: {
+    flex: 1,
+    flexShrink: 1,
     ...Typography.caption,
     color: Colors.brand.textSecondary,
   },
+  subtitleRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    gap: FOLDER_SCREEN.headerRowGap,
+    marginTop: FOLDER_SCREEN.subtitleRowOffsetTop,
+  },
 
   canvas: {
-    backgroundColor: Colors.brand.surface,
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: Colors.brand.line,
-    padding: CANVAS_PADDING,
-    gap: 16,
+    backgroundColor: Colors.brand.transparent,
+    borderRadius: FOLDER_SCREEN.canvasRadius,
+    borderWidth: FOLDER_SCREEN.canvasBorderWidth,
+    borderColor: Colors.brand.transparent,
+    paddingHorizontal: CANVAS_PADDING_HORIZONTAL,
+    paddingVertical: CANVAS_PADDING_VERTICAL,
+    gap: FOLDER_SCREEN.canvasGap,
   },
   grid: {
     width: '100%',

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -25,6 +25,7 @@ export interface FolderCardProps {
   disabled?: boolean;
   icon?: boolean;
   variant?: FolderCardVariant;
+  compactFolderName?: boolean;
 }
 
 export function FolderCard({
@@ -36,6 +37,7 @@ export function FolderCard({
   disabled = false,
   icon = true,
   variant = 'tabbed',
+  compactFolderName,
 }: FolderCardProps) {
   const moreRef = useRef<View>(null);
   const cardWidth = width ?? FOLDER_CARD.defaultWidth;
@@ -43,6 +45,7 @@ export function FolderCard({
   const guardedOnMorePress = useGuardedPress(onMorePress, { disabled });
   const isTabbed = variant === 'tabbed';
   const isCompact = cardWidth <= FOLDER_CARD.defaultWidth;
+  const shouldUseCompactFolderName = compactFolderName ?? isCompact;
   const cardHeight = isCompact ? FOLDER_CARD.compact.height : FOLDER_CARD.height;
   const bodyTop = isCompact ? FOLDER_CARD.compact.bodyTop : FOLDER_CARD.bodyTop;
   const bodyMinHeight = isCompact ? FOLDER_CARD.compact.bodyMinHeight : FOLDER_CARD.bodyMinHeight;
@@ -125,7 +128,7 @@ export function FolderCard({
         <Text
           style={[
             styles.folderName,
-            isCompact && styles.folderNameCompact,
+            shouldUseCompactFolderName && styles.folderNameCompact,
             disabled && styles.folderNameDisabled,
           ]}
           numberOfLines={FOLDER_CARD.folderNameLines}
@@ -165,7 +168,11 @@ const styles = StyleSheet.create({
     borderWidth: FOLDER_CARD.borderWidth,
     borderColor: Colors.brand.line,
     backgroundColor: Colors.brand.folderCard.body,
-    overflow: 'hidden',
+    shadowColor: Colors.brand.text,
+    shadowOffset: FOLDER_CARD.shadowOffset,
+    shadowOpacity: FOLDER_CARD.shadowOpacity,
+    shadowRadius: FOLDER_CARD.shadowRadius,
+    elevation: FOLDER_CARD.elevation,
   },
   bodyPlain: {
     flex: 0,
@@ -197,11 +204,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   folderName: {
-    ...Typography.title,
+    ...Typography.folderName,
     color: Colors.brand.text,
   },
   folderNameCompact: {
-    ...Typography.section,
+    ...Typography.folderNameCompact,
   },
   folderNameDisabled: {
     color: Colors.brand.textHint,

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -97,7 +97,7 @@ export function FolderCard({
           !isTabbed && styles.bodyPlain,
         ]}
       >
-        <View style={styles.header}>
+        <View style={[styles.header, { minHeight: menuSize }]}>
           <Text style={[styles.count, disabled && styles.countDisabled]}>{urlCount}개</Text>
           {icon ? (
             <View ref={moreRef} collapsable={false}>
@@ -178,7 +178,6 @@ const styles = StyleSheet.create({
     transform: [{ scale: FOLDER_CARD.pressedScale }],
   },
   header: {
-    minHeight: FOLDER_CARD.compact.menuSize,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -1,32 +1,13 @@
 import { useRef } from 'react';
 import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import { Colors, Typography } from '@/constants/theme';
+import { Colors, ComponentTokens, Typography } from '@/constants/theme';
 import { useGuardedPress } from '@/utils/press-guard';
 import { IconSymbol } from './icon-symbol';
 
 type FolderCardVariant = 'tabbed' | 'plain';
 
-const DEFAULT_CARD_WIDTH = 144;
-const CARD_HEIGHT = 128;
-const CARD_BODY_TOP = 16;
-const CARD_BODY_MIN_HEIGHT = 112;
-const CARD_TAB_WIDTH = 72;
-const CARD_TAB_LEFT = 10;
-const CARD_HORIZONTAL_PADDING = 14;
-const CARD_VERTICAL_PADDING = 18;
-const CARD_MENU_SIZE = 22;
-const CARD_RADIUS = 12;
-const TAB_RADIUS = 8;
-const TOUCH_HIT_SLOP = 8;
-const COMPACT_CARD_HEIGHT = 116;
-const COMPACT_CARD_BODY_TOP = 14;
-const COMPACT_CARD_BODY_MIN_HEIGHT = 102;
-const COMPACT_CARD_TAB_WIDTH = 64;
-const COMPACT_CARD_HORIZONTAL_PADDING = 12;
-const COMPACT_CARD_VERTICAL_PADDING = 14;
-const COMPACT_CARD_MENU_SIZE = 20;
-const PRESSED_SCALE = 0.98;
+const FOLDER_CARD = ComponentTokens.folderCard;
 
 export interface AnchorPosition {
   x: number;
@@ -57,18 +38,18 @@ export function FolderCard({
   variant = 'tabbed',
 }: FolderCardProps) {
   const moreRef = useRef<View>(null);
-  const cardWidth = width ?? DEFAULT_CARD_WIDTH;
+  const cardWidth = width ?? FOLDER_CARD.defaultWidth;
   const guardedOnPress = useGuardedPress(onPress, { disabled });
   const guardedOnMorePress = useGuardedPress(onMorePress, { disabled });
   const isTabbed = variant === 'tabbed';
-  const isCompact = cardWidth <= DEFAULT_CARD_WIDTH;
-  const cardHeight = isCompact ? COMPACT_CARD_HEIGHT : CARD_HEIGHT;
-  const bodyTop = isCompact ? COMPACT_CARD_BODY_TOP : CARD_BODY_TOP;
-  const bodyMinHeight = isCompact ? COMPACT_CARD_BODY_MIN_HEIGHT : CARD_BODY_MIN_HEIGHT;
-  const tabWidth = isCompact ? COMPACT_CARD_TAB_WIDTH : CARD_TAB_WIDTH;
-  const horizontalPadding = isCompact ? COMPACT_CARD_HORIZONTAL_PADDING : CARD_HORIZONTAL_PADDING;
-  const verticalPadding = isCompact ? COMPACT_CARD_VERTICAL_PADDING : CARD_VERTICAL_PADDING;
-  const menuSize = isCompact ? COMPACT_CARD_MENU_SIZE : CARD_MENU_SIZE;
+  const isCompact = cardWidth <= FOLDER_CARD.defaultWidth;
+  const cardHeight = isCompact ? FOLDER_CARD.compact.height : FOLDER_CARD.height;
+  const bodyTop = isCompact ? FOLDER_CARD.compact.bodyTop : FOLDER_CARD.bodyTop;
+  const bodyMinHeight = isCompact ? FOLDER_CARD.compact.bodyMinHeight : FOLDER_CARD.bodyMinHeight;
+  const tabWidth = isCompact ? FOLDER_CARD.compact.tabWidth : FOLDER_CARD.tabWidth;
+  const horizontalPadding = isCompact ? FOLDER_CARD.compact.horizontalPadding : FOLDER_CARD.horizontalPadding;
+  const verticalPadding = isCompact ? FOLDER_CARD.compact.verticalPadding : FOLDER_CARD.verticalPadding;
+  const menuSize = isCompact ? FOLDER_CARD.compact.menuSize : FOLDER_CARD.menuSize;
 
   const handleMorePress = () => {
     moreRef.current?.measure((_fx, _fy, measuredWidth, measuredHeight, px, py) => {
@@ -123,7 +104,12 @@ export function FolderCard({
               <TouchableOpacity
                 onPress={handleMorePress}
                 disabled={disabled}
-                hitSlop={{ top: TOUCH_HIT_SLOP, bottom: TOUCH_HIT_SLOP, left: TOUCH_HIT_SLOP, right: TOUCH_HIT_SLOP }}
+                hitSlop={{
+                  top: FOLDER_CARD.touchHitSlop,
+                  bottom: FOLDER_CARD.touchHitSlop,
+                  left: FOLDER_CARD.touchHitSlop,
+                  right: FOLDER_CARD.touchHitSlop,
+                }}
                 activeOpacity={0.7}
                 style={styles.moreButton}
               >
@@ -142,7 +128,7 @@ export function FolderCard({
             isCompact && styles.folderNameCompact,
             disabled && styles.folderNameDisabled,
           ]}
-          numberOfLines={2}
+          numberOfLines={FOLDER_CARD.folderNameLines}
         >
           {folderName}
         </Text>
@@ -159,12 +145,12 @@ const styles = StyleSheet.create({
   rootPlain: {},
   tab: {
     position: 'absolute',
-    top: 0,
-    left: CARD_TAB_LEFT,
-    borderTopLeftRadius: TAB_RADIUS,
-    borderTopRightRadius: TAB_RADIUS,
-    borderWidth: 1,
-    borderBottomWidth: 0,
+    top: FOLDER_CARD.origin,
+    left: FOLDER_CARD.tabLeft,
+    borderTopLeftRadius: FOLDER_CARD.tabRadius,
+    borderTopRightRadius: FOLDER_CARD.tabRadius,
+    borderWidth: FOLDER_CARD.borderWidth,
+    borderBottomWidth: FOLDER_CARD.hiddenBorderWidth,
     borderColor: Colors.brand.line,
     backgroundColor: Colors.brand.softMint,
   },
@@ -175,10 +161,10 @@ const styles = StyleSheet.create({
   body: {
     flex: 1,
     justifyContent: 'space-between',
-    borderRadius: CARD_RADIUS,
-    borderWidth: 1,
+    borderRadius: FOLDER_CARD.radius,
+    borderWidth: FOLDER_CARD.borderWidth,
     borderColor: Colors.brand.line,
-    backgroundColor: Colors.brand.surface,
+    backgroundColor: Colors.brand.folderCard.body,
     overflow: 'hidden',
   },
   bodyPlain: {
@@ -186,17 +172,17 @@ const styles = StyleSheet.create({
   },
   bodyDisabled: {
     borderColor: Colors.brand.line,
-    backgroundColor: Colors.brand.surface,
+    backgroundColor: Colors.brand.folderCard.body,
   },
   pressed: {
-    transform: [{ scale: PRESSED_SCALE }],
+    transform: [{ scale: FOLDER_CARD.pressedScale }],
   },
   header: {
-    minHeight: COMPACT_CARD_MENU_SIZE,
+    minHeight: FOLDER_CARD.compact.menuSize,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    gap: 8,
+    gap: FOLDER_CARD.headerGap,
   },
   count: {
     ...Typography.body,
@@ -206,8 +192,8 @@ const styles = StyleSheet.create({
     color: Colors.brand.textHint,
   },
   moreButton: {
-    width: CARD_MENU_SIZE,
-    height: CARD_MENU_SIZE,
+    width: FOLDER_CARD.menuSize,
+    height: FOLDER_CARD.menuSize,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -20,6 +20,14 @@ const CARD_MENU_SIZE = 22;
 const CARD_RADIUS = 12;
 const TAB_RADIUS = 8;
 const TOUCH_HIT_SLOP = 8;
+const COMPACT_CARD_HEIGHT = 116;
+const COMPACT_CARD_BODY_TOP = 14;
+const COMPACT_CARD_BODY_MIN_HEIGHT = 102;
+const COMPACT_CARD_TAB_WIDTH = 64;
+const COMPACT_CARD_TAB_HEIGHT = 26;
+const COMPACT_CARD_HORIZONTAL_PADDING = 12;
+const COMPACT_CARD_VERTICAL_PADDING = 14;
+const COMPACT_CARD_MENU_SIZE = 20;
 
 export interface AnchorPosition {
   x: number;
@@ -54,6 +62,15 @@ export function FolderCard({
   const guardedOnPress = useGuardedPress(onPress, { disabled });
   const guardedOnMorePress = useGuardedPress(onMorePress, { disabled });
   const isTabbed = variant === 'tabbed';
+  const isCompact = cardWidth <= DEFAULT_CARD_WIDTH;
+  const cardHeight = isCompact ? COMPACT_CARD_HEIGHT : CARD_HEIGHT;
+  const bodyTop = isCompact ? COMPACT_CARD_BODY_TOP : CARD_BODY_TOP;
+  const bodyMinHeight = isCompact ? COMPACT_CARD_BODY_MIN_HEIGHT : CARD_BODY_MIN_HEIGHT;
+  const tabWidth = isCompact ? COMPACT_CARD_TAB_WIDTH : CARD_TAB_WIDTH;
+  const tabHeight = isCompact ? COMPACT_CARD_TAB_HEIGHT : CARD_TAB_HEIGHT;
+  const horizontalPadding = isCompact ? COMPACT_CARD_HORIZONTAL_PADDING : CARD_HORIZONTAL_PADDING;
+  const verticalPadding = isCompact ? COMPACT_CARD_VERTICAL_PADDING : CARD_VERTICAL_PADDING;
+  const menuSize = isCompact ? COMPACT_CARD_MENU_SIZE : CARD_MENU_SIZE;
 
   const handleMorePress = () => {
     moreRef.current?.measure((_fx, _fy, measuredWidth, measuredHeight, px, py) => {
@@ -66,7 +83,9 @@ export function FolderCard({
       style={({ pressed }) => [
         styles.root,
         { width: cardWidth },
-        isTabbed ? styles.rootTabbed : styles.rootPlain,
+        isTabbed
+          ? [styles.rootTabbed, { height: cardHeight, paddingTop: bodyTop }]
+          : [styles.rootPlain, { minHeight: bodyMinHeight }],
         pressed && !disabled && styles.pressed,
       ]}
       onPress={guardedOnPress}
@@ -75,12 +94,26 @@ export function FolderCard({
       accessibilityState={{ disabled }}
     >
       {isTabbed ? (
-        <View style={[styles.tab, disabled && styles.tabDisabled]} />
+        <View
+          style={[
+            styles.tab,
+            {
+              width: tabWidth,
+              height: tabHeight,
+            },
+            disabled && styles.tabDisabled,
+          ]}
+        />
       ) : null}
       <View
         style={[
           styles.body,
-          { width: cardWidth },
+          {
+            width: cardWidth,
+            minHeight: bodyMinHeight,
+            paddingHorizontal: horizontalPadding,
+            paddingVertical: verticalPadding,
+          },
           disabled && styles.bodyDisabled,
           !isTabbed && styles.bodyPlain,
         ]}
@@ -98,14 +131,21 @@ export function FolderCard({
               >
                 <IconSymbol
                   name="ellipsis"
-                  size={CARD_MENU_SIZE}
+                  size={menuSize}
                   color={disabled ? Colors.brand.textHint : Colors.brand.textHint}
                 />
               </TouchableOpacity>
             </View>
           ) : null}
         </View>
-        <Text style={[styles.folderName, disabled && styles.folderNameDisabled]} numberOfLines={2}>
+        <Text
+          style={[
+            styles.folderName,
+            isCompact && styles.folderNameCompact,
+            disabled && styles.folderNameDisabled,
+          ]}
+          numberOfLines={2}
+        >
           {folderName}
         </Text>
       </View>
@@ -117,19 +157,12 @@ const styles = StyleSheet.create({
   root: {
     flexShrink: 0,
   },
-  rootTabbed: {
-    height: CARD_HEIGHT,
-    paddingTop: CARD_BODY_TOP,
-  },
-  rootPlain: {
-    minHeight: CARD_BODY_MIN_HEIGHT,
-  },
+  rootTabbed: {},
+  rootPlain: {},
   tab: {
     position: 'absolute',
     top: 0,
     left: CARD_TAB_LEFT,
-    width: CARD_TAB_WIDTH,
-    height: CARD_TAB_HEIGHT,
     borderTopLeftRadius: TAB_RADIUS,
     borderTopRightRadius: TAB_RADIUS,
     borderWidth: 1,
@@ -143,14 +176,11 @@ const styles = StyleSheet.create({
   },
   body: {
     flex: 1,
-    minHeight: CARD_BODY_MIN_HEIGHT,
     justifyContent: 'space-between',
     borderRadius: CARD_RADIUS,
     borderWidth: 1,
     borderColor: Colors.brand.line,
     backgroundColor: Colors.brand.surface,
-    paddingHorizontal: CARD_HORIZONTAL_PADDING,
-    paddingVertical: CARD_VERTICAL_PADDING,
     overflow: 'hidden',
   },
   bodyPlain: {
@@ -164,7 +194,7 @@ const styles = StyleSheet.create({
     opacity: 0.82,
   },
   header: {
-    minHeight: CARD_MENU_SIZE,
+    minHeight: COMPACT_CARD_MENU_SIZE,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -186,6 +216,9 @@ const styles = StyleSheet.create({
   folderName: {
     ...Typography.title,
     color: Colors.brand.text,
+  },
+  folderNameCompact: {
+    ...Typography.section,
   },
   folderNameDisabled: {
     color: Colors.brand.textHint,

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -1,11 +1,25 @@
 import { useRef } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
+import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
 import { Colors, Typography } from '@/constants/theme';
 import { useGuardedPress } from '@/utils/press-guard';
-import { AppIcon } from './app-icon';
+import { IconSymbol } from './icon-symbol';
+
+type FolderCardVariant = 'tabbed' | 'plain';
 
 const DEFAULT_CARD_WIDTH = 144;
+const CARD_HEIGHT = 128;
+const CARD_BODY_TOP = 16;
+const CARD_BODY_MIN_HEIGHT = 112;
+const CARD_TAB_WIDTH = 72;
+const CARD_TAB_HEIGHT = 30;
+const CARD_TAB_LEFT = 10;
+const CARD_HORIZONTAL_PADDING = 14;
+const CARD_VERTICAL_PADDING = 18;
+const CARD_MENU_SIZE = 22;
+const CARD_RADIUS = 12;
+const TAB_RADIUS = 8;
+const TOUCH_HIT_SLOP = 8;
 
 export interface AnchorPosition {
   x: number;
@@ -21,6 +35,8 @@ export interface FolderCardProps {
   onPress?: () => void;
   onMorePress?: (anchor: AnchorPosition) => void;
   disabled?: boolean;
+  icon?: boolean;
+  variant?: FolderCardVariant;
 }
 
 export function FolderCard({
@@ -30,11 +46,14 @@ export function FolderCard({
   onPress,
   onMorePress,
   disabled = false,
+  icon = true,
+  variant = 'tabbed',
 }: FolderCardProps) {
   const moreRef = useRef<View>(null);
   const cardWidth = width ?? DEFAULT_CARD_WIDTH;
   const guardedOnPress = useGuardedPress(onPress, { disabled });
   const guardedOnMorePress = useGuardedPress(onMorePress, { disabled });
+  const isTabbed = variant === 'tabbed';
 
   const handleMorePress = () => {
     moreRef.current?.measure((_fx, _fy, measuredWidth, measuredHeight, px, py) => {
@@ -44,55 +63,52 @@ export function FolderCard({
 
   return (
     <Pressable
-      style={({ pressed }) => [styles.root, { width: cardWidth }, pressed && !disabled && styles.pressed]}
+      style={({ pressed }) => [
+        styles.root,
+        { width: cardWidth },
+        isTabbed ? styles.rootTabbed : styles.rootPlain,
+        pressed && !disabled && styles.pressed,
+      ]}
       onPress={guardedOnPress}
       accessibilityRole="button"
       accessibilityLabel={`${folderName} 폴더, ${urlCount}개`}
       accessibilityState={{ disabled }}
     >
-      {disabled ? (
-        <View style={[styles.shadow, styles.shadowDisabled]}>
-          <View style={[styles.cardDisabled, { width: cardWidth }]}>
-            <View style={styles.header}>
-              <Text style={[styles.count, styles.countDisabled]}>{urlCount}개</Text>
-              <View ref={moreRef} collapsable={false}>
-                <AppIcon
-                  name="more"
-                  size={16}
-                  disabled={disabled}
-                  onPress={handleMorePress}
+      {isTabbed ? (
+        <View style={[styles.tab, disabled && styles.tabDisabled]} />
+      ) : null}
+      <View
+        style={[
+          styles.body,
+          { width: cardWidth },
+          disabled && styles.bodyDisabled,
+          !isTabbed && styles.bodyPlain,
+        ]}
+      >
+        <View style={styles.header}>
+          <Text style={[styles.count, disabled && styles.countDisabled]}>{urlCount}개</Text>
+          {icon ? (
+            <View ref={moreRef} collapsable={false}>
+              <TouchableOpacity
+                onPress={handleMorePress}
+                disabled={disabled}
+                hitSlop={{ top: TOUCH_HIT_SLOP, bottom: TOUCH_HIT_SLOP, left: TOUCH_HIT_SLOP, right: TOUCH_HIT_SLOP }}
+                activeOpacity={0.7}
+                style={styles.moreButton}
+              >
+                <IconSymbol
+                  name="ellipsis"
+                  size={CARD_MENU_SIZE}
+                  color={disabled ? Colors.brand.textHint : Colors.brand.textHint}
                 />
-              </View>
+              </TouchableOpacity>
             </View>
-            <Text style={[styles.folderName, styles.folderNameDisabled]} numberOfLines={2}>
-              {folderName}
-            </Text>
-          </View>
+          ) : null}
         </View>
-      ) : (
-        <View style={[styles.shadow, styles.shadowActive]}>
-          <LinearGradient
-            colors={[Colors.brand.folderGradientStart, Colors.brand.folderGradientEnd]}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={[styles.card, { width: cardWidth }]}
-          >
-            <View style={styles.header}>
-              <Text style={styles.count}>{urlCount}개</Text>
-              <View ref={moreRef} collapsable={false}>
-                <AppIcon
-                  name="more"
-                  size={16}
-                  onPress={handleMorePress}
-                />
-              </View>
-            </View>
-            <Text style={styles.folderName} numberOfLines={2}>
-              {folderName}
-            </Text>
-          </LinearGradient>
-        </View>
-      )}
+        <Text style={[styles.folderName, disabled && styles.folderNameDisabled]} numberOfLines={2}>
+          {folderName}
+        </Text>
+      </View>
     </Pressable>
   );
 }
@@ -101,54 +117,74 @@ const styles = StyleSheet.create({
   root: {
     flexShrink: 0,
   },
-  shadow: {
-    borderRadius: 16,
-    shadowColor: Colors.brand.shadow,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 4,
+  rootTabbed: {
+    height: CARD_HEIGHT,
+    paddingTop: CARD_BODY_TOP,
   },
-  shadowActive: {
-    backgroundColor: Colors.brand.folderGradientEnd,
+  rootPlain: {
+    minHeight: CARD_BODY_MIN_HEIGHT,
   },
-  shadowDisabled: {
+  tab: {
+    position: 'absolute',
+    top: 0,
+    left: CARD_TAB_LEFT,
+    width: CARD_TAB_WIDTH,
+    height: CARD_TAB_HEIGHT,
+    borderTopLeftRadius: TAB_RADIUS,
+    borderTopRightRadius: TAB_RADIUS,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    borderColor: Colors.brand.line,
     backgroundColor: Colors.brand.softMint,
   },
-  card: {
-    borderRadius: 16,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    width: 144,
-    minHeight: 96,
-    justifyContent: 'space-between',
+  tabDisabled: {
+    backgroundColor: Colors.brand.softMint,
+    borderColor: Colors.brand.line,
   },
-  pressed: {
-    opacity: 0.8,
-  },
-  cardDisabled: {
-    borderRadius: 16,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    width: 144,
-    minHeight: 96,
+  body: {
+    flex: 1,
+    minHeight: CARD_BODY_MIN_HEIGHT,
     justifyContent: 'space-between',
+    borderRadius: CARD_RADIUS,
+    borderWidth: 1,
+    borderColor: Colors.brand.line,
+    backgroundColor: Colors.brand.surface,
+    paddingHorizontal: CARD_HORIZONTAL_PADDING,
+    paddingVertical: CARD_VERTICAL_PADDING,
     overflow: 'hidden',
   },
+  bodyPlain: {
+    flex: 0,
+  },
+  bodyDisabled: {
+    borderColor: Colors.brand.line,
+    backgroundColor: Colors.brand.surface,
+  },
+  pressed: {
+    opacity: 0.82,
+  },
   header: {
+    minHeight: CARD_MENU_SIZE,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'flex-start',
+    alignItems: 'center',
+    gap: 8,
   },
   count: {
-    ...Typography.regular12,
+    ...Typography.body,
     color: Colors.brand.textSecondary,
   },
   countDisabled: {
     color: Colors.brand.textHint,
   },
+  moreButton: {
+    width: CARD_MENU_SIZE,
+    height: CARD_MENU_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   folderName: {
-    ...Typography.section,
+    ...Typography.title,
     color: Colors.brand.text,
   },
   folderNameDisabled: {

--- a/components/ui/folder-card.tsx
+++ b/components/ui/folder-card.tsx
@@ -12,7 +12,6 @@ const CARD_HEIGHT = 128;
 const CARD_BODY_TOP = 16;
 const CARD_BODY_MIN_HEIGHT = 112;
 const CARD_TAB_WIDTH = 72;
-const CARD_TAB_HEIGHT = 30;
 const CARD_TAB_LEFT = 10;
 const CARD_HORIZONTAL_PADDING = 14;
 const CARD_VERTICAL_PADDING = 18;
@@ -24,10 +23,10 @@ const COMPACT_CARD_HEIGHT = 116;
 const COMPACT_CARD_BODY_TOP = 14;
 const COMPACT_CARD_BODY_MIN_HEIGHT = 102;
 const COMPACT_CARD_TAB_WIDTH = 64;
-const COMPACT_CARD_TAB_HEIGHT = 26;
 const COMPACT_CARD_HORIZONTAL_PADDING = 12;
 const COMPACT_CARD_VERTICAL_PADDING = 14;
 const COMPACT_CARD_MENU_SIZE = 20;
+const PRESSED_SCALE = 0.98;
 
 export interface AnchorPosition {
   x: number;
@@ -67,7 +66,6 @@ export function FolderCard({
   const bodyTop = isCompact ? COMPACT_CARD_BODY_TOP : CARD_BODY_TOP;
   const bodyMinHeight = isCompact ? COMPACT_CARD_BODY_MIN_HEIGHT : CARD_BODY_MIN_HEIGHT;
   const tabWidth = isCompact ? COMPACT_CARD_TAB_WIDTH : CARD_TAB_WIDTH;
-  const tabHeight = isCompact ? COMPACT_CARD_TAB_HEIGHT : CARD_TAB_HEIGHT;
   const horizontalPadding = isCompact ? COMPACT_CARD_HORIZONTAL_PADDING : CARD_HORIZONTAL_PADDING;
   const verticalPadding = isCompact ? COMPACT_CARD_VERTICAL_PADDING : CARD_VERTICAL_PADDING;
   const menuSize = isCompact ? COMPACT_CARD_MENU_SIZE : CARD_MENU_SIZE;
@@ -99,7 +97,7 @@ export function FolderCard({
             styles.tab,
             {
               width: tabWidth,
-              height: tabHeight,
+              height: bodyTop,
             },
             disabled && styles.tabDisabled,
           ]}
@@ -191,7 +189,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brand.surface,
   },
   pressed: {
-    opacity: 0.82,
+    transform: [{ scale: PRESSED_SCALE }],
   },
   header: {
     minHeight: COMPACT_CARD_MENU_SIZE,

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -25,7 +25,7 @@ const dangerBackgroundColor = '#F5C8C8';
 const selectedOverlayColor = 'rgba(0,0,0,0.08)';
 const modalBackdropColor = 'rgba(0,0,0,0.4)';
 const inverseSubtleOverlayColor = 'rgba(255,255,255,0.08)';
-const folderCardBodyColor = '#FAFCFB';
+const folderCardBodyColor = surfaceColor;
 
 const socialButtonBackgroundColor = '#FFFFFF';
 const socialButtonBorderColor = lineColor;
@@ -171,15 +171,28 @@ export const Typography = {
 };
 
 export const ComponentTokens = {
+  folderScreen: {
+    contentHorizontalPadding: 24,
+    canvasPaddingHorizontal: 0,
+    canvasPaddingVertical: 16,
+    canvasGap: 16,
+    canvasRadius: 20,
+    canvasBorderWidth: 0,
+    gridGap: 12,
+    minTwoColumnCardWidth: 120,
+    headerRowGap: 10,
+    compactWidth: 380,
+    subtitleRowOffsetTop: -2,
+  },
   folderCard: {
     defaultWidth: 144,
-    height: 128,
+    height: 172,
     bodyTop: 16,
-    bodyMinHeight: 112,
+    bodyMinHeight: 156,
     tabWidth: 72,
     tabLeft: 10,
-    horizontalPadding: 14,
-    verticalPadding: 18,
+    horizontalPadding: 18,
+    verticalPadding: 20,
     menuSize: 22,
     radius: 12,
     tabRadius: 8,

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -29,7 +29,6 @@ const folderCardBodyColor = surfaceColor;
 
 const socialButtonBackgroundColor = '#FFFFFF';
 const socialButtonBorderColor = lineColor;
-const googleIconColor = '#4285F4';
 const appleButtonBackgroundColor = '#111111';
 const appleButtonTextColor = '#FFFFFF';
 
@@ -89,8 +88,6 @@ export const Colors = {
         accent: textWarningColor,
       },
     },
-    folderGradientStart: '#8FE2C6',
-    folderGradientEnd: '#499B80',
     folderCard: {
       body: folderCardBodyColor,
     },
@@ -98,7 +95,6 @@ export const Colors = {
   social: {
     buttonBackground: socialButtonBackgroundColor,
     buttonBorder: socialButtonBorderColor,
-    googleIcon: googleIconColor,
     appleButtonBackground: appleButtonBackgroundColor,
     appleButtonText: appleButtonTextColor,
   },
@@ -144,6 +140,8 @@ const fontSizeSectionTitle = 20;
 const fontSizeSection = 18;
 const fontSizeProfile = 17;
 const fontSizeBody = 16;
+const fontSizeFolderName = 20;
+const fontSizeFolderNameCompact = 18;
 const fontSizeSummary = 14;
 const fontSizeCaption = 13;
 const fontSizeUrl = 12;
@@ -163,6 +161,8 @@ export const Typography = {
   section: { fontSize: fontSizeSection, fontWeight: fontWeightBold },
   profile: { fontSize: fontSizeProfile, fontWeight: fontWeightBold },
   body: { fontSize: fontSizeBody, fontWeight: fontWeightRegular },
+  folderName: { fontSize: fontSizeFolderName, fontWeight: fontWeightBold },
+  folderNameCompact: { fontSize: fontSizeFolderNameCompact, fontWeight: fontWeightBold },
   summary: { fontSize: fontSizeSummary, fontWeight: fontWeightRegular },
   caption: { fontSize: fontSizeCaption, fontWeight: fontWeightBold },
   url: { fontSize: fontSizeUrl, fontWeight: fontWeightRegular, textDecorationLine: 'underline' as const },
@@ -173,11 +173,8 @@ export const Typography = {
 export const ComponentTokens = {
   folderScreen: {
     contentHorizontalPadding: 24,
-    canvasPaddingHorizontal: 0,
     canvasPaddingVertical: 16,
     canvasGap: 16,
-    canvasRadius: 20,
-    canvasBorderWidth: 0,
     gridGap: 12,
     minTwoColumnCardWidth: 120,
     headerRowGap: 10,
@@ -203,6 +200,10 @@ export const ComponentTokens = {
     origin: 0,
     headerGap: 8,
     folderNameLines: 2,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 5,
+    elevation: 1,
     compact: {
       height: 116,
       bodyTop: 14,

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -25,6 +25,7 @@ const dangerBackgroundColor = '#F5C8C8';
 const selectedOverlayColor = 'rgba(0,0,0,0.08)';
 const modalBackdropColor = 'rgba(0,0,0,0.4)';
 const inverseSubtleOverlayColor = 'rgba(255,255,255,0.08)';
+const folderCardBodyColor = '#FAFCFB';
 
 const socialButtonBackgroundColor = '#FFFFFF';
 const socialButtonBorderColor = lineColor;
@@ -90,6 +91,9 @@ export const Colors = {
     },
     folderGradientStart: '#8FE2C6',
     folderGradientEnd: '#499B80',
+    folderCard: {
+      body: folderCardBodyColor,
+    },
   },
   social: {
     buttonBackground: socialButtonBackgroundColor,
@@ -165,3 +169,35 @@ export const Typography = {
   bold12: { fontSize: fontSizeBold12, fontWeight: fontWeightBold },
   regular12: { fontSize: fontSizeRegular12, fontWeight: fontWeightRegular },
 };
+
+export const ComponentTokens = {
+  folderCard: {
+    defaultWidth: 144,
+    height: 128,
+    bodyTop: 16,
+    bodyMinHeight: 112,
+    tabWidth: 72,
+    tabLeft: 10,
+    horizontalPadding: 14,
+    verticalPadding: 18,
+    menuSize: 22,
+    radius: 12,
+    tabRadius: 8,
+    touchHitSlop: 8,
+    pressedScale: 0.98,
+    borderWidth: 1,
+    hiddenBorderWidth: 0,
+    origin: 0,
+    headerGap: 8,
+    folderNameLines: 2,
+    compact: {
+      height: 116,
+      bodyTop: 14,
+      bodyMinHeight: 102,
+      tabWidth: 64,
+      horizontalPadding: 12,
+      verticalPadding: 14,
+      menuSize: 20,
+    },
+  },
+} as const;


### PR DESCRIPTION
Closes #81

## 개요
폴더 화면의 폴더 카드 UI를 Figma 디자인 방향에 맞춰 개편했습니다.

기존 폴더 카드는 그라데이션 배경을 사용하는 단일 카드 형태였지만, 이번 작업에서는 폴더의 형태가 더 직접적으로 드러나도록 상단 탭과 카드 body가 분리된 구조로 변경했습니다.

또한 작은 화면에서 카드가 과하게 크게 보이지 않도록 카드 폭 기준 compact 스타일을 적용했습니다. PR #65에서 적용했던 폴더 화면의 반응형 카드 폭 계산 흐름은 유지하면서, 새 폴더 카드 UI 내부의 높이, padding, 폰트 크기, 메뉴 아이콘 크기가 좁은 화면에서 자연스럽게 줄어들도록 보완했습니다.

폴더 카드를 길게 눌렀을 때 뒤에 가려진 탭 영역이 비쳐 보이지 않도록 눌림 효과도 opacity 방식에서 scale 방식으로 변경했습니다.

마지막으로 폴더 카드의 색상과 치수 값을 컴포넌트 내부에 직접 하드코딩하지 않고, `constants/theme.ts`의 토큰으로 분리해 관리하도록 정리했습니다.

## 주요 구현 내용
- 폴더 카드를 상단 tab + body 형태의 UI로 변경
- `FolderCard`에 `icon`, `variant`, `disabled` 기반 표시 옵션 추가
- 폴더 카드 더보기 버튼과 카드 눌림 동작 유지
- 카드 눌림 효과를 opacity에서 scale 방식으로 변경
- 작은 화면에서 폴더 카드 높이, padding, 탭 너비, 메뉴 아이콘, 폴더명 typography를 compact하게 조정
- 폴더 카드 body 색상을 `Colors.brand.folderCard.body` 토큰으로 분리
- 폴더 카드 치수, 간격, radius, 눌림 scale 값을 `ComponentTokens.folderCard`로 분리
- 컴포넌트 내부 hex/rgba 색상 하드코딩 제거

## 파일별 역할
- `components/ui/folder-card.tsx`: 폴더 카드 UI 구조 개편, compact 크기 대응, 눌림 효과 보정, 디자인 토큰 참조 적용
- `constants/theme.ts`: 폴더 카드 body 색상 및 카드 치수/간격 관련 component token 추가

## 해결한 이슈 목록
- [x] 기존 폴더 카드 UI를 Figma 방향에 맞춰 폴더 형태의 카드로 개편
- [x] 폴더 카드 상단 tab과 body가 자연스럽게 맞물리도록 조정
- [x] 폴더 카드를 길게 눌렀을 때 뒤쪽 탭 영역이 비쳐 보이지 않도록 수정
- [x] 작은 화면에서 폴더 카드가 과하게 크게 보이지 않도록 compact 크기 적용
- [x] 폴더명, URL 개수, 더보기 아이콘 표시 흐름 유지
- [x] 폴더 카드 클릭 및 더보기 메뉴 anchor 측정 흐름 유지
- [x] 폴더 카드 색상과 치수 값을 `theme.ts` 토큰으로 분리
- [x] 컴포넌트 내부 색상 하드코딩 없이 `Colors.brand.*` 참조 사용

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 폴더 목록/상세 이동 흐름 유지
- [x] 기존 폴더명 수정/삭제 메뉴 흐름 유지

## 참고사항
- PR #65에서 적용된 폴더 화면의 카드 폭 반응형 계산 흐름을 유지했습니다.
- 이번 PR에서는 폴더 카드 컴포넌트와 관련 디자인 토큰만 수정했습니다.
- 폴더 생성, 수정, 삭제 API 흐름은 변경하지 않았습니다.
- 실제 기기에서 최종 색상과 카드 크기 확인 후 필요하면 추가 미세 조정이 필요할 수 있습니다.

## Screenshots or Video
- 수정한 폴더 캡쳐입니다.
<img width="498" height="1013" alt="폴더 최종 수정본 (일반 화면)" src="https://github.com/user-attachments/assets/5f3b9e3f-f5ed-41ed-adba-b67dbb9a4152" />


- 작은 화면에서 폴더 캡쳐입니다.
<img width="451" height="800" alt="폴더 최종 수정본 (작은 화면)" src="https://github.com/user-attachments/assets/c7e5d25c-b224-40bb-9fa4-02df654e724c" />
