### PR TITLE
[FEATURE] 페이지 불가용 분석 응답 처리

### DIFF
--- a/api/analyses.ts
+++ b/api/analyses.ts
@@ -29,6 +29,7 @@ export type AnalysisResponse = {
   errorCode?: string;
   errorStage?: number;
   errorMessage?: string;
+  contentAnalysisError?: string;
 };
 
 export type VerdictStatisticsResponse = Record<AnalysisVerdict, number>;

--- a/app/(tabs)/(home)/scan-result-block.tsx
+++ b/app/(tabs)/(home)/scan-result-block.tsx
@@ -11,6 +11,7 @@ import {
   getAnalysisDisplayUrl,
   getAnalysisReasonText,
   getAnalysisResultPath,
+  getContentAnalysisErrorText,
   getRouteParam,
 } from '@/utils/analysis-result-display';
 import { useGuardedPress } from '@/utils/press-guard';
@@ -30,6 +31,7 @@ export default function ScanResultBlockScreen() {
   const { analysis, isLoading, errorMessage } = useAnalysisResult(analysisId);
   const displayUrl = getAnalysisDisplayUrl(analysis, url);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('danger'));
+  const contentAnalysisErrorText = getContentAnalysisErrorText(analysis);
   const shouldRedirectToVerdict = Boolean(analysis?.verdict && analysis.verdict !== 'danger');
   const isVerifyingAnalysis = Boolean(analysisId) && !errorMessage && (!analysis?.verdict || isLoading);
   const isCompactResult = windowHeight <= COMPACT_RESULT_HEIGHT;
@@ -107,7 +109,20 @@ export default function ScanResultBlockScreen() {
         {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-        <ScanResultReason reason={reason} style={[styles.reasonCard, isCompactResult && styles.reasonCardCompact]} />
+        <ScanResultReason
+          reason={reason}
+          style={[
+            styles.reasonCard,
+            isCompactResult && styles.reasonCardCompact,
+            Boolean(contentAnalysisErrorText) && styles.reasonCardWithNotice,
+          ]}
+        />
+
+        <ScanResultReason
+          label="페이지 접근 안내"
+          reason={contentAnalysisErrorText}
+          style={[styles.noticeCard, isCompactResult && styles.noticeCardCompact]}
+        />
 
         {/* 검사 대상 카드 */}
         <View style={[styles.card, isCompactResult && styles.cardCompact]}>
@@ -169,7 +184,16 @@ const styles = StyleSheet.create({
   reasonCard: {
     marginBottom: 24,
   },
+  reasonCardWithNotice: {
+    marginBottom: 12,
+  },
   reasonCardCompact: {
+    marginBottom: 16,
+  },
+  noticeCard: {
+    marginBottom: 24,
+  },
+  noticeCardCompact: {
     marginBottom: 16,
   },
   statusText: {

--- a/app/(tabs)/(home)/scan-result-caution.tsx
+++ b/app/(tabs)/(home)/scan-result-caution.tsx
@@ -14,6 +14,7 @@ import {
   getAnalysisFinalUrl,
   getAnalysisReasonText,
   getAnalysisResultPath,
+  getContentAnalysisErrorText,
   getRouteParam,
 } from '@/utils/analysis-result-display';
 import { showAlert } from '@/utils/guarded-alert';
@@ -36,6 +37,7 @@ export default function ScanResultCautionScreen() {
   const displayUrl = getAnalysisDisplayUrl(analysis, url);
   const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('caution'));
+  const contentAnalysisErrorText = getContentAnalysisErrorText(analysis);
   const [saveModalVisible, setSaveModalVisible] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const isSavingRef = useRef(false);
@@ -167,7 +169,20 @@ export default function ScanResultCautionScreen() {
         {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-        <ScanResultReason reason={reason} style={[styles.reasonCard, isCompactResult && styles.reasonCardCompact]} />
+        <ScanResultReason
+          reason={reason}
+          style={[
+            styles.reasonCard,
+            isCompactResult && styles.reasonCardCompact,
+            Boolean(contentAnalysisErrorText) && styles.reasonCardWithNotice,
+          ]}
+        />
+
+        <ScanResultReason
+          label="페이지 접근 안내"
+          reason={contentAnalysisErrorText}
+          style={[styles.noticeCard, isCompactResult && styles.noticeCardCompact]}
+        />
 
         {/* 검사 대상 카드 */}
         <View style={[styles.card, isCompactResult && styles.cardCompact]}>
@@ -254,7 +269,16 @@ const styles = StyleSheet.create({
   reasonCard: {
     marginBottom: 24,
   },
+  reasonCardWithNotice: {
+    marginBottom: 12,
+  },
   reasonCardCompact: {
+    marginBottom: 16,
+  },
+  noticeCard: {
+    marginBottom: 24,
+  },
+  noticeCardCompact: {
     marginBottom: 16,
   },
   statusText: {

--- a/app/(tabs)/(home)/scan-result.tsx
+++ b/app/(tabs)/(home)/scan-result.tsx
@@ -14,6 +14,7 @@ import {
   getAnalysisFinalUrl,
   getAnalysisReasonText,
   getAnalysisResultPath,
+  getContentAnalysisErrorText,
   getRouteParam,
 } from '@/utils/analysis-result-display';
 import { showAlert } from '@/utils/guarded-alert';
@@ -36,6 +37,7 @@ export default function ScanResultScreen() {
   const displayUrl = getAnalysisDisplayUrl(analysis, url);
   const finalUrl = getAnalysisFinalUrl(analysis, displayUrl);
   const reason = getAnalysisReasonText(analysis, getMockScanResultReason('safe'));
+  const contentAnalysisErrorText = getContentAnalysisErrorText(analysis);
   const [saveModalVisible, setSaveModalVisible] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const isSavingRef = useRef(false);
@@ -167,7 +169,20 @@ export default function ScanResultScreen() {
         {isLoading && <Text style={styles.statusText}>분석 결과를 불러오는 중입니다.</Text>}
         {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-        <ScanResultReason reason={reason} style={[styles.reasonCard, isCompactResult && styles.reasonCardCompact]} />
+        <ScanResultReason
+          reason={reason}
+          style={[
+            styles.reasonCard,
+            isCompactResult && styles.reasonCardCompact,
+            Boolean(contentAnalysisErrorText) && styles.reasonCardWithNotice,
+          ]}
+        />
+
+        <ScanResultReason
+          label="페이지 접근 안내"
+          reason={contentAnalysisErrorText}
+          style={[styles.noticeCard, isCompactResult && styles.noticeCardCompact]}
+        />
 
         {/* 검사 대상 카드 */}
         <View style={[styles.card, isCompactResult && styles.cardCompact]}>
@@ -256,7 +271,16 @@ const styles = StyleSheet.create({
   reasonCard: {
     marginBottom: 24,
   },
+  reasonCardWithNotice: {
+    marginBottom: 12,
+  },
   reasonCardCompact: {
+    marginBottom: 16,
+  },
+  noticeCard: {
+    marginBottom: 24,
+  },
+  noticeCardCompact: {
     marginBottom: 16,
   },
   statusText: {

--- a/app/(tabs)/(home)/scanning.tsx
+++ b/app/(tabs)/(home)/scanning.tsx
@@ -19,6 +19,10 @@ const VERY_SHORT_SCREEN_HEIGHT = 700;
 const DEFAULT_ANIMATION_SIZE = 280;
 const SHORT_ANIMATION_SIZE = 216;
 const VERY_SHORT_ANIMATION_SIZE = 188;
+const PAGE_UNAVAILABLE_ERROR_CODE = 'PAGE_UNAVAILABLE';
+const PAGE_UNAVAILABLE_DEFAULT_MESSAGE = '페이지에 연결할 수 없습니다.';
+const PAGE_UNAVAILABLE_HELP_MESSAGE =
+  '사이트 접속이 제한되었거나 일시적으로 응답하지 않을 수 있습니다.';
 
 export default function ScanningScreen() {
   const { getToken, isLoaded, isSignedIn } = useAuth();
@@ -316,7 +320,7 @@ function handleAnalysisResult(
   }
 
   if (analysis.status === 'failed') {
-    throw new Error(analysis.errorMessage || 'ANALYSIS_FAILED');
+    throw new Error(getFailedAnalysisErrorMessage(analysis));
   }
 
   if (!analysis.verdict) {
@@ -408,6 +412,32 @@ function getAnalysisErrorMessage(error: unknown) {
   }
 
   return '링크 검사에 실패했습니다. 잠시 후 다시 시도해주세요.';
+}
+
+function getFailedAnalysisErrorMessage(analysis: AnalysisResponse) {
+  if (analysis.errorCode === PAGE_UNAVAILABLE_ERROR_CODE) {
+    return getPageUnavailableErrorMessage(analysis.errorMessage);
+  }
+
+  return analysis.errorMessage?.trim() || 'ANALYSIS_FAILED';
+}
+
+function getPageUnavailableErrorMessage(errorMessage?: string) {
+  const normalizedMessage = errorMessage?.trim();
+
+  if (!normalizedMessage || isTechnicalErrorCode(normalizedMessage)) {
+    return `${PAGE_UNAVAILABLE_DEFAULT_MESSAGE}\n${PAGE_UNAVAILABLE_HELP_MESSAGE}`;
+  }
+
+  if (normalizedMessage.includes(PAGE_UNAVAILABLE_HELP_MESSAGE)) {
+    return normalizedMessage;
+  }
+
+  return `${normalizedMessage}\n${PAGE_UNAVAILABLE_HELP_MESSAGE}`;
+}
+
+function isTechnicalErrorCode(value: string) {
+  return /^[A-Z0-9_]+$/.test(value) || /^[a-z0-9_]+$/.test(value);
 }
 
 function getUrlParam(value: string | string[] | undefined) {

--- a/components/ui/scan-result-reason.tsx
+++ b/components/ui/scan-result-reason.tsx
@@ -3,17 +3,18 @@ import { Colors, Typography } from '@/constants/theme';
 
 interface ScanResultReasonProps {
   reason: string;
+  label?: string;
   style?: StyleProp<ViewStyle>;
 }
 
-export function ScanResultReason({ reason, style }: ScanResultReasonProps) {
+export function ScanResultReason({ reason, label = '판정 이유', style }: ScanResultReasonProps) {
   const normalizedReason = reason.trim();
 
   if (!normalizedReason) return null;
 
   return (
     <View style={[styles.container, style]}>
-      <Text style={styles.label}>판정 이유</Text>
+      <Text style={styles.label}>{label}</Text>
       <Text style={styles.reason} numberOfLines={4}>
         {normalizedReason}
       </Text>

--- a/utils/analysis-result-display.ts
+++ b/utils/analysis-result-display.ts
@@ -1,5 +1,8 @@
 import type { AnalysisResponse, AnalysisVerdict } from '@/api/analyses';
 
+const DEFAULT_CONTENT_ANALYSIS_ERROR_MESSAGE =
+  '페이지 내용을 가져오지 못했어요. 사이트 접속이 제한되었거나 일시적으로 응답하지 않을 수 있습니다.';
+
 export function getRouteParam(value: string | string[] | undefined) {
   return typeof value === 'string' ? value : undefined;
 }
@@ -34,6 +37,20 @@ export function getAnalysisReasonText(
   return fallbackReason;
 }
 
+export function getContentAnalysisErrorText(analysis: AnalysisResponse | null) {
+  const contentAnalysisError = analysis?.contentAnalysisError?.trim();
+
+  if (!contentAnalysisError) {
+    return '';
+  }
+
+  if (isTechnicalErrorCode(contentAnalysisError)) {
+    return DEFAULT_CONTENT_ANALYSIS_ERROR_MESSAGE;
+  }
+
+  return `페이지 내용을 가져오지 못했어요. ${contentAnalysisError}`;
+}
+
 export function getAnalysisResultPath(verdict: AnalysisVerdict) {
   switch (verdict) {
     case 'safe':
@@ -51,4 +68,8 @@ export function getSiteName(url: string) {
   } catch {
     return '정보 없음';
   }
+}
+
+function isTechnicalErrorCode(value: string) {
+  return /^[A-Z0-9_]+$/.test(value) || /^[a-z0-9_]+$/.test(value);
 }


### PR DESCRIPTION
Closes #83

## 개요
백엔드 `LinClean-BE-spring` PR #47에서 추가된 페이지 불가용(PAGE_UNAVAILABLE) 처리 결과를 프론트에 반영했습니다.

Spring 분석 응답에 추가된 `contentAnalysisError` 필드를 프론트 타입에 반영하고, 분석 결과 화면에서 페이지 본문을 가져오지 못한 사유를 사용자에게 안내하도록 처리했습니다.

또한 분석 자체가 `FAILED`로 종료되고 `errorCode`가 `PAGE_UNAVAILABLE`인 경우에는 검사 중 화면에서 페이지 불가용 전용 안내 문구를 표시하도록 보완했습니다.

## 주요 구현 내용
- `AnalysisResponse` 타입에 `contentAnalysisError` 필드 추가
- `contentAnalysisError`를 사용자 안내 문구로 변환하는 유틸 추가
- 코드성 에러 값이 내려와도 원문을 그대로 노출하지 않고 기본 안내 문구 표시
- 안전/주의/위험 결과 화면에 `페이지 접근 안내` 카드 추가
- `contentAnalysisError`가 없는 기존 결과 화면은 기존 UI 유지
- `ScanResultReason`에 `label` prop 추가
- 기존 `판정 이유` 라벨은 기본값으로 유지
- `FAILED + PAGE_UNAVAILABLE` 응답은 검사 중 화면에서 전용 실패 안내로 처리
- 페이지 불가용 실패 시 기존 `다시 검사`, `돌아가기` 흐름 유지
- 기존 분석 요청, polling, 결과 화면 이동 정책 유지

## 파일별 역할
- `api/analyses.ts`: 분석 응답 타입에 `contentAnalysisError?: string` 추가
- `utils/analysis-result-display.ts`: `contentAnalysisError`를 사용자용 문구로 변환하는 `getContentAnalysisErrorText` 추가
- `components/ui/scan-result-reason.tsx`: 결과 사유 카드의 라벨을 외부에서 지정할 수 있도록 `label` prop 추가
- `app/(tabs)/(home)/scan-result.tsx`: 안전 결과 화면에 페이지 접근 안내 카드 표시
- `app/(tabs)/(home)/scan-result-caution.tsx`: 주의 결과 화면에 페이지 접근 안내 카드 표시
- `app/(tabs)/(home)/scan-result-block.tsx`: 위험 결과 화면에 페이지 접근 안내 카드 표시
- `app/(tabs)/(home)/scanning.tsx`: `FAILED + PAGE_UNAVAILABLE` 응답에 대한 전용 안내 문구 처리

## 해결한 이슈 목록
- [x] 백엔드 PR #47의 분석 응답 변경 사항 확인
- [x] `api/analyses.ts`의 `AnalysisResponse` 타입에 `contentAnalysisError?: string` 필드 추가
- [x] `contentAnalysisError`가 없는 기존 정상 분석 응답 흐름 유지
- [x] `contentAnalysisError`가 있는 응답을 검사 결과 화면에서 안내할 수 있도록 처리
- [x] 페이지 불가용 사유를 사용자에게 자연스러운 한글 문구로 변환
- [x] 코드성 또는 예상하지 못한 `contentAnalysisError` 값이 와도 화면이 깨지지 않도록 방어 처리
- [x] 페이지 본문 분석을 완료하지 못한 경우에도 기존 verdict 결과 화면 이동 흐름 유지
- [x] 안전 결과 화면에서 페이지 접근 안내 카드 표시
- [x] 주의 결과 화면에서 페이지 접근 안내 카드 표시
- [x] 위험 결과 화면에서 페이지 접근 안내 카드 표시
- [x] 기존 `summary`와 `reasons` 표시 우선순위 유지
- [x] `ScanResultReason`의 기존 판정 이유 카드 동작 유지
- [x] 저장 링크 모달에 전달되는 기존 제목/설명 흐름 유지
- [x] 저장 링크 API 호출 시 `analysisId` 기반 저장 흐름 유지
- [x] `FAILED + PAGE_UNAVAILABLE` 케이스에서 검사 중 화면에 페이지 불가용 안내 표시
- [x] `FAILED + PAGE_UNAVAILABLE` 케이스에서 `다시 검사`, `돌아가기` 버튼 흐름 유지

## 체크 사항
- [x] 커밋/코딩 컨벤션에 맞게 작성
- [x] 기존 분석 요청 및 polling 흐름 유지
- [x] 기존 안전/주의/위험 결과 화면 이동 정책 유지
- [x] `contentAnalysisError`가 없는 결과 화면 UI 영향 없음
- [x] `npm run lint` 통과

## 참고사항
- 백엔드 PR: https://github.com/403-Forb2dden/LinClean-BE-spring/pull/47
- `contentAnalysisError`는 Spring 응답의 `AnalysisResponse`에 추가된 필드입니다.
- 백엔드 분석 API는 `{ data: AnalysisResponse }` 형태로 응답하지만, 프론트 공통 API 클라이언트가 `data`를 unwrap하므로 화면에서는 기존처럼 `AnalysisResponse`로 다룹니다.
- `status: succeeded`이고 `contentAnalysisError`가 있는 경우에는 결과 화면에서 `페이지 접근 안내` 카드를 표시합니다.
- `status: failed`이고 `errorCode: PAGE_UNAVAILABLE`인 경우에는 결과 화면으로 이동하지 않고 검사 중 화면에서 실패 안내를 표시합니다.

## Screenshots or Video
- `contentAnalysisError`가 있는 분석 결과에서만 `페이지 접근 안내` 카드가 추가로 표시됩니다.
- `PAGE_UNAVAILABLE` 실패 응답에서는 검사 중 화면의 실패 안내 문구가 보강됩니다
<img width="505" height="1015" alt="image" src="https://github.com/user-attachments/assets/4fc6336e-6c2c-40f8-8db9-beba0bb2b9d5" />
